### PR TITLE
docs(airdrop): consolidate specs into vultihub as single source of truth

### DIFF
--- a/docs/airdrop-specs/README.md
+++ b/docs/airdrop-specs/README.md
@@ -1,0 +1,23 @@
+# Vultiverse Airdrop — Spec Index
+
+A 28-day promotional airdrop for the Station → VultiAgent rebrand. Users board during a 5-day window, a fixed number win the raffle, winners complete 3 of 5 in-app activities, then claim VULT through the agent — with the backend paying gas via a relayer wallet.
+
+For a non-technical walkthrough start with [`overview.md`](overview.md). Technical detail lives in the per-component specs below — they are the canonical source of truth, this file is just navigation.
+
+## Backend (this team)
+
+- [`shared-concerns.md`](shared-concerns.md) — Cross-cutting infrastructure: auth model, env-var inventory, schema overview, shared Go packages, implementation order. **Read first.**
+- [`stage-0-preflight.md`](stage-0-preflight.md) — Procurement, cross-mission alignment, treasury, and the decisions table for Strategy/Founder. No code outputs.
+- [`stage-1-boarding.md`](stage-1-boarding.md) — Days 8–12. Three endpoints (`POST /airdrop/register`, `GET /airdrop/status`, `GET /airdrop/stats`), one table.
+- [`stage-2-raffle-draw.md`](stage-2-raffle-draw.md) — Day 12. Single `airdrop-raffle` CLI with `draw`, `load-winners`, `verify-onchain` subcommands. Hands `winners.csv` to the multisig for batched `setWinners(...)` calls. One table for winners.
+- [`stage-3-quest-tracking.md`](stage-3-quest-tracking.md) — Days 13–27. One internal endpoint, two tables, hard-coded validators per quest type. Backend-side eligibility (no on-chain attestation).
+- [`stage-4-claim-relayer.md`](stage-4-claim-relayer.md) — Day 28+. On-chain submission path, operator UI, confirmation monitor. Two tables.
+
+## Sibling missions (other engineers)
+
+- [`sibling-mobile-app.md`](sibling-mobile-app.md) — Mobile app changes: UI flows, EVM address derivation, polling cadence, error UX.
+- [`sibling-on-chain-contract.md`](sibling-on-chain-contract.md) — `AirdropClaim.sol` surface (mapping-based allowance, no Merkle), deploy + `setWinners` steps. **Contract repo: [`vultisig/vultiagent-airdrop`](https://github.com/vultisig/vultiagent-airdrop)** (not `mergecontract` — the dedicated repo supersedes the older home).
+
+## Source ticket
+
+[ai-combinator/vultihub#18](https://github.com/ai-combinator/vultihub/issues/18) — the upstream mission.

--- a/docs/airdrop-specs/overview.md
+++ b/docs/airdrop-specs/overview.md
@@ -1,0 +1,117 @@
+# Vultiverse Airdrop — Plain-English Overview
+
+A non-technical end-to-end walkthrough of what this campaign is and what gets built. For the technical spec index see [`README.md`](README.md). Component-by-component:
+
+- **Backend** (this team) — [`stage-0-preflight.md`](stage-0-preflight.md) through [`stage-4-claim-relayer.md`](stage-4-claim-relayer.md), plus [`shared-concerns.md`](shared-concerns.md).
+- **Mobile app** (sibling mission) — [`sibling-mobile-app.md`](sibling-mobile-app.md).
+- **On-chain contract** (sibling mission) — [`sibling-on-chain-contract.md`](sibling-on-chain-contract.md).
+
+---
+
+## The setup
+
+Vultisig is rebranding **Station Wallet** (a wallet app with around 500k installs that mostly sit dormant on people's phones) into **VultiAgent** — a chat-style crypto wallet where you talk to your wallet and it does things for you ("swap 100 USDC for ETH", "bridge to Arbitrum", etc.).
+
+To wake those dormant users up, mark the relaunch, and create a viral moment, we're running an airdrop. Some users will get free **VULT** (Vultisig's token) for participating early.
+
+---
+
+## How a user experiences it
+
+Imagine you're a Station Wallet user who hasn't opened the app in a year.
+
+**Day 1–7.** Vultisig posts teaser content on social media. You start seeing hints something's coming.
+
+**Day 8.** The Station app updates on your phone. You open it, see the new VultiAgent branding, and a screen says "import your seed phrase or vault to enter the raffle for free VULT." You import. The app shows "you're aboard, here's a countdown screen until the launch." You're now an entrant in a raffle.
+
+**Day 12.** The boarding window closes. Behind the scenes, we draw a fixed number of winners (say 700, of however many imported). Winners' app screens update: "you won! Complete 3 in-app activities to claim your VULT." Losers see: "thanks for boarding, no win this time."
+
+**Day 13–27.** You're a winner. To unlock the claim, you have to do **3 of 5 in-app activities** through the agent — swap a token, bridge between chains, do a DeFi action, etc. The agent is fully functional during this window so you're using the new product as you earn the right to claim.
+
+**Day 28+.** You finished 3 quests. The app shows a big "claim my VULT" button. You tap it. A few seconds later, VULT appears in your wallet. You never paid gas, you never approved a transaction, you never had any ETH — the backend handled all of that on your behalf. This is the **hero moment** for the campaign — "I talked to my wallet and tokens appeared."
+
+---
+
+## What the backend has to do, end to end
+
+Five things, sequenced by when each one fires.
+
+### 1. Take registrations during the 5-day boarding window (Days 8–12)
+
+Three HTTP endpoints in the existing `agent-backend` repo:
+- One the app calls when a user imports — records them in a `registrations` table.
+- One the app polls to show "you're registered, here's your status."
+- One marketing reads to post live boarding-count tweets.
+
+Plus one row in the database per user who joined.
+
+### 2. On Day 12, draw winners and publish them on-chain
+
+Once boarding closes, an operator (a human) runs a CLI tool that:
+1. Reads everyone who registered.
+2. Randomly picks the winners.
+3. Spits out a `winners.csv` with one row per winner — Ethereum address + VULT amount.
+
+The operator then hands `winners.csv` to whoever holds the multisig wallet that owns the on-chain contract. The multisig signer splits the list into chunks of about 100 and calls `setWinners(addresses[], amounts[])` on the contract once per chunk — about seven transactions in total. Each call writes those winners' allowances into the contract's storage. After this, the contract knows exactly how much VULT each winner address can claim.
+
+The operator also loads the same list into our database so the app's status endpoint can tell each user whether they won or lost, and so the relayer (step 4) can look up "this user's recipient address and amount" when they tap claim.
+
+(Earlier drafts of this campaign used a Merkle tree to compress the winners list into a single hash on-chain. Dropped 2026-04-23 in favour of the simpler mapping above — for our 700-winner scale with a centralised relayer paying gas, the mapping was both cheaper overall and substantially simpler.)
+
+### 3. Day 13–27, watch what users do in the app and tick off quests
+
+Every time the mobile app reports back "the user just signed and broadcast a transaction" (the existing tx-proposal `/sign` call), the backend looks up what kind of transaction it was. The agent already tagged the proposal at creation time with a tool name (`build_swap_tx`, `build_evm_tx`, etc.) and a small `quest_metadata` blob containing normalised data (USD value, source/destination chains, target contract). If it was a swap above $10, we tick the "swap quest" box for that user. If it was a bridge, we tick "bridge quest." Etc.
+
+Once any user has 3 of 5 quests ticked, they're flagged as `claim_eligible` in the database.
+
+### 4. Day 28+, accept claim requests and pay out
+
+The user taps "claim my VULT." The app POSTs to `/airdrop/claim`. The backend:
+1. Checks they're a winner with 3 quests done and haven't already claimed.
+2. Looks up their recipient address and amount from the database.
+3. Builds an Ethereum transaction calling the contract's `claim()` function.
+4. **Pays the gas itself** — out of a "relayer wallet" the team funded ahead of time with about 5 ETH.
+5. Signs the transaction using a key held in AWS KMS (so the key never lives on a server's disk).
+6. Broadcasts it.
+7. Returns the transaction hash to the app immediately ("submitted").
+8. A background process watches Ethereum, sees the transaction confirm, and updates our database to "confirmed."
+9. Next time the user polls `/airdrop/status`, they see `already_claimed: true` and the app shows "VULT received!"
+
+### 5. Run an operator dashboard so a human can fix things if they break
+
+A simple HTML page (no JavaScript, just server-rendered) at `/ops` showing:
+- How much ETH is left in the relayer wallet (for "we need to top up" alerts).
+- A list of any transactions that have been pending for too long.
+- A "rebroadcast with higher gas" button per stuck transaction.
+
+Behind a username/password.
+
+---
+
+## What the on-chain contract does
+
+Lives in a separate repo (`vultisig/vultiagent-airdrop`), built by @NeOMakinG:
+- Holds the VULT prize pool.
+- Holds an `allowance` mapping — for each winner address, how much VULT they can claim.
+- Has a `setWinners(addresses[], amounts[])` function the multisig owner calls in batches to populate that mapping after the Day 12 draw.
+- Has a `claim(recipient)` function that pays the recipient's allowance and zeros the slot.
+- Has a `recoverERC20()` function the multisig can call after the campaign to reclaim unclaimed VULT.
+
+Our backend's only on-chain interaction is calling `claim(recipient)` repeatedly, once per claiming user. We also need the contract's address and ABI to build those calls.
+
+---
+
+## What the mobile app does
+
+Lives in the agent-app / station-mobile codebase, built by the mobile engineer:
+- The Vultiverse intro screen and migration flow (mostly already shipped).
+- Computing the user's Ethereum address from their vault locally (so the backend never has to derive it).
+- Calling `POST /airdrop/register` after a successful import.
+- Polling `GET /airdrop/status` to drive the pending screen state machine.
+- Showing the "claim my VULT" button when the user is claim-eligible, and posting `POST /airdrop/claim` on tap.
+
+---
+
+## The mental model in one sentence
+
+A small Go service that **takes registrations, picks winners, watches the app for qualifying actions, then pays VULT out of a hot wallet on demand** — with a database keeping track of who's at what stage and a tiny dashboard for ops. Surrounded by an on-chain contract that holds the prize pool, and a mobile app that talks to both.

--- a/docs/airdrop-specs/shared-concerns.md
+++ b/docs/airdrop-specs/shared-concerns.md
@@ -1,0 +1,230 @@
+# Shared Concerns — Cross-Cutting Infrastructure
+
+## What this doc covers
+
+Things that don't belong to any single stage but get used across multiple. Implementing these once, in shared packages, prevents the "Stage 4 reimplements Stage 3's KMS signer" pattern.
+
+**Read this before starting code on any stage.** It's the canonical reference for the env-var inventory, the auth model, the schema overview, and the order in which to lay things down.
+
+If you're picking up a stage and find yourself building something that "feels generic" — check here first. If it's not in this doc and seems like it should be, add it before duplicating code.
+
+---
+
+## Implementation order
+
+A single engineer can ship the whole pipeline in roughly this sequence. Stages have hard external deadlines (Day 8, 12, 13, 28); shared infra has none, so it slots in wherever attention is available.
+
+0. **Cross-team prerequisite for Stage 3.** MCP team adds `quest_metadata` to `build_*` tool results; agent-backend team adds `tool_name` + `quest_metadata` columns to `agent_tx_proposals` and populates them at proposal-creation time. **Hard blocker for Stage 3.** Schema in `stage-3-quest-tracking.md` "Cross-team contract" section. Slot in early — both PRs need to merge before Stage 3 can be E2E-tested.
+1. **This doc + the shared infra it scopes** (internal-token middleware, env-var loader, KMS signer, EVM client, eligibility helper). Roughly a day's work; no external dependencies.
+2. **Stage 1 — Boarding.** Hard deadline Day 8. Must be live in staging first. First consumer of `eligibility.go`.
+3. **Stage 2 — Raffle Draw CLI.** Doesn't deploy as a service; can be developed in parallel with Stage 3 once Stage 1 is in staging. One subcommand (`draw`) plus `load-winners` and `verify-onchain` helpers.
+4. **Stage 3 — Quest Tracking.** Hooks into the existing `SignTxProposal` handler (`internal/api/tx_proposals.go`), reading `tool_name` + `quest_metadata` from the just-signed proposal row. Blocked on item 0.
+5. **Stage 4 — Claim Relayer.** Depends on Stage 2's `agent_raffle_winners` table existing and reuses `eligibility.go` from shared infra.
+
+Sibling missions run in parallel:
+- **Mobile app** (`sibling-mobile-app.md`) needs the Stage 1 endpoints in staging by Day 8 to wire up boarding.
+- **On-chain contract** (`sibling-on-chain-contract.md`) needs to be deployed before the Day 12 raffle, and the multisig must finish the batched `setWinners(...)` calls before Day 28. Stage 2's `verify-onchain` subcommand is the gate confirming the on-chain mapping matches `winners.csv`.
+
+---
+
+## Auth model — three surfaces
+
+Three distinct auth mechanisms, each owning a clear path prefix:
+
+| Surface | Auth | Used by | Implemented in |
+|---|---|---|---|
+| `/airdrop/register`, `/airdrop/status`, `/airdrop/claim` | JWT (existing `/auth/token` flow — vault ECDSA sig → 24h JWT) | Mobile app | Existing `internal/api/middleware.go` — no changes needed |
+| `/internal/quests/event` | `X-Internal-Token: <secret>` matching `INTERNAL_API_KEY` env var | The agent-backend's `SignTxProposal` handler (in this same binary), curl by ops | New: `internal/api/internal_token_middleware.go` |
+| `/ops/*` (HTML pages, including `POST /ops/rebroadcast`) | HTTP Basic Auth via `OPS_USERNAME` + `OPS_PASSWORD` env vars | Operator's browser, or curl-from-script | Inlined: 5-line stdlib check in the ops handler |
+| `/airdrop/stats` | None (public) | Marketing | n/a |
+| `/healthz` | None (existing) | Load balancer | Existing |
+
+The internal-token middleware is tiny (~15 lines). Implement it once in the shared infra phase; every internal endpoint picks it up via route registration. Basic Auth is inlined in the ops handler — only one route group uses it, so no shared package warranted.
+
+---
+
+## Env var inventory
+
+All 19 vars across the 5 stages, in one table. Locked values come from the Stage 0 decisions table; defaults are reasonable starting values for staging.
+
+| Var | Stage | Type | Default | Notes |
+|---|---|---|---|---|
+| `TRANSITION_WINDOW_START` | 1 | RFC3339 | none | Boarding opens at this timestamp; 403 before |
+| `TRANSITION_WINDOW_END` | 1 | RFC3339 | none | Boarding closes at this timestamp; 403 after |
+| `INTERNAL_API_KEY` | 3, 4 | string secret | none | `X-Internal-Token` shared secret for `/internal/*` |
+| `QUEST_ACTIVATION_TIMESTAMP` | 3 | RFC3339 | none | Day 13 wall clock; quest events before this rejected |
+| `QUEST_THRESHOLD` | 3 | int | 3 | How many of 5 quests needed to be claim-eligible |
+| `DEFI_ACTION_CONTRACT_ALLOWLIST` | 3 | comma-separated 0x-addresses | none | Allow-list for the `defi_action` quest |
+| `SWAP_QUEST_MIN_USD` | 3 | int | 10 | Min USD value for a swap to count |
+| `BRIDGE_QUEST_MIN_USD` | 3 | int | 10 | Min USD value for a bridge to count |
+| `KMS_RELAYER_KEY_ARN` | 4 | AWS ARN | none | The single KMS key — signs claim txs |
+| `EVM_RPC_URL` | 4 | URL | none | Ethereum mainnet RPC. Free public endpoint OK. |
+| `EVM_CHAIN_ID` | 4 | int | 1 | 1 for mainnet |
+| `AIRDROP_CLAIM_CONTRACT_ADDRESS` | 4 | 0x-address | none | Deployed `AirdropClaim.sol` address |
+| `CLAIM_WINDOW_OPEN_AT` | 4 | RFC3339 | none | Day 28 wall clock; claims rejected before |
+| `CLAIM_ENABLED` | 4 | bool | true | Operator kill switch; checked on every request |
+| `LOW_BALANCE_THRESHOLD_ETH` | 4 | decimal | 0.5 | Triggers `low_balance_warning` in balance endpoint |
+| `CONFIRMATION_BLOCKS` | 4 | int | 1 | Reorg depth before marking confirmed |
+| `CONFIRMATION_POLL_INTERVAL_SECONDS` | 4 | int | 15 | How often the monitor checks receipts |
+| `OPS_USERNAME` | 4 | string | none | Basic Auth user for `/ops/*` |
+| `OPS_PASSWORD` | 4 | string secret | none | Basic Auth password |
+
+Loaded via the existing `internal/config/config.go` with `envconfig` (or whatever the agent-backend uses today). Add fields to the existing struct rather than introducing a new config struct.
+
+---
+
+## Schema overview
+
+Six new tables, one shared types prefix (`airdrop_*` for Postgres enums). All naming follows the existing `agent_*` convention.
+
+| Table | Owning stage | Purpose | Key columns |
+|---|---|---|---|
+| `agent_airdrop_registrations` | 1 | One row per user who joined the raffle | `public_key` (PK), `source`, `recipient_address`, `registered_at` |
+| `agent_raffle_winners` | 2 | One row per winner; populated by `load-winners` CLI. Mirrors the contract's on-chain `allowance` mapping for status display. | `public_key` (PK), `recipient`, `amount`, `loaded_at` |
+| `agent_quest_events` | 3 | Append-only audit log of incoming quest events (counted + rejected) | `tool_call_id` (PK), `public_key`, `quest_id`, `tx_hash`, `counted` (bool), `reject_reason`, `tx_proposal_id`, `created_at` |
+| `agent_user_quests` | 3 | Materialized "which quests has each user completed" | `(public_key, quest_id)` (PK), `completed_at` |
+| `agent_claim_submissions` | 4 | One row per claim attempt; lifecycle from submitted → confirmed/failed. Rebroadcasts update `tx_hash` in place. | `nonce` (UNIQUE), `public_key`, `recipient`, `amount`, `tx_hash`, `status`, gas fields, timestamps |
+| `agent_relayer_state` | 4 | Singleton holding the relayer's `next_nonce` counter | `id=1` (CHECK), `next_nonce`, `last_synced` |
+
+Plus three Postgres enum types:
+- `airdrop_registration_source` — `seed`, `vault_share`
+- `airdrop_quest_id` — `swap`, `bridge`, `defi_action`, `alert`, `dca`
+- `airdrop_claim_status` — `submitted`, `confirmed`, `failed`
+
+No foreign keys between airdrop tables — the relationships are by `public_key` value only. This keeps each migration independent and avoids ordering games at deploy time.
+
+**Cross-cutting note:** Stage 3 also depends on two new columns on the existing `agent_tx_proposals` table — `tool_name TEXT` and `quest_metadata JSONB` — populated by the agent-backend at proposal-creation time. Those columns aren't airdrop-owned and the migration that adds them lives in the agent-backend team's PR (see Stage 3 plan Task 0). Listed here for cross-cutting visibility.
+
+### Migration ordering
+
+Goose migration filenames need monotonically increasing timestamps. Create migrations in this order to match the implementation sequence:
+
+1. `XXXXXXXXXXXXXX_create_agent_airdrop_registrations.sql`
+2. `XXXXXXXXXXXXXX_create_agent_raffle_winners.sql`
+3. `XXXXXXXXXXXXXX_create_agent_quest_events.sql`
+4. `XXXXXXXXXXXXXX_create_agent_user_quests.sql`
+5. `XXXXXXXXXXXXXX_create_agent_claim_submissions.sql`
+6. `XXXXXXXXXXXXXX_create_agent_relayer_state.sql`
+
+Each migration is a single `CREATE TABLE` (plus `CREATE TYPE` for enums where needed). No data migrations.
+
+---
+
+## Shared Go packages
+
+Code that should live in one place even though multiple stages use it.
+
+### `internal/api/internal_token_middleware.go`
+
+```
+func (s *Server) InternalTokenMiddleware(next echo.HandlerFunc) echo.HandlerFunc
+```
+
+Reads `X-Internal-Token` header, compares to `s.internalToken` (constant-time), 401 on mismatch. Used by Stage 3 (`/internal/quests/event`). Stage 4's ops health and stuck-claims views are served directly from `/ops/*` over Basic Auth — no `/internal/relayer/*` route group exists.
+
+### `internal/service/airdrop/quests/eligibility.go`
+
+```
+func IsClaimEligible(ctx context.Context, db DB, publicKey string) (eligible bool, reason string, err error)
+```
+
+Computes the composite from `agent_raffle_winners`, `agent_user_quests`, and `agent_claim_submissions`. Returns a `reason` string for logging when eligible == false (`"not_a_winner"`, `"only_2_quests_complete"`, `"already_claimed"`, etc.). Called inline by Stage 1's status handler and Stage 4's claim handler — pure DB read, no HTTP boundary.
+
+**Owned by Stage 1's plan** (Stage 1 is the first consumer); listed here because Stages 3 + 4 both reuse it. Don't duplicate in stage-specific code.
+
+### `internal/service/airdrop/kms/signer.go`
+
+```
+type Signer interface {
+    SignDigest(ctx context.Context, digest []byte) (signature []byte, err error)
+    Address() common.Address
+}
+
+func NewKMSSigner(ctx context.Context, keyARN string) (Signer, error)
+```
+
+Wraps AWS KMS `Sign` API. Handles DER → EVM `(r, s, v)` conversion, recovers the EVM address from the public key. Used only by Stage 4's relayer (signing EIP-1559 txs). Lives in a shared package so any future signing need (e.g. if the contract team ever asks for a signed admin call) reuses it.
+
+If you're new to the KMS-to-EVM dance, the canonical pattern: KMS returns DER-encoded ASN.1 signatures, EVM expects raw `(r, s, v)`. The `r` and `s` come from parsing the DER; `v` requires recovering the public key against the digest and picking the recovery byte that matches.
+
+### `internal/service/airdrop/ethclient/client.go`
+
+```
+type Client interface {
+    LatestBaseFee(ctx context.Context) (*big.Int, error)
+    SuggestGasTipCap(ctx context.Context) (*big.Int, error)
+    NonceAt(ctx context.Context, address common.Address, blockNumber *big.Int) (uint64, error)
+    SendRawTransaction(ctx context.Context, signedTxBytes []byte) (txHash common.Hash, err error)
+    GetTransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error)
+    BalanceOf(ctx context.Context, token, account common.Address) (*big.Int, error)
+    Balance(ctx context.Context, account common.Address) (*big.Int, error)
+    BlockNumber(ctx context.Context) (uint64, error)
+}
+
+func NewClient(rpcURL string) (Client, error)
+```
+
+Thin wrapper over `go-ethereum/ethclient.Client` exposing only the methods the relayer actually needs. Centralized so retry policy, timeout, and any future RPC-rotation logic lives in one place rather than scattered through Stage 4.
+
+---
+
+## Cross-mission interfaces
+
+Three artifacts cross repo boundaries. All need to be locked early to avoid late surprises.
+
+### Backend ↔ `vultisig/vultiagent-airdrop`
+
+**Inbound:** compiled `AirdropClaim.sol` ABI, deployed mainnet address, local Foundry/Anvil deployment fixture for backend integration tests against a fork.
+
+**Outbound:** the `winners.csv` artifact from Stage 2's `draw` CLI is what the multisig signer uses to construct the batched `setWinners(...)` calls. No off-chain merkle artifacts to share — the contract's `allowance` mapping is the on-chain source of truth.
+
+**When to lock:** the contract ABI must be stable before Stage 4 starts encoding `claim(recipient)` calldata. No cross-language hashing concerns to resolve (Merkle was dropped 2026-04-23, removing what used to be deck Risk #1).
+
+### Backend ↔ Mobile app
+
+**Bidirectional:** the request/response shapes for `/airdrop/register`, `/airdrop/status`, `/airdrop/claim`. Source of truth is the backend stage docs; app team mocks against them.
+
+**When to lock:** before Day 8 (Stage 1 ships). Spec is already in `stage-1-boarding.md` and `stage-4-claim-relayer.md`.
+
+### Backend → Operator
+
+The `winners.csv` artifact from Stage 2's `draw` subcommand, handed to the multisig signer for batched `setWinners(...)` calls. Standard CSV with header row: `public_key, recipient, amount, registered_at, source`. The multisig signer (or their tooling) splits this into ~100-row batches and constructs one `setWinners(addresses[], amounts[])` tx per batch.
+
+---
+
+## Observability conventions
+
+Across all stages:
+
+- **Logging.** Structured JSON via the existing `logrus` setup. Always include: `request_id`, `public_key` (first 8 chars only — privacy), the action verb, and `result`. Per-stage specs add fields specific to their domain (`tool_call_id`, `nonce`, `tx_hash`, etc.).
+- **Metrics.** Prometheus, registered under the existing `internal/metrics/` registry. Naming convention `airdrop_<verb>_<unit>` (e.g. `airdrop_register_total`, `airdrop_claim_submit_duration_seconds`). Every endpoint gets a counter + a duration histogram.
+- **Alerts.** One alert worth paging on: `airdrop_relayer_eth_balance_wei < 0.5e18`. Wire to whatever the team uses (PagerDuty, Slack, etc.). Other metrics are dashboard fodder, not page-worthy.
+- **Tracing.** Use the existing tracing setup if there is one; otherwise nothing new to introduce.
+
+---
+
+## Things this doc explicitly does not cover
+
+To keep scope clear:
+
+- Per-stage business logic (covered by the stage docs).
+- Database schema details (each `CREATE TABLE` lives in its stage spec; this doc only lists tables).
+- Operational runbooks (Day 12 raffle runbook, Day 28 relayer bringup, oracle key rotation — all are stage-specific or have been removed). They live in `docs/runbooks/` once written.
+- The contract source code or contract repo conventions (covered by `sibling-on-chain-contract.md`).
+- The mobile app UI implementation (covered by `sibling-mobile-app.md`).
+- Anything in the existing `agent-backend` codebase that doesn't change — the existing JWT middleware, the existing `SignTxProposal` handler (which Stage 3 hooks into additively), the `cmd/server` entrypoint, etc.
+
+---
+
+## Done when
+
+- The four shared Go packages above exist and have unit tests (internal-token middleware, eligibility helper, KMS signer, ETH client).
+- The six migrations exist and apply cleanly on a fresh DB in order.
+- The 19 env vars are loadable from the existing config struct without errors.
+- Internal-token middleware rejects missing/wrong tokens with 401; accepts correct tokens.
+- KMS signer can sign a no-op digest against a real (LocalStack) KMS key and the recovered EVM address matches.
+- ETH client can read the latest base fee + block number against a public mainnet RPC.
+
+(Basic Auth coverage lives in Stage 4 — it's inlined in the ops handler, not part of shared infra.)
+
+Once those tick, the per-stage work has the foundations it needs.

--- a/docs/airdrop-specs/sibling-mobile-app.md
+++ b/docs/airdrop-specs/sibling-mobile-app.md
@@ -1,0 +1,186 @@
+# Sibling Spec — Mobile App (Vultiverse Airdrop UX)
+
+## What this spec covers
+
+The mobile app changes needed to deliver the Vultiverse Airdrop user experience. **Owned by the mobile engineer, not the backend team.** Documented here so the backend ↔ app contract is shared and either side can review.
+
+> **Two-repo split across the campaign timeline.** The boarding window (Day 8–12) is delivered from **`StationWallet/station-mobile`** — this is the installed app users wake up to on Day 8. Mid-campaign, once boarding closes, Station is swapped out for the rebranded **`vultisig/vultiagent-app`** for Day 13–27 quest earning and Day 28+ claiming. So Stage 1 work (register + pending screen) goes in `station-mobile`; Stage 3 (quest tiles) and Stage 4 (claim UX) go in `vultiagent-app`. Both apps share the same backend, so the API contract is identical regardless of which binary the user has on the day.
+
+The same mental model as the backend specs: plain-English context up top, concrete tasks below, explicit interface contracts where the app talks to the backend.
+
+---
+
+## What's already shipped
+
+A lot of the rebrand and migration work has already landed in `StationWallet/station-mobile` (PRs #38–#63). The relevant pieces that Stage 1 boarding builds on top of:
+
+- **RiveIntro screen** (PR #63) — the Vultiverse-themed Rive animation with the swipe-up-to-board gesture and the chevron hint.
+- **Migration flow** (PRs #38, #41, #42, #44, #45, #51, #52, #54) — Station → Fast Vault import via seed phrase or vault share. Lands the user with a working Fast Vault.
+- **Waiting screen** (PR #62) — the post-import "you're aboard" placeholder, currently with generic "increase your chance for rewards" copy.
+- **Auth menu + bottom-sheet** (PR #54) — Add Wallet flows.
+
+What still needs to be built is the wiring between those screens and the airdrop backend.
+
+---
+
+## User flows the app must support
+
+### Flow 1 — Boarding (Days 8–12)
+
+1. User launches the app for the first time after the Day 8 update (or installs fresh).
+2. RiveIntro plays, user swipes up.
+3. AuthMenu offers: Import Seed Phrase / Import Vault Share / Create New Vault.
+4. User picks a path. Existing migration / vault-creation UI runs through to a working Fast Vault.
+5. **App computes the user's EVM address** from the new Fast Vault locally — see [EVM address derivation](#evm-address-derivation) below.
+6. App acquires a JWT via the existing `POST /auth/token` flow (vault sig → 24h JWT).
+7. App calls `POST /airdrop/register` with `{ source: "seed" | "vault_share", recipient_address }`.
+8. App stores the response (`registered_at`, `recipient_address`, `source`).
+9. App transitions to the waiting screen.
+
+### Flow 2 — Pending (Days 8–28+)
+
+The waiting screen is a state machine driven by `GET /airdrop/status`.
+
+App polls the endpoint while the screen is active (suggested cadence: every 30s) and renders one of these states:
+
+| `raffle_state` | Quest fields | What the app shows |
+|---|---|---|
+| `pending` | n/a | "Boarding open. Window closes in HH:MM." Countdown timer driven by `window_closes_at` from `/airdrop/stats`. |
+| `awaiting_draw` | n/a | "Boarding closed. Drawing winners — back soon." |
+| `lost` | n/a | Consolation copy: "No win this time. Try the agent — it's open to everyone." |
+| `won`, `quests_completed < 3`, `claim_eligible: false` | per-quest state map | "You won! Complete 3 of 5 quests to claim." Renders the 5 quest tiles, each marked completed/pending. |
+| `won`, `claim_eligible: true`, `already_claimed: false` | n/a | "You're cleared to claim." Shows a prominent **Claim my VULT** button. |
+| `won`, `already_claimed: true` | n/a | "VULT received." Etherscan link from `claim_tx_hash` in the status response (server-side, survives reinstall). |
+
+Not registered (`registered: false`) — show the same boarding entry CTA as a fresh user.
+
+### Flow 3 — Quest earning (Days 13–27)
+
+The user just uses VultiAgent normally. They chat with the agent, build swap/bridge/DeFi-action transactions, sign and broadcast each via the existing tool-call UX.
+
+**The app's only specific responsibility here is what it already does:** call `POST /conversations/{id}/tool-result` after a tool-built transaction is signed and broadcast. The backend's quest-tracking layer (Stage 3) hooks off that existing notification — no new API call from the app for quests.
+
+The waiting screen, when active, polls `/airdrop/status` and re-renders the quest tile map as quests tick over.
+
+### Flow 4 — Claim (Day 28+)
+
+1. User taps **Claim my VULT** on the waiting screen.
+2. App POSTs `/airdrop/claim` (JWT only, no body).
+3. App receives `{ tx_hash, status: 'submitted', nonce, submitted_at }`.
+4. App switches the waiting screen to "Claim submitted." Renders the tx_hash with an Etherscan link. Optionally shows a spinner / "this usually takes 30–60 seconds."
+5. App keeps polling `/airdrop/status`. Once the response shows `already_claimed: true`, switch to the "VULT received" state.
+
+If the POST returns 503 (RPC or KMS transient failure) — show a "couldn't submit, try again" toast and let the user re-tap. Idempotency at the backend means a second tap that races a successful first tap will return the same tx_hash.
+
+If the POST returns 403 with `CLAIM_DISABLED` — show "claims temporarily paused, please check back" and stop polling for a few minutes (operator kill switch is on).
+
+---
+
+## EVM address derivation
+
+The backend never derives EVM addresses. **The app does.** This is load-bearing: every winner's prize is paid to the address the app sends at registration time, and that address is published on-chain on Day 12 (via the multisig's batched `setWinners` calls) — wrong address = wrong recipient = user can't recover their VULT.
+
+### Standard case (most users)
+
+The Fast Vault has an ECDSA public key. EVM address is the standard Ethereum derivation:
+
+1. Take the uncompressed ECDSA public key (64 bytes — strip the `0x04` prefix if present).
+2. Compute `keccak256` of those 64 bytes.
+3. Take the last 20 bytes.
+4. Format with `0x` prefix → that's the EVM address.
+
+**Existing helper:** `deriveEthAddress(compressedPubKeyHex, hexChainCode?)` at `vultiagent-app/src/services/auth/addressDerivation.ts:50`. Uses secp256k1 + keccak256, returns the standard 20-byte EVM address. Reuse it directly — do not hand-roll.
+
+### Legacy Terra-only case
+
+A subset of legacy Station Wallet vaults are **Terra-only** — the original Station Wallet only exposed Terra keys, and even after migration to a Fast Vault, the resulting vault structure may not have a usable ECDSA key from which an EVM address can be derived.
+
+> **Net-new logic.** The vultiagent-app codebase has no existing "is this vault Terra-only" check, no fallback prompt UI. `deriveEthAddress` (at `src/services/auth/addressDerivation.ts:50`) handles the standard ECDSA path but throws on missing keys without a graceful UI fallback. This whole subsection is net-new mobile work — flag in the mobile-engineer's task scope, not bundled into the existing migration flow PRs.
+
+For these vaults the app must:
+
+1. Detect the Terra-only condition during the post-migration `recipient_address` computation step. Concretely: attempt the ECDSA derivation; if it throws or returns no usable key, fall through to the prompt path. Suggest adding a small `isTerraOnlyVault(vault)` helper alongside the existing derivation code.
+2. Show a UI prompting the user for an EVM address: "Where would you like to receive your VULT? Paste an Ethereum address." Include explainer copy (e.g. "this is because your vault was migrated from a Terra-only wallet").
+3. Validate format client-side: must match `^0x[a-fA-F0-9]{40}$`.
+4. Send that address as `recipient_address` in the `POST /airdrop/register` call.
+
+The user can also opt to provide their own address in the standard case if the team decides to add an "edit recipient" UI — but the default flow uses the derived address with no extra friction for non-Terra-only users.
+
+---
+
+## API contract reference
+
+For each endpoint, the canonical spec lives in the backend stage docs. The app implements the consumer side of these.
+
+| Endpoint | Spec doc | Used in flow |
+|---|---|---|
+| `POST /auth/token` | (existing agent-backend) | All flows — bootstrap |
+| `POST /airdrop/register` | `stage-1-boarding.md` | Flow 1 |
+| `GET /airdrop/status` | `stage-1-boarding.md` | Flow 2, 3, 4 (polling) |
+| `POST /airdrop/claim` | `stage-4-claim-relayer.md` | Flow 4 |
+| `POST /conversations/{id}/tool-result` | (existing agent-backend) | Flow 3 — the app already calls this; no change |
+
+`GET /airdrop/stats` is used by marketing / web, **not the app**.
+
+---
+
+## Polling cadence
+
+| Screen | Polling target | Cadence |
+|---|---|---|
+| Waiting screen, `pending` state | `/airdrop/status` | Every 30s while screen is foreground |
+| Waiting screen, `awaiting_draw` | `/airdrop/status` | Every 15s (more eager — waiting for the result) |
+| Waiting screen, `won, claim_eligible: false` | `/airdrop/status` | Every 60s |
+| Waiting screen, post-claim (`status: submitted`) | `/airdrop/status` | Every 10s until `already_claimed: true` or 5 min timeout |
+
+All polling pauses when the screen is backgrounded. No background fetch.
+
+---
+
+## Error UX
+
+The app must handle these error responses gracefully:
+
+| Backend response | App UX |
+|---|---|
+| 401 (JWT expired) | Re-acquire JWT via `/auth/token` and retry the failing call once. Surface only on second failure. |
+| 403 `WINDOW_NOT_OPEN` (register) | "Boarding hasn't opened yet. Try again on Day 8." |
+| 403 `WINDOW_CLOSED` (register) | "Boarding has closed. The agent is open to everyone — explore!" |
+| 403 `NOT_CLAIM_ELIGIBLE` (claim) | Should never happen if the app reads `claim_eligible: true` first. Treat as a stale-state bug; refresh status. |
+| 403 `CLAIM_WINDOW_NOT_OPEN` (claim) | "Claiming opens on [Day 28]." Show countdown. |
+| 403 `CLAIM_DISABLED` (claim) | "Claims temporarily paused. Check back soon." |
+| 503 (claim) | "Network issue, try again in a moment." |
+| 5xx generic | Retry once with backoff, then show generic "something went wrong" with a "report" affordance. |
+
+---
+
+## What the app does NOT do
+
+To make the contract clear:
+
+- **Does not** sign claim transactions. The relayer signs them with its own KMS key.
+- **Does not** know about the contract address or any Ethereum chain interaction beyond receiving an `etherscan.io/tx/<hash>` URL to display.
+- **Does not** track quest events itself. Tool-result reporting (already a thing) is the only signal.
+- **Does not** verify the user is eligible — backend does. App reads `claim_eligible` from `/airdrop/status` and uses it as a UI gate only.
+- **Does not** know the random seed used for the raffle, the slot count, or the VULT amount — these are backend / contract concerns. App reads outcomes only.
+
+---
+
+## Open dependencies
+
+- Backend Stage 1 endpoints live in staging (Day 8 deadline).
+- Designs / Figma frames for each waiting-screen state.
+- Final copy for each state.
+- Mobile engineer assigned.
+
+---
+
+## Done when
+
+- Each user flow above has UI implementation.
+- EVM address derivation works correctly for standard vaults (golden test against a known seed).
+- Terra-only prompt UX implemented and tested by deliberately simulating a Terra-only vault.
+- All seven `raffle_state` × quest-state × claim-state combinations render correctly.
+- Polling pauses on background; resumes on foreground.
+- Error UX matches the table above.
+- Manual QA against backend staging covering: register → status pending → status awaiting_draw → status won → quest tile updates → claim → status confirmed.

--- a/docs/airdrop-specs/sibling-on-chain-contract.md
+++ b/docs/airdrop-specs/sibling-on-chain-contract.md
@@ -1,0 +1,196 @@
+# Sibling Spec — On-Chain Contract (`AirdropClaim.sol`)
+
+## What this spec covers
+
+The Solidity contract that holds the VULT prize pool, accepts a per-recipient allowance map from the multisig owner, and pays VULT to claiming winners. **Owned by the contract engineer** (@NeOMakinG) in a dedicated repo at [`vultisig/vultiagent-airdrop`](https://github.com/vultisig/vultiagent-airdrop). Documented here so the backend ↔ contract interface is shared and both teams can review.
+
+> **Implementation status (as of 2026-04-24):** Contract is **implemented and test-covered** in `vultiagent-airdrop/foundry/src/AirdropClaim.sol`. Tests live at `foundry/test/{AirdropClaim.t.sol, AirdropClaim.fork.t.sol, Invariants.t.sol}`; deploy script at `foundry/script/DeployAirdropClaim.s.sol`. What's outstanding is the mainnet deploy + VULT prize pool funding — tracked at [vultisig/vultiagent-airdrop#1](https://github.com/vultisig/vultiagent-airdrop/issues/1).
+
+Patterns follow Foundry-built, OZ ^5.2.0, Solidity ^0.8.28. The simplified surface (mapping-based allowance + setWinners + claim) reflects the 2026-04-22 (eligibility moves backend-side) and 2026-04-23 (Merkle dropped) decisions.
+
+---
+
+## What changed from the original plan
+
+Three things are off the table compared to the campaign deck's original sketch:
+
+1. **No EIP-712 quest attestation step.** The deck originally had the contract verify a backend-signed `QuestAttestation` before paying out. Dropped 2026-04-22 because the backend is the only relayer (a backend compromise would also compromise any on-chain attestation key, so the on-chain check provided no real defence). Quest eligibility is now enforced backend-side only.
+2. **No `tier` field.** The original two-tier (Station OG / Vault OG) raffle was simplified to a single pool on 2026-04-21 (Terra Classic eligibility check was dropped). All winners receive the same `amount`.
+3. **No Merkle tree.** Dropped 2026-04-23 after a careful gas + complexity comparison. For 700 winners with a centralised relayer paying gas, the Merkle approach was actually *more* expensive (~$7k vs ~$5k all-in at 30 gwei, due to per-claim proof verification gas), and added the highest-risk failure mode in the entire system (cross-language leaf encoding mismatch). The current design stores winner allowances in a `mapping(address => uint256)` populated by the multisig before the claim window opens.
+
+What remains is a minimal allowance-based claim contract — about 30 lines of Solidity.
+
+---
+
+## Tech stack
+
+- Solidity ^0.8.28
+- Foundry (`forge` for tests, `cast` for deploy) — `foundry.toml` at `vultiagent-airdrop/foundry/foundry.toml` (project is nested one level under `foundry/`)
+- OpenZeppelin contracts ^5.2.0 (vendored under `foundry/lib/openzeppelin-contracts`): `Ownable`, `SafeERC20`
+- Ethereum mainnet (chain ID 1)
+
+---
+
+## Contract surface
+
+### Storage
+
+```solidity
+contract AirdropClaim is IAirdropClaim, Ownable {
+    IERC20  public immutable VULT;
+    mapping(address => uint256) public allowance;   // recipient => VULT amount; 0 = not winner OR already claimed
+}
+```
+
+That's it. No merkle root, no claimed mapping, no `raffleClosed` bool. The single mapping is both the eligibility check and the dedup mechanism — `claim()` zeros the slot.
+
+The implementation additionally overrides `renounceOwnership()` to revert with `OwnershipRenounceDisabled()` — safety guard so a fat-fingered multisig tx can't brick the campaign's cleanup path. Errors + events are declared in an `IAirdropClaim` interface for cleanliness.
+
+### Constructor
+
+```solidity
+constructor(IERC20 _vult, address _initialOwner)
+```
+
+- Stores the VULT token address.
+- Sets the owner (the Vultisig multisig).
+- `allowance` mapping is empty at deploy.
+
+### `setWinners(address[] calldata recipients, uint256[] calldata amounts) external onlyOwner`
+
+Owner populates the allowance map. Called by the multisig in batched chunks (~100 entries per tx) on Day 12, after the off-chain raffle draw produces `winners.csv`.
+
+Behavior:
+1. Reverts if `recipients.length != amounts.length`.
+2. For `i` in `recipients`: `allowance[recipients[i]] = amounts[i]`.
+3. Emits one `WinnerSet(recipient, amount)` per entry (so indexers + the operator can audit who got allocated what).
+
+**Idempotency / re-entry:** can be called multiple times. Re-running with the same address overwrites the allowance — this is intentional (lets the multisig fix typos, add missed winners, or zero out an entry that shouldn't have been included). It's also the operational footgun: **don't include addresses that have already claimed**, because that would re-arm them. This is documented in the Day 12 runbook; the multisig signer's checklist includes "diff against any prior `setWinners` calls + any confirmed `Claimed` events."
+
+### `claim(address recipient) external`
+
+Anyone can call (in practice the relayer always does). Pays the recipient's allowance, zeros the slot.
+
+Behavior:
+1. `uint256 amount = allowance[recipient]`.
+2. Reverts if `amount == 0` (`"no allowance"`).
+3. `allowance[recipient] = 0`.
+4. Calls `vult.safeTransfer(recipient, amount)`.
+5. Emits `Claimed(recipient, amount)`.
+
+Note that the contract is **agnostic to who calls it** — the relayer pays gas in practice, but a winner could claim themselves if they had ETH. Allocation is keyed on `recipient`, not `msg.sender`.
+
+### `recoverERC20(IERC20 token, uint256 amount, address to) external onlyOwner`
+
+End-of-campaign cleanup. Owner can pull any ERC-20 (including VULT) from the contract — typically called after the claim window has wound down to reclaim unclaimed VULT.
+
+- Calls `token.safeTransfer(to, amount)`.
+- Emits `Recovered(token, amount, to)`.
+
+No restrictions on token / amount / recipient — the owner is trusted (it's the multisig).
+
+### Events
+
+```solidity
+event WinnerSet(address indexed recipient, uint256 amount);
+event Claimed(address indexed recipient, uint256 amount);
+event Recovered(address indexed token, uint256 amount, address to);
+```
+
+The `Claimed` event is what the relayer's confirmation monitor watches to detect successful payouts. The `WinnerSet` event is the audit trail for "who did the multisig allocate VULT to."
+
+---
+
+## Per-claim gas (budget context)
+
+Approximate gas accounting at 30 gwei:
+
+| Item | Gas |
+|---|---|
+| Tx base + calldata (`claim(address)` is small) | ~25,000 |
+| Read `allowance[recipient]` | 2,100 |
+| Write `allowance[recipient] = 0` (refund-eligible) | ~0 net (refund cap) |
+| ERC-20 transfer to fresh recipient (cold SSTORE on their balance) | ~33,000 |
+| Emit `Claimed` | ~1,500 |
+| **Total** | **~62,000** |
+
+700 claims × 62k × 30 gwei ≈ 0.13 ETH (~$455). Stage 0 provisions ~5 ETH at the relayer for buffer against gas spikes and rebroadcasts.
+
+---
+
+## Tests (Foundry)
+
+- Constructor sets owner + token correctly.
+- `setWinners` populates the mapping; `WinnerSet` events match.
+- `setWinners` reverts on length mismatch.
+- `setWinners` reverts when called by non-owner.
+- `setWinners` is re-callable; second call overwrites.
+- `claim` with non-zero allowance transfers VULT, zeros slot, emits `Claimed`.
+- `claim` reverts when allowance is zero (never set OR already claimed).
+- `claim` reverts when called twice for the same recipient (second call sees zeroed slot).
+- `claim` works regardless of `msg.sender` (relayer or anyone else).
+- `recoverERC20` is owner-only; transfers expected amount.
+
+No cross-language test vector. No Merkle proof tests.
+
+---
+
+## Deploy + setup steps
+
+The "Day 0 → Day 28 critical path" from the contract side:
+
+1. **Deploy** with `(VULT_TOKEN_ADDRESS, MULTISIG_ADDRESS)` via `foundry/script/DeployAirdropClaim.s.sol`. Can happen any time before Day 12 — no dependency on the raffle draw.
+2. **Verify on Etherscan** (Foundry's `--verify` flag during deploy, or `forge verify-contract` after).
+3. **Capture the deployed address** — pass it to backend as `AIRDROP_CLAIM_CONTRACT_ADDRESS` env var.
+4. **Multisig sends VULT prize pool** to the contract address. Amount: `slot_count × amount_per_winner × 1.05` (5% buffer per the funding sizing).
+5. **Backend (Stage 2)** runs the raffle CLI on Day 12; produces `winners.csv`.
+6. **Multisig calls `setWinners(addresses, amounts)`** in batched chunks (~100/batch, ~7 txs total for 700 winners) before the relayer goes live on Day 28.
+7. **Backend (Stage 4)** relayer goes live; starts processing claims.
+8. **End of campaign**: backend operator flips `CLAIM_ENABLED=false` so the relayer stops accepting new claims. Multisig then calls `recoverERC20(VULT_TOKEN, vult.balanceOf(thisContract), treasuryAddress)` to drain unclaimed VULT back to treasury. The contract is then dormant — no `selfdestruct`, no upgrade path. Stays deployed indefinitely so the public can verify the historical state on Etherscan.
+
+Setup gas (one-time): ~700k for deploy + ~18M total across the setWinners batches ≈ **~$2k at 30 gwei** (~$6k at 100 gwei spike). Treasury should be aware of this Day 12 burn.
+
+---
+
+## Cross-mission interfaces
+
+**To the backend:**
+- The deployed contract address (post-deploy step 3 above).
+- The compiled ABI (Foundry generates this — backend imports for `claim()` calldata construction).
+- A local Foundry/Anvil deployment fixture for backend's integration tests against a fork.
+
+**From the backend:**
+- The `winners.csv` artifact produced by the Stage 2 raffle CLI. Multisig pulls this from the operator-committed artifact directory and constructs the batched `setWinners` calls.
+
+**To the operator:**
+- An Etherscan link per `setWinners` batch confirmation.
+- An Etherscan link for `recoverERC20(...)` confirmation at end of campaign.
+
+---
+
+## Security posture
+
+- **Owner is trusted** — it's the Vultisig multisig. `recoverERC20` is unrestricted because there's no scenario where the multisig wants to be limited.
+- **No reentrancy concerns** in `claim` — single external call (`safeTransfer`) at the end after state is updated. VULT is a standard ERC-20 (no callback hooks).
+- **`setWinners` is repeatable, with one footgun.** Re-calling for an already-claimed address re-arms their allowance and lets them claim again. Mitigated operationally by the multisig signer's checklist (diff against confirmed `Claimed` events). Could be hardened by adding a separate `mapping(address => bool) claimed` and refusing to overwrite, but that adds gas and storage; the operational mitigation is judged sufficient.
+- **`claim` has no caller restrictions** — anyone with an allowance can submit, paying gas. This is intentional: it means a user with their own ETH could in principle claim without the relayer if the relayer is down. (No app UX for this, but the contract supports it.)
+
+---
+
+## Open dependencies
+
+- **VULT token mainnet address — UNKNOWN.** `Token.sol` exists in `vultisig-contract` but no deployment config in the repo references a deployed mainnet address. Must be confirmed with whoever holds the VULT token contract before deploy. Hard blocker for the constructor.
+- **Multisig owner address — UNKNOWN.** No precedent in the repo's existing `script/Deploy*.s.sol` files. Must be confirmed with whoever holds the Vultisig treasury multisig. Hard blocker for the constructor's `_initialOwner` argument.
+- Free public Ethereum RPC for backend integration testing — operator concern.
+
+Both UNKNOWN items are tracked in Stage 0's procurement section as hard prerequisites (see `stage-0-preflight.md`).
+
+---
+
+## Done when
+
+- Contract deployed to mainnet via `foundry/script/DeployAirdropClaim.s.sol` and verified on Etherscan.
+- All Foundry tests passing.
+- Multisig has tested the `setWinners` + `claim` flow on a testnet (Sepolia or similar) end-to-end.
+- Multisig has tested `recoverERC20` on testnet.
+- Backend's integration tests pass against a Foundry-deployed fixture of this contract.

--- a/docs/airdrop-specs/stage-0-preflight.md
+++ b/docs/airdrop-specs/stage-0-preflight.md
@@ -1,0 +1,103 @@
+# Stage 0 — Pre-flight Setup
+
+Personal punchlist of everything that has to be in place before Stage 1 code can ship. No code outputs — every item here is procurement, coordination, or a decision someone else owns. Tick boxes as items complete.
+
+Sequenced by what blocks what. The Decisions table at the top is the artifact to drop into a Slack thread with Founder/Strategy.
+
+> **2026-04-21 update:** Stakeholders dropped the Terra Classic eligibility check. The two-tier (Station OG / Vault OG) split is gone — there's now one raffle pool, one slot count, one VULT amount per winner. Archive node procurement, hosting account, Mintscan/Hexxagon outreach, and the snapshot extractor are all out of scope.
+>
+> **2026-04-23 update:** Merkle tree dropped in favour of an on-chain `mapping(address => uint256) allowance` populated by the multisig via batched `setWinners(...)` calls. The "leaf encoding spec + cross-language test vector" cross-mission item is gone (was deck Risk #1). The multisig signer now needs to budget gas for ~7 batched setWinners txs on Day 12 (~$2k at 30 gwei, up to ~$6k in a gas spike) — flag to whoever holds the ETH treasury.
+
+---
+
+## Decisions to push to Strategy/Founder
+
+Drop this table into a Slack thread. Each row needs a yes-on-default or an override. Defaults are from the campaign deck where one exists.
+
+| # | Decision | Default | Why we need it locked | Owner |
+|---|---|---|---|---|
+| 1 | Slot count (number of winners) | TBD (deck previously implied ~700 across two tiers) | Sizes the raffle pool and total VULT budget | Founder |
+| 2 | VULT per winner | TBD (deck previously had a 1,500 / 3,000 split — pick one number now) | Sizes total VULT prize budget | Founder |
+| 3 | `TRANSITION_WINDOW_END` (boarding closes) | TBD | When `/airdrop/register` starts rejecting | Strategy |
+| 4 | `QUEST_ACTIVATION_TIMESTAMP` (Day 13 wall clock) | TBD | Quest events fired before this are rejected | Strategy |
+| 5 | `DEFI_ACTION_CONTRACT_ALLOWLIST` | TBD | Which contract addresses count for the DeFi quest | Product |
+| 6 | Beta launch date (Day 28) | TBD | Drives in-app countdown + claim window open | Founder |
+| 7 | Recovery timeout (claim window length) | TBD | How long after Day 28 the claim endpoint stays open | Strategy/Eng |
+| 8 | Final 5-quest list | swap, bridge, defi_action, alert?, DCA? | Quest validators can't ship without exact list | Product |
+
+Engineering-side decisions (don't need Founder, but lock before deploy):
+
+| # | Decision | Default | Owner |
+|---|---|---|---|
+| 9 | KMS provider | AWS KMS | Eng lead |
+| 10 | Stuck-tx auto-bump in v1 | No (manual re-broadcast) | Eng lead |
+| 11 | Raffle randomness source | `crypto/rand` u64 seed, recorded in the post-draw manifest for audit | Eng lead |
+| 12 | `quest_metadata` JSONB schema locked across MCP, agent-backend, and airdrop teams | Schema in `stage-3-quest-tracking.md` "Cross-team contract" section | MCP eng + agent-backend eng + airdrop eng |
+
+---
+
+## Procurement
+
+- [ ] **Spend approval.**
+  - What: Budget sign-off for AWS KMS (negligible, <$10/mo) and one-time treasury asks (~5 ETH + the VULT prize pool).
+  - Done when: Whoever owns the budget says yes in writing (Slack message, email, or signed-off doc) I can point back to.
+
+- [ ] **AWS account / sub-account.**
+  - What: An AWS account where airdrop infra lives. Immediate use is KMS (Stages 3+4); could later host RDS replicas or other infra.
+  - Done when: I have IAM access with permission to create KMS keys, and the billing owner is named.
+
+- [ ] **One AWS KMS key for the relayer wallet.**
+  - What: `airdrop-relayer-wallet` — signs EIP-1559 EVM transactions when paying out VULT claims. `Sign` permission only, scoped to the agent-backend service identity.
+  - Done when: ARN is in env var (`KMS_RELAYER_KEY_ARN`) and a test goroutine in agent-backend can sign + verify a no-op message via it. The EVM address derived from the key's public key is captured for treasury funding.
+  - Depends on: AWS account.
+  - Note: original plan included a second `airdrop-quest-oracle` KMS key for EIP-712 attestations. Dropped 2026-04-22 — eligibility is enforced backend-side, not on-chain, since the backend is the only relayer (a backend compromise would also compromise any on-chain attestation key, so the attestation provided no real defence).
+
+---
+
+## Cross-mission alignment
+
+- [x] **Airdrop contract ownership decided.** Resolved — @NeOMakinG owns the contract work, landed in the dedicated `vultisig/vultiagent-airdrop` repo. `AirdropClaim.sol` + Foundry tests + deploy script are already committed; outstanding work is the mainnet deploy op (tracked in [vultisig/vultiagent-airdrop#1](https://github.com/vultisig/vultiagent-airdrop/issues/1)).
+
+- [ ] **Multisig owner address captured.**
+  - What: The mainnet address of the Vultisig multisig that will own `AirdropClaim.sol` — passed as the constructor's `initialOwner` and the only address authorised to call `setWinners`, `recoverERC20`. Must be confirmed externally with the treasury team.
+  - Done when: address is recorded in this doc and in `vultiagent-airdrop/foundry/script/DeployAirdropClaim.s.sol` (or the deploy `.env`).
+  - Depends on: nothing — pure ask.
+
+- [ ] **VULT mainnet token address captured.**
+  - What: The deployed mainnet ERC-20 address of VULT. Must be confirmed with whoever holds the VULT token contract (`vultisig/vultisig-contract` is the token repo but references no deployed address).
+  - Done when: address is recorded in this doc and in `vultiagent-airdrop/foundry/script/DeployAirdropClaim.s.sol` (or the deploy `.env`). The contract's constructor `vultToken` argument is fed from this.
+  - Depends on: nothing — pure ask.
+  - Why both this and the previous item are blockers: the `AirdropClaim.sol` constructor takes both as required arguments. Without them, the deploy script can't run.
+
+- [ ] **`quest_metadata` cross-team contract locked.**
+  - What: The `agent_tx_proposals.quest_metadata` JSONB shape is agreed and committed by all three teams (MCP server, agent-backend, airdrop eng). Schema lives in `stage-3-quest-tracking.md` "Cross-team contract" section. MCP-side build_* tools emit it; agent-backend-side scheduler.go writes it to the new column at proposal-creation time.
+  - Done when: PR open in `vultisig/mcp-ts` (TypeScript MCP server — the Go `vultisig/mcp` is not in the agent chat path) adding `quest_metadata` to at least `build_swap_tx` and `build_evm_tx` results; PR open in `vultisig/agent-backend` adding the migration + scheduler.go change. Both reviewed and merged before Stage 3 ships.
+  - Why this is Stage 0: Stage 3 is hard-blocked on this. Without `quest_metadata`, the airdrop module has no reliable way to classify or evaluate a tx and quest tracking can't function.
+
+- [ ] **App team API shapes confirmed.**
+  - What: Whoever's building the agent-app registration + status UI agrees the request/response shapes for `POST /airdrop/register`, `GET /airdrop/status`, `POST /airdrop/claim`.
+  - Done when: A short shared doc or OpenAPI fragment is pinned somewhere both teams can see, and the app team can mock against it.
+
+- [ ] **Artifact storage repo identified.**
+  - What: A private repo (or a folder in `vultisig/vultiagent-airdrop`) where the operator commits the Day 12 raffle artifacts (`winners.csv`, `manifest.json`) for durability + audit. Multisig signer pulls `winners.csv` from here to construct the batched `setWinners(...)` calls.
+  - Done when: Repo path is named, operator has push access, decision recorded in this doc.
+
+---
+
+## Treasury
+
+- [ ] **Relayer wallet funded with ETH.**
+  - What: ~5 ETH at the relayer wallet address (the EVM address derived from `KMS_RELAYER_KEY_ARN`'s public key). Sized for the planned winner count at 30 gwei + buffer.
+  - Done when: ETH visible at the relayer address on Etherscan; the multisig owner who funded it confirms; a refill runbook is written down for Day 28+.
+  - Depends on: KMS keys (so the relayer address is known); spend approval.
+
+- [ ] **VULT prize pool funded.**
+  - What: `slot_count × amount_per_winner × 1.05` VULT, sent to the deployed `AirdropClaim.sol` contract.
+  - Done when: Tokens visible at the contract address on Etherscan; multisig owner confirms.
+  - Depends on: Decisions table rows 1–2 locked; `AirdropClaim.sol` deployed to mainnet (tracked at [vultisig/vultiagent-airdrop#1](https://github.com/vultisig/vultiagent-airdrop/issues/1)).
+
+---
+
+## Stage 0 done when
+
+Every checkbox above is ticked, the decisions table has been signed off (or overrides applied to env defaults), and the test scripts referenced in "Done when" lines have been run successfully. At that point Stage 1 code can be written and deployed against real infrastructure with no placeholder values left.

--- a/docs/airdrop-specs/stage-1-boarding.md
+++ b/docs/airdrop-specs/stage-1-boarding.md
@@ -1,0 +1,260 @@
+# Stage 1 — Boarding
+
+## What this stage does
+
+When a user opens the app during the 5-day boarding window and imports their wallet, we record their entry and tell them they're in. We also expose a public counter so marketing can post live "X passengers aboard" updates.
+
+That's it. No eligibility check (Terra Classic was dropped 2026-04-21). No tier assignment. No quest tracking (Stage 3). No raffle logic (Stage 2). One table, three endpoints.
+
+**Hard deadline:** all three endpoints live in staging before Day 8.
+
+---
+
+## Auth model
+
+All write/read endpoints scoped to a vault use the existing JWT auth: client first calls `POST /auth/token` with a vault ECDSA signature, gets a 24h JWT, then calls airdrop endpoints with `Authorization: Bearer <jwt>`. Public key is derived from the JWT claim — never sent in request bodies. The existing middleware in `agent-backend/internal/api/middleware.go` already handles validation.
+
+`GET /airdrop/stats` is the one public endpoint — no auth.
+
+---
+
+## Endpoints
+
+### `POST /airdrop/register`
+
+**Purpose:** record this vault's entry into the raffle.
+
+**Request:**
+```http
+POST /airdrop/register
+Authorization: Bearer <jwt>
+Content-Type: application/json
+
+{
+  "source": "seed" | "vault_share",
+  "recipient_address": "0x..."
+}
+```
+
+`source` is the import flow the user came through: `seed` for "import a seed phrase into a Fast Vault," `vault_share` for "import an existing Vultisig vault share."
+
+`recipient_address` is the EVM address VULT will be paid to if this entry wins. **Required.** The client computes it locally from the vault — for standard Vultisig vaults that means deriving the EVM address from the vault's ECDSA public key; for legacy Terra-only vaults (which can't derive one) the client prompts the user for an address. **The backend never derives, never inspects vault internals, never tries to detect Terra-only — it just stores what the client sends.** This keeps backend logic simple and puts the derivation in the place that already has the vault material.
+
+**Response — 200 (new row OR existing row):**
+```json
+{
+  "registered_at": "2026-04-25T12:34:56Z",
+  "source": "seed",
+  "recipient_address": "0x..."
+}
+```
+
+The client can tell whether this was a fresh registration or a retry by inspecting `registered_at` (recent vs. old).
+
+**Errors:**
+
+| Status | Body | When |
+|---|---|---|
+| 401 | (handled by middleware) | Missing or invalid JWT |
+| 400 | `{"error":"INVALID_SOURCE"}` | `source` missing, or value not in enum |
+| 400 | `{"error":"INVALID_RECIPIENT_ADDRESS"}` | `recipient_address` missing, or doesn't match `^0x[a-fA-F0-9]{40}$` |
+| 403 | `{"error":"WINDOW_NOT_OPEN"}` | `now() < TRANSITION_WINDOW_START` |
+| 403 | `{"error":"WINDOW_CLOSED"}` | `now() >= TRANSITION_WINDOW_END` |
+
+**Behavior:**
+
+1. Validate body shape; reject with `400 INVALID_SOURCE` if `source` is missing or not in the enum.
+2. Validate `recipient_address` against `^0x[a-fA-F0-9]{40}$` (no EIP-55 checksum required); reject with `400 INVALID_RECIPIENT_ADDRESS` if missing or malformed.
+3. Check window: if `now()` is outside `[TRANSITION_WINDOW_START, TRANSITION_WINDOW_END)`, reject with the appropriate 403.
+4. `INSERT ... ON CONFLICT (public_key) DO NOTHING RETURNING ...`, then `SELECT` to return the actual row. Existing row wins — both `source` and `recipient_address` are **immutable** after first registration. Re-registering with different values is a no-op (returns the original row); the analytics signal stays clean.
+5. Return the row at 200.
+
+### `GET /airdrop/status`
+
+**Purpose:** drive the in-app pending screen.
+
+**Request:**
+```http
+GET /airdrop/status
+Authorization: Bearer <jwt>
+```
+
+**Response — 200, registered:**
+```json
+{
+  "registered": true,
+  "registered_at": "2026-04-25T12:34:56Z",
+  "source": "seed",
+  "recipient_address": "0x...",
+  "raffle_state": "pending" | "awaiting_draw" | "won" | "lost",
+  "quests": {
+    "swap":        "completed" | "pending",
+    "bridge":      "completed" | "pending",
+    "defi_action": "completed" | "pending",
+    "alert":       "completed" | "pending",
+    "dca":         "completed" | "pending"
+  },
+  "quests_completed": 2,
+  "claim_eligible": false,
+  "already_claimed": false,
+  "claim_tx_hash": null
+}
+```
+
+**Response — 200, not registered:**
+```json
+{ "registered": false }
+```
+
+All fields above are **always present** in registered responses regardless of campaign phase. Before Stages 3 / 4 deploy, downstream-stage fields default to safe values (`quests` all `pending`, `quests_completed: 0`, `claim_eligible: false`, `already_claimed: false`, `claim_tx_hash: null`). The mobile app integrates against one stable shape forever.
+
+`claim_eligible` is the composite the app uses to enable the claim button. Backend computes it: `claim_eligible = (raffle_state == "won") AND (quests_completed >= QUEST_THRESHOLD) AND (already_claimed == false)`. Single source of truth — the client doesn't recompute.
+
+`claim_tx_hash` is the latest submission's `tx_hash` from `agent_claim_submissions` when `already_claimed: true`; null otherwise. Lets the app render an Etherscan link without keeping local state across reinstalls.
+
+`quests`, `already_claimed`, and `claim_tx_hash` come from the Stage 3 / Stage 4 tables (`agent_user_quests`, `agent_claim_submissions`); Stage 1 spec defines the response shape; Stage 3 / Stage 4 specs define the underlying writes.
+
+**Raffle state machine** (computed at request time):
+
+| State | Condition |
+|---|---|
+| `pending` | `now() < TRANSITION_WINDOW_END` |
+| `awaiting_draw` | `now() >= TRANSITION_WINDOW_END` AND `NOT EXISTS(SELECT 1 FROM agent_raffle_winners LIMIT 1)` |
+| `won` | a row exists in `agent_raffle_winners` for this public_key |
+| `lost` | window closed AND `EXISTS(SELECT 1 FROM agent_raffle_winners LIMIT 1)` AND no row for this public_key |
+
+The "raffle has been drawn" signal is just `EXISTS(SELECT 1 FROM agent_raffle_winners LIMIT 1)` — Stage 2's `load-winners` runs in a single transaction, so this is reliable.
+
+**Errors:** `401` only.
+
+### `GET /airdrop/stats`
+
+**Purpose:** marketing's live "passengers aboard" counter.
+
+**Request:** no auth, no body.
+
+**Response — 200:**
+```json
+{
+  "total_registrations": 1234,
+  "by_source": { "seed": 800, "vault_share": 434 },
+  "window_state": "upcoming" | "open" | "closed",
+  "window_opens_at": "2026-04-25T00:00:00Z",
+  "window_closes_at": "2026-04-30T00:00:00Z"
+}
+```
+
+**Behavior:** single Postgres query (`SELECT source, COUNT(*) FROM agent_airdrop_registrations GROUP BY source`), marshal, return. Table is small (single-digit thousands at most); query is sub-millisecond. No caching — the cache layer was more code than the query it would protect.
+
+**Errors:** none expected.
+
+---
+
+## Schema
+
+```sql
+-- Migration: XXXXXXXXXXXXXX_create_airdrop_registrations.sql
+
+CREATE TYPE airdrop_registration_source AS ENUM ('seed', 'vault_share');
+
+CREATE TABLE agent_airdrop_registrations (
+    public_key        TEXT                        PRIMARY KEY,
+    source            airdrop_registration_source NOT NULL,
+    recipient_address TEXT                        NOT NULL,    -- 0x-prefixed EVM address; client computes; backend never derives
+    registered_at     TIMESTAMPTZ                 NOT NULL DEFAULT NOW()
+);
+```
+
+No secondary indexes — the only queries are by public_key (PK lookup) and full-table aggregations for `/airdrop/stats` (table stays small). `recipient_address` is consumed at draw time by Stage 2.
+
+Naming follows the existing `agent_*` convention.
+
+---
+
+## Configuration
+
+New env vars introduced by this stage:
+
+| Var | Type | Notes |
+|---|---|---|
+| `TRANSITION_WINDOW_START` | RFC3339 timestamp | When `/airdrop/register` starts accepting |
+| `TRANSITION_WINDOW_END`   | RFC3339 timestamp | When `/airdrop/register` starts rejecting |
+
+Both values are sourced from the Stage 0 decisions table.
+
+---
+
+## Observability
+
+Prometheus metrics (following existing `agent-backend` conventions in `internal/metrics/`):
+
+| Metric | Type | Labels |
+|---|---|---|
+| `airdrop_register_total` | Counter | `result` ∈ `{created, existing, window_not_open, window_closed, invalid_source}` |
+| `airdrop_status_total` | Counter | `state` ∈ `{not_registered, pending, awaiting_draw, won, lost}` |
+
+Per-endpoint latency + error metrics come from the existing HTTP middleware automatically.
+
+Structured logs include: `public_key` (first 8 chars only — privacy), `source`, `request_id`, `result`. The existing logrus context wiring handles this if we add the fields per request.
+
+---
+
+## Tests
+
+**Unit (in `internal/service/airdrop/registration_test.go`):**
+- Source enum validation: missing, empty, wrong value, valid `seed`, valid `vault_share`.
+- Recipient validation: missing (rejected), valid lowercase, valid mixed-case, missing 0x prefix, wrong length, non-hex chars.
+- Window enforcement: before-start, at-start, mid-window, at-end, after-end. Use an injected clock.
+- Idempotency: register twice returns same row; second source / recipient_address values are ignored.
+- Raffle state computation: each of the four states with mocked `raffle_winners` and clock.
+
+**Integration (against real Postgres):**
+- Full round-trip: register → status (own status, pending) → stats (count incremented).
+- Concurrent register: 100 parallel calls for the same public_key insert exactly one row.
+- Concurrent register: 100 parallel calls for 100 different public_keys insert 100 rows.
+- Window transition: register at `TRANSITION_WINDOW_END - 1s` succeeds, at `TRANSITION_WINDOW_END + 1s` returns `WINDOW_CLOSED`.
+
+**Load:**
+- 1000 concurrent registers across 1000 distinct public keys: p99 latency under 100ms.
+- 100 RPS sustained against `/airdrop/stats` for 1 minute: p99 latency under 50ms.
+
+---
+
+## Files
+
+```
+internal/api/airdrop/
+├── register.go         POST /airdrop/register handler
+├── status.go           GET /airdrop/status handler
+└── stats.go            GET /airdrop/stats handler
+
+internal/service/airdrop/
+└── registration.go     Pure business logic — register, status, stats. DB injected; no I/O in unit tests.
+
+internal/storage/postgres/
+├── migrations/XXXXXXXXXXXXXX_create_airdrop_registrations.sql
+└── sqlc/airdrop_registrations.sql     Insert (idempotent), select-by-pk, count-all, count-by-source
+
+internal/api/server.go   (edit) — register the three new routes under existing JWT middleware (and bare for /stats)
+internal/config/config.go (edit) — add TRANSITION_WINDOW_START / _END env vars
+```
+
+Routes register under existing patterns — JWT-scoped routes go through the same middleware as `/agent/conversations/*`; the public stats endpoint sits alongside `/healthz`.
+
+---
+
+## Open dependencies
+
+- **Stage 2 contract — `agent_raffle_winners` table exists.** Stage 1's status endpoint reads it for the `won` / `lost` / `awaiting_draw` state. Stage 2 spec defines the schema.
+- **Stage 0 decisions table rows 1, 3, 4** — `slot_count` is not used by Stage 1 directly but informs the load-test sizing and the marketing copy ("X of N entries"). `TRANSITION_WINDOW_END` is the load-bearing env var; without it Stage 1 cannot deploy.
+
+---
+
+## Done when
+
+- Migration committed and applied to staging.
+- Three endpoints respond with documented shapes against documented status codes.
+- Unit and integration tests above pass.
+- Load test meets p99 < 100ms for register and p99 < 50ms for stats.
+- All three endpoints live in staging by Day 8.
+- Stats endpoint URL handed to marketing for their live counter.

--- a/docs/airdrop-specs/stage-2-raffle-draw.md
+++ b/docs/airdrop-specs/stage-2-raffle-draw.md
@@ -1,0 +1,229 @@
+# Stage 2 — Raffle Draw
+
+## What this stage does
+
+After the boarding window closes on Day 12, fairly pick the winners, hand the resulting list to the multisig owner so they can publish it via batched `setWinners(...)` calls on the contract, and load the same list into Postgres so Stage 1's status endpoint and Stage 4's relayer have the data they need.
+
+This is a one-shot operation, run by a human operator on Day 12. No off-chain Merkle tree, no proofs, no leaf encoding (all dropped 2026-04-23 — see `sibling-on-chain-contract.md` for the reasoning). The CLI is one subcommand. The on-chain "publish the winners" step is owned by the multisig signer, who reads `winners.csv` and constructs the batched `setWinners` calls.
+
+The contract is the source of truth for who's a winner. The backend's `agent_raffle_winners` table is a local cache for status display — it should match the contract's `allowance` mapping after Day 12. Any divergence is a Day 12 op error, caught by an integration check in the runbook.
+
+---
+
+## The Day 12 operational flow
+
+1. Boarding window closes at `TRANSITION_WINDOW_END`.
+2. Operator runs `airdrop-raffle draw --seed <int>`. CLI emits `winners.csv` and `manifest.json` to a local output directory.
+3. Operator commits the artifact directory to a private ops repo (or `vultisig/vultiagent-airdrop`) for durability + audit trail.
+4. Operator hands `winners.csv` to the multisig signer.
+5. Multisig signer reviews the CSV (row count, eyeball spot-check), splits it into batches of ~100, and calls `AirdropClaim.setWinners(addresses, amounts)` once per batch (~7 txs total for 700 winners).
+6. Operator runs `airdrop-raffle load-winners --output-dir <dir>`. Inserts every winner into `agent_raffle_winners` in a single transaction. Stage 1's `/airdrop/status` endpoint immediately starts returning `won` / `lost` to all users.
+7. Operator runs `airdrop-raffle verify-onchain --output-dir <dir>`. Reads each row of `winners.csv`, calls `allowance(recipient)` on the contract, asserts each value matches. **This catches multisig batch errors** (missed batch, wrong amount, wrong address) before users start claiming.
+
+Both `load-winners` and `verify-onchain` are simple enough to be added to the same binary as `draw`. The hard work is over once `draw` runs.
+
+---
+
+## Randomness
+
+The randomness source is a `crypto/rand`-generated 64-bit integer the operator captures at draw time. The seed is recorded in `manifest.json` and published in a post-draw note (X post or commit message in the artifact repo). Anyone can re-run the draw with the same seed and verify the same winners.
+
+This is "trust Vultisig but verifiable after the fact" rather than "trustless via on-chain randomness." For a one-shot internal-promotion campaign with a small audience that already trusts Vultisig with their MPC vaults, the simpler approach is appropriate.
+
+---
+
+## Recipient address
+
+`recipient` for each winner is read directly from `agent_airdrop_registrations.recipient_address` — the column is `NOT NULL`, captured client-side at registration time (see Stage 1). The CLI never derives, never inspects vault internals, never falls back. If the registration row is missing for some reason, that's a hard error.
+
+### Correcting a wrong winner address
+
+If a winner's recipient address turns out to be wrong (mobile-app derivation bug, user complaint about a typo, lost wallet), the multisig can fix it by calling `setWinners([wrongWinnerAddress, correctWinnerAddress], [0, originalAmount])`. Setting the wrong address's allowance to 0 effectively revokes it; setting the new address's allowance to the original amount re-arms the claim there. The relayer then sees the corrected address on next claim.
+
+This works because `setWinners` is repeatable and doesn't track who's been "officially registered" beyond the mapping itself. The operational guard is the multisig's own checklist: never re-arm an already-claimed address (ops should diff against confirmed `Claimed` events on Etherscan before re-running setWinners).
+
+After correcting on-chain, also update the local `agent_raffle_winners` row with the new `recipient` so the `/airdrop/status` response matches:
+
+```sql
+UPDATE agent_raffle_winners SET recipient = '0xCORRECT' WHERE public_key = 'pk1';
+```
+
+A small `airdrop-raffle update-recipient --public-key X --new-recipient 0xY` subcommand could wrap this; deferred until ops actually hits the case.
+
+---
+
+## Subcommands
+
+All routed from one binary: `airdrop-raffle <subcommand>`.
+
+### `airdrop-raffle draw`
+
+**Inputs (flags):**
+
+| Flag | Required | Notes |
+|---|---|---|
+| `--seed <uint64>` | no, default = `crypto/rand` u64 | The PRNG seed. Default mints a fresh random one and prints it; pass explicitly to reproduce a prior draw. |
+| `--slot-count <int>` | yes | Number of winners to draw. From Stage 0 decisions. |
+| `--vult-amount <decimal>` | yes | VULT per winner, in base units. Accepts up to a `uint256`. |
+| `--output-dir <path>` | yes | Local directory for artifacts. Created if missing. |
+| `--db-url <conn>` | yes | Postgres connection string. Reads from `agent_airdrop_registrations`. |
+
+**Behavior:**
+
+1. Connect to DB. Read all rows from `agent_airdrop_registrations`.
+2. **Hard fail** if registration count == 0 (exit code 2).
+3. **Loud warning + proceed** if registration count ≤ slot_count: print a multi-line banner like `WARNING: undersubscribed (50 entries vs 700 slots). All entries will win. Prize pool will be undersubscribed by 650 × amount VULT.` All entries are winners.
+4. Otherwise, seed PRNG with `--seed` (or freshly generated u64), run Fisher–Yates shuffle, take the first `slot_count` entries.
+5. For each winner, read `recipient_address` from the registration row.
+6. Serialize artifacts:
+   - `winners.csv` — `public_key, recipient, amount, registered_at, source` per row, header line included. **This is the file the multisig signer reads to construct setWinners batches.**
+   - `manifest.json` — `{ seed, slot_count, vult_amount, registration_count, winner_count, draw_timestamp, undersubscribed: bool }`.
+7. Write both files to `--output-dir`.
+8. Print a summary: winner count, seed, undersubscribed flag, output path. Operator commits the directory to the ops repo for durability.
+
+**Exit codes:** `0` success, `1` input validation error, `2` zero registrations, `4` output write error.
+
+**Idempotency:** re-running with the same `--seed` against the same registrations table produces byte-identical output.
+
+### `airdrop-raffle load-winners`
+
+**Inputs:**
+
+| Flag | Required | Notes |
+|---|---|---|
+| `--output-dir <path>` | yes | Directory containing `winners.csv` from a prior `draw`. |
+| `--db-url <conn>` | yes | |
+
+**Behavior:**
+
+1. Read `winners.csv`.
+2. Open a Postgres transaction.
+3. **Refuse** if `agent_raffle_winners` already has any rows (raffle already loaded). Operator must explicitly `TRUNCATE agent_raffle_winners` to re-load. Exit non-zero with a clear message.
+4. `INSERT INTO agent_raffle_winners (...) VALUES (...)` for every row in the CSV. Batched multi-row INSERT.
+5. COMMIT.
+6. Print a summary.
+
+**Atomicity:** all winners land in one transaction. Stage 1's `/airdrop/status` flips from `awaiting_draw` → `won` / `lost` for all users in that single commit.
+
+### `airdrop-raffle verify-onchain`
+
+**Inputs:**
+
+| Flag | Required | Notes |
+|---|---|---|
+| `--output-dir <path>` | yes | |
+| `--rpc-url <url>` | yes | Ethereum RPC. Read-only — no signing. |
+| `--contract <0x...>` | yes | Deployed `AirdropClaim` address. |
+
+**Behavior:**
+
+1. Read `winners.csv`.
+2. For each row, call `allowance(recipient)` on the contract.
+3. Assert returned value equals the CSV's `amount`. Print pass/fail per row.
+4. Summary: matched / mismatched / total. Exit `0` on full match, non-zero otherwise.
+
+**Why this exists:** the multisig is splitting `winners.csv` into ~7 batched `setWinners` calls, manually. Missed batch, wrong amount, fat-fingered address — all are possible. Running this command after the multisig finishes is the canary that catches those errors *before* users start claiming on Day 28.
+
+This is the spiritual replacement for the old `verify` Merkle subcommand: same intent (catch multisig-side errors at the gate), much simpler implementation (just read the contract, no tree replay).
+
+---
+
+## Schema
+
+```sql
+CREATE TABLE agent_raffle_winners (
+    public_key  TEXT          PRIMARY KEY,                     -- joins to agent_airdrop_registrations
+    recipient   TEXT          NOT NULL,                        -- the 0x... EVM address VULT will be paid to
+    amount      NUMERIC(78,0) NOT NULL,
+    loaded_at   TIMESTAMPTZ   NOT NULL DEFAULT NOW()
+);
+```
+
+PK on `public_key` covers the only access pattern (Stage 1 status check, Stage 4 claim build). No secondary indexes needed.
+
+`EXISTS(SELECT 1 FROM agent_raffle_winners LIMIT 1)` is the canonical "raffle has been drawn" signal — Stage 1's `/airdrop/status` reads it. `load-winners` runs in a single Postgres transaction, so partial loads aren't a real failure mode.
+
+`recipient` is denormalized from `agent_airdrop_registrations.recipient_address` so the relayer (Stage 4) can build claim calldata in a single PK-lookup against `agent_raffle_winners` without joining.
+
+No `leaf` or `proof[]` columns — those were Merkle artifacts and are gone.
+
+---
+
+## Configuration
+
+No new env vars. All inputs are CLI flags so the same binary can target dev / staging / prod by varying the flags rather than swapping config.
+
+Artifact durability is achieved by the operator committing the output directory to a private ops repo (or `vultisig/vultiagent-airdrop`) after the draw — same audit trail as a versioned bucket, no AWS dependency in the CLI.
+
+---
+
+## Observability
+
+This is a CLI, not a service — no Prometheus surface. Observability is:
+
+- Structured JSON logs to stdout for each subcommand (one line per major step).
+- Presence of any row in `agent_raffle_winners` is the canonical "raffle was drawn" record; ops can `psql` it to confirm.
+- The committed artifact directory in the ops repo is the audit trail for prior runs.
+
+---
+
+## Tests
+
+**Unit (in `internal/service/airdrop/raffle/*_test.go`):**
+- PRNG produces same output for same seed (regression-tested with a hardcoded seed and expected first 10 outputs).
+- Fisher–Yates shuffle is uniform (statistical sanity check across many runs with different seeds).
+- Undersubscription path: 10 entries, 700 slots → all 10 win, banner printed.
+- Zero entries: hard-fail with exit code 2.
+- Oversubscription: 1000 entries, 700 slots → 700 distinct winners, no duplicates.
+- Idempotency: same `--seed` + same registrations → byte-identical `winners.csv`.
+- Recipient passthrough: `recipient_address` from the registration row appears unchanged in `winners.csv`.
+
+**Integration (real Postgres):**
+- Full pipeline: seed registrations table → `draw` → `winners.csv` in output dir → `load-winners` → rows in `agent_raffle_winners`.
+- Re-run `load-winners` against already-loaded state → refuses with clear error.
+- `verify-onchain` against an Anvil-deployed `AirdropClaim` with full + matching mapping → all pass.
+- `verify-onchain` against an Anvil-deployed `AirdropClaim` with deliberately-missing entries → reports the gaps non-zero.
+
+**End-to-end (with `vultiagent-airdrop`):**
+- `draw` → operator splits `winners.csv` and calls `setWinners` in batches against a Foundry-deployed `AirdropClaim.sol` → `verify-onchain` passes → `load-winners` → claim flow (Stage 4) succeeds for a sample winner.
+
+---
+
+## Files
+
+```
+cmd/airdrop-raffle/
+├── main.go              CLI entrypoint, subcommand routing (cobra or flag stdlib)
+├── draw.go              draw subcommand
+├── load_winners.go      load-winners subcommand
+└── verify_onchain.go    verify-onchain subcommand
+
+internal/service/airdrop/raffle/
+├── selection.go         Fisher-Yates draw against a seeded PRNG
+└── output.go            Serialize winners.csv + manifest.json
+
+internal/storage/postgres/
+├── migrations/XXXXXXXXXXXXXX_create_agent_raffle_winners.sql
+└── sqlc/airdrop_raffle.sql      Insert winners (batched), read for verify-onchain
+```
+
+No more `leaf_encoding.go`, `merkle.go`. Both deleted along with the cross-language test vector dependency.
+
+---
+
+## Open dependencies
+
+- **Stage 0 — `slot_count` and `vult_amount` decisions locked.** These are CLI flags; without locked values the CLI can run against placeholders in dev but won't ship to mainnet.
+- **Stage 0 — private ops repo (or `vultiagent-airdrop`) available to the operator** for committing artifact directories post-draw.
+- **Stage 1 — `recipient_address` column populated.** Done — see Stage 1 spec.
+- **Stage 4 — relayer reads `agent_raffle_winners`.** This spec defines the table; Stage 4 spec consumes it.
+- **`AirdropClaim.sol` deployed and `setWinners` callable** by the multisig before Day 28. The `verify-onchain` subcommand depends on the contract being live.
+
+---
+
+## Done when
+
+- All three subcommands implemented and unit-tested.
+- Integration test against real Postgres + Anvil-deployed contract passes.
+- E2E test: drawn winners → multisig sets allowances → `verify-onchain` passes → `load-winners` populates DB → single claim succeeds via Stage 4's relayer against the same contract.
+- A short operator runbook (`docs/runbooks/raffle-day-12.md`) drafted: "what to do, in order, on Day 12" — including the multisig signer's batch-construction checklist and the post-batch `verify-onchain` gate.

--- a/docs/airdrop-specs/stage-3-quest-tracking.md
+++ b/docs/airdrop-specs/stage-3-quest-tracking.md
@@ -1,0 +1,311 @@
+# Stage 3 — Quest Tracking
+
+## What this stage does
+
+Winning the raffle doesn't immediately get the user VULT. Winners must complete **3 of 5 in-app activities** during Days 13–27 first — swap a token, bridge between chains, do a DeFi action, set up an alert, set up a DCA. This filters bots and rewards engagement before payout.
+
+Every time a user signs and broadcasts a transaction the agent built for them, the agent-backend's existing tx-proposal `/sign` handler fires a quest event into the airdrop module. The event includes a normalised `quest_metadata` payload that the agent layer pre-computed at proposal-creation time (USD value, chain IDs, target contract). The airdrop module then runs the per-quest validator against that payload and, if it qualifies, marks the quest complete. Once a user hits 3 quests they're flagged `claim_eligible`; Stage 4's relayer reads that flag before submitting any on-chain claim.
+
+**Eligibility is enforced backend-side, not on-chain.** The contract trusts the relayer to only submit claims for eligible users. Since the backend is the only relayer and a backend compromise would also compromise any on-chain attestation key, an EIP-712 attestation step would add complexity without meaningful security. (Decision recorded 2026-04-22.)
+
+This stage is alive between Day 13 and Day 27 (the quest-earning window) and the eligibility data continues to be readable indefinitely after that for late claims.
+
+> **2026-04-23 update.** The classifier-based design (sniffing JSONB at quest-event time) was dropped in favour of the agent layer pre-computing a normalised `quest_metadata` field at proposal-creation time. The change moves the work to where the truth lives — the build_* tool that built the tx already knows the USD amount, the route, the target contract. Ripping classification logic out of the airdrop module and replacing it with a clean lookup table is both simpler and more reliable. See "Cross-team contract" below.
+
+---
+
+## The 5 quests
+
+| ID | Triggering tool | Validator reads from `quest_metadata` |
+|---|---|---|
+| `swap` | `build_swap_tx` | `amount_usd >= SWAP_QUEST_MIN_USD`, `token_in_symbol != token_out_symbol`, `router_address` present |
+| `bridge` | `build_swap_tx` (cross-chain), or a future `build_bridge_tx` | `amount_usd >= BRIDGE_QUEST_MIN_USD`, `source_chain_id != dest_chain_id` |
+| `defi_action` | `build_evm_tx` | `target_contract` in `DEFI_ACTION_CONTRACT_ALLOWLIST` |
+| `alert` | (TBD with Product) | (TBD) |
+| `dca` | (TBD with Product) | (TBD) |
+
+The first three are well-defined; `alert` and `dca` are pending Product lock per the Stage 0 decisions table. The validator code for those two ships as stubs that return "not counting" until the rules are filled in. The dispatch table (`tool_name` → `quest_type`) is generic, so adding a new quest is a one-file change with no architectural impact.
+
+3-of-5 is the threshold. This is `QUEST_THRESHOLD = 3` in config — could move if Product changes their mind.
+
+---
+
+## Cross-team contract — the `quest_metadata` shape
+
+The hook depends on two new columns on `agent_tx_proposals`, populated by the agent-backend at proposal-creation time. Without these columns, this stage cannot ship.
+
+```sql
+ALTER TABLE agent_tx_proposals ADD COLUMN tool_name TEXT;        -- e.g. "build_swap_tx"
+ALTER TABLE agent_tx_proposals ADD COLUMN quest_metadata JSONB;  -- normalised, see below
+```
+
+`quest_metadata` schema — flat JSON object, all fields optional, validators only read what they need:
+
+```json
+{
+  "amount_usd":         25.50,
+  "token_in_symbol":    "USDC",
+  "token_out_symbol":   "ETH",
+  "source_chain_id":    1,
+  "dest_chain_id":      1,
+  "target_contract":    "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+  "router_address":     "0x6131b5fae19ea4f9d964eac0408e4408b66337b5"
+}
+```
+
+Notes:
+- `amount_usd` is a JSON number (decimal, not an integer in cents). For swap/bridge it's the USD value of the user-side amount, computed by whichever tool built the tx using its existing quote pipeline.
+- Chain IDs are **integers** (1, 42161, 8453, …), not strings. This is a deliberate divergence from the existing `tx_proposals.chain` column (which holds strings like "ethereum"). Integers are the universal EVM convention; the validators do `source_chain_id != dest_chain_id` cleanly without string-normalisation.
+- Addresses are lowercase hex with `0x` prefix. The DeFi-action validator does a lowercase compare against the configured allowlist.
+- For tools that don't compute USD value (e.g. native sends with no quote), `amount_usd` is omitted. The validators treat absence as "below threshold" and reject the event.
+
+**Three-team responsibility split:**
+
+| Layer | Responsibility |
+|---|---|
+| **MCP team** (`vultisig/mcp-ts` repo — TypeScript MCP server the agent-backend talks to) | Each `build_*` tool emits a `quest_metadata` block in its result, populated from the data it already has during quote/build. **Sized:** `build_evm_tx` ~5 lines (chain ID + target_contract are already in the result struct, just expose). `build_swap_tx` ~25 lines (call the existing `fetchPriceQuote` helper in `src/tools/utility/price-oracle.ts` to compute `amount_usd` from the user's input amount + fetched USD price; swap bundle's router address is already available as `native.router` / `native.inbound_address` or `tx.evm.to`). No new external dependency — CoinGecko oracle is already wired up in `mcp-ts`. Note: the legacy Go `vultisig/mcp` repo is not in the agent chat path. |
+| **agent-backend team** | Migration to add `tool_name` + `quest_metadata` columns. In `internal/service/scheduler/scheduler.go` (call site of `txProposalRepo.Create`; grep for it — currently around line 320, may drift), capture `tool.Name` from the active `result.ToolLogs` entry and forward `tool.Result.quest_metadata` to the new columns. ~10 lines of Go + 1 migration. |
+| **Airdrop module (this stage)** | Read the populated columns at quest-event time. Trivial dispatch + validators. |
+
+Stage 0's decisions table tracks the cross-team commit on this schema (row 12).
+
+---
+
+## Auth model
+
+All quest endpoints are **internal** — paths under `/internal/quests/...`. Every request must carry `X-Internal-Token: <secret>` matching the `INTERNAL_API_KEY` env var. No JWT, no public exposure. Middleware rejects anything missing or wrong with `401 Unauthorized`.
+
+The agent-backend's `SignTxProposal` handler injects the header on its in-process call to `/internal/quests/event`. If/when other services need to fire quest events, they read the same secret from a shared store.
+
+---
+
+## Endpoints
+
+This stage exposes only one endpoint — the quest event ingester. Eligibility is read directly by Stage 4 from the same database tables this stage writes to.
+
+### `POST /internal/quests/event`
+
+**Purpose:** record a single quest-relevant action. Called from the existing `SignTxProposal` handler in this binary after the mobile app reports that a tool-built transaction was signed and broadcast. The hook reads `proposal.tool_name` and `proposal.quest_metadata` from the now-marked-signed row and forwards the values here.
+
+**Request:**
+```http
+POST /internal/quests/event
+X-Internal-Token: <secret>
+Content-Type: application/json
+
+{
+  "public_key":     "...",
+  "tool_call_id":   "...",          // proposal_id is fine — same idempotency property
+  "tx_hash":        "0x...",
+  "tool_name":      "build_swap_tx",
+  "quest_metadata": { /* the agent-backend's persisted blob, forwarded as-is */ }
+}
+```
+
+The handler dispatches `tool_name` → `quest_type` via a 5-line lookup table. If the tool has no quest mapping (e.g. `build_observe_tx`), the handler returns 200 with `recorded: false` — not an error.
+
+`tool_call_id` is the idempotency key — if the same proposal is signed-and-reported twice, the second call is a no-op. In practice the proposal's UUID is fine here. `tx_hash` is captured for audit.
+
+**Response — 200:**
+```json
+{ "recorded": true, "quest_completed": false, "quests_completed": 2 }
+```
+
+`recorded` is true if the event was inserted (fresh OR idempotent retry). `quest_completed` is true only when this event is the one that flipped the user's `user_quests` row to complete. `quests_completed` is the user's running count.
+
+If `tool_name` has no mapping, returns `{ "recorded": false }` with no quest event written.
+
+**Errors:**
+
+| Status | Body | When |
+|---|---|---|
+| 401 | `{"error":"UNAUTHORIZED"}` | Missing or wrong `X-Internal-Token` |
+| 400 | `{"error":"MISSING_FIELDS"}` | `public_key` / `tool_name` / `tool_call_id` missing |
+| 403 | `{"error":"QUEST_NOT_ACTIVE"}` | `now() < QUEST_ACTIVATION_TIMESTAMP` |
+
+**Behavior:**
+
+1. Validate envelope (`public_key`, `tool_name`, `tool_call_id`, `tx_hash`).
+2. Reject if `now() < QUEST_ACTIVATION_TIMESTAMP` (Day 13).
+3. Look up `tool_name` in the dispatch table. If unmapped, return 200 with `recorded: false`.
+4. Dispatch to the per-quest validator. Validator returns `{ qualifies: bool, reason: string }`.
+5. If `qualifies == false`: insert a `quest_events` row with `counted=false` and the reason. Return 200 with `recorded: true, quest_completed: false`. (Logging the rejection helps Product see why borderline events didn't count.)
+6. If `qualifies == true`:
+   - `INSERT INTO agent_quest_events ... ON CONFLICT (tool_call_id) DO NOTHING` (idempotent).
+   - `INSERT INTO agent_user_quests (public_key, quest_id) VALUES (...) ON CONFLICT DO NOTHING RETURNING xmax = 0 AS was_inserted` to mark the quest complete (no-op if already complete).
+   - Read the user's current `quests_completed`.
+7. Return 200 with the result fields.
+
+## Eligibility check
+
+Stage 4's relayer reads eligibility directly from the database — there is no `/internal/quests/eligibility` endpoint. The query is:
+
+```sql
+SELECT
+  EXISTS(SELECT 1 FROM agent_raffle_winners WHERE public_key = $1) AS won_raffle,
+  (SELECT COUNT(*) FROM agent_user_quests WHERE public_key = $1) AS quests_completed
+```
+
+A user is claim-eligible iff `won_raffle = true AND quests_completed >= QUEST_THRESHOLD AND no row in agent_claim_submissions WHERE public_key = $1 AND status IN ('submitted','confirmed')`.
+
+This composite is also what Stage 1's `/airdrop/status` returns as the `claim_eligible` field. A small shared `eligibility.go` helper lives in `internal/service/airdrop/quests/` and is called from both the status handler (Stage 1) and the claim handler (Stage 4).
+
+---
+
+## Wiring the runtime hook
+
+The hook lives in agent-backend's existing `SignTxProposal` handler (`internal/api/tx_proposals.go:95-117`). After the existing `MarkSigned` call succeeds, add:
+
+1. Re-read the proposal (or pass `proposal.ToolName` + `proposal.QuestMetadata` through `MarkSigned`'s return — implementer's choice).
+2. If `tool_name` is empty (proposal predates the migration, or a tool that doesn't tag itself), skip — no quest event fires.
+3. Build the request body: `{ public_key, tool_call_id: proposal.ID, tx_hash: req.TxHash, tool_name, quest_metadata }`.
+4. POST to `http://localhost:<server-port>/internal/quests/event` with `X-Internal-Token: <INTERNAL_API_KEY>`.
+5. Errors are logged but **do not propagate** to the user's `/sign` response. Quest tracking is best-effort — a failed quest hook doesn't fail the user's sign action. If the quest event was lost, the user can re-trigger by repeating the action; ops audits via the `quest_events` table and the `agent_tx_proposals` row's `quest_metadata` field.
+
+The `tool_name → quest_type` map lives in one Go file (`internal/service/airdrop/quests/dispatch.go`):
+
+```go
+var toolToQuest = map[string]string{
+    "build_swap_tx":   "swap",   // or "bridge" — depends on source_chain_id == dest_chain_id; resolved by the validator dispatch
+    "build_bridge_tx": "bridge",
+    "build_evm_tx":    "defi_action",
+}
+```
+
+For `build_swap_tx` specifically, the dispatch needs to inspect `quest_metadata.source_chain_id` vs `dest_chain_id` to decide swap vs bridge — same tool, different quest depending on whether the chains differ. One small switch in the dispatch.
+
+---
+
+## Schema
+
+```sql
+CREATE TYPE airdrop_quest_id AS ENUM ('swap', 'bridge', 'defi_action', 'alert', 'dca');
+
+CREATE TABLE agent_quest_events (
+    tool_call_id    TEXT             PRIMARY KEY,                       -- idempotency key (in practice, the proposal UUID)
+    public_key      TEXT             NOT NULL,
+    quest_id        airdrop_quest_id NOT NULL,
+    tx_hash         TEXT             NOT NULL,
+    counted         BOOLEAN          NOT NULL,                          -- true if the validator qualified this event
+    reject_reason   TEXT,                                               -- non-null only when counted = false
+    tx_proposal_id  UUID,                                               -- soft reference to agent_tx_proposals(id) for audit. No FK — keeps migrations independent and tolerates proposal cleanup.
+    created_at      TIMESTAMPTZ      NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_quest_events_public_key ON agent_quest_events (public_key);
+
+CREATE TABLE agent_user_quests (
+    public_key   TEXT              NOT NULL,
+    quest_id     airdrop_quest_id  NOT NULL,
+    completed_at TIMESTAMPTZ       NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (public_key, quest_id)
+);
+```
+
+Two tables. `quest_events` is the append-only audit log (one row per incoming event, including rejected ones). `user_quests` is the materialised "which quests has each user completed" view.
+
+`tool_call_id` as the events PK gives free idempotency at the database layer. `(public_key, quest_id)` as the user_quests PK gives free deduplication.
+
+`quests_completed` for a user is `SELECT COUNT(*) FROM agent_user_quests WHERE public_key = ?` — fast PK lookup, no separate counter.
+
+The `tool_name` + `quest_metadata` columns on `agent_tx_proposals` are owned by the agent-backend team (see Cross-team contract above), not this stage's migration set.
+
+---
+
+## Configuration
+
+| Var | Type | Notes |
+|---|---|---|
+| `INTERNAL_API_KEY` | string secret | Shared secret for `X-Internal-Token` on `/internal/*` endpoints |
+| `QUEST_ACTIVATION_TIMESTAMP` | RFC3339 timestamp | Day 13 wall clock — events before this are rejected |
+| `QUEST_THRESHOLD` | int, default 3 | How many of 5 quests are needed to be claim-eligible |
+| `DEFI_ACTION_CONTRACT_ALLOWLIST` | comma-separated 0x-addresses | Allow-list for the `defi_action` quest validator. Lowercased at parse time. |
+| `SWAP_QUEST_MIN_USD` | int, default 10 | Min USD value for a swap to count |
+| `BRIDGE_QUEST_MIN_USD` | int, default 10 | Min USD value for a bridge to count |
+
+---
+
+## Observability
+
+Prometheus metrics:
+
+| Metric | Type | Labels |
+|---|---|---|
+| `airdrop_quest_event_total` | Counter | `quest_type`, `result` ∈ `{counted, rejected, idempotent_retry, unmapped_tool}` |
+| `airdrop_quest_event_reject_reason_total` | Counter | `quest_type`, `reason` |
+| `airdrop_quest_completion_total` | Counter | `quest_type` (incremented when a quest first flips to complete for a user) |
+
+Structured logs include `public_key` (first 8 chars), `tool_name`, `quest_type`, `tool_call_id`, `tx_hash`, `result`, `request_id`.
+
+---
+
+## Tests
+
+**Unit (per quest validator):**
+- Boundary cases: just-below threshold, just-above, exact match — using `quest_metadata` fixtures.
+- Negative cases: missing `amount_usd` → rejected, contract not on allowlist → rejected, swap with same chain ID and same token → rejected.
+- Idempotency: same `tool_call_id` twice yields one row, both responses are 200.
+- Unmapped `tool_name`: returns 200 with `recorded: false`, no DB write.
+
+**Unit (eligibility helper):**
+- Won raffle + 3 quests + not claimed → eligible.
+- Won raffle + 2 quests → not eligible.
+- Lost raffle (no winners row) + 3 quests → not eligible.
+- Won raffle + 3 quests + already claimed → not eligible.
+
+**Integration (real Postgres):**
+- Full path: synthetic `agent_tx_proposals` row with `tool_name` + `quest_metadata` populated → call `SignTxProposal` → quest event recorded → `quests_completed` increments → eligibility check flips to true at 3rd completion.
+- Activation timestamp gate: pre-activation event is rejected; post-activation is counted.
+
+---
+
+## Files
+
+```
+internal/api/airdrop/
+└── quests_event.go      POST /internal/quests/event handler
+
+internal/service/airdrop/quests/
+├── dispatch.go          Map tool_name → quest_type (handles swap-vs-bridge by chain ID)
+├── validators/
+│   ├── swap.go          Reads quest_metadata.amount_usd, token symbols, router_address
+│   ├── bridge.go        Reads quest_metadata.amount_usd, source/dest chain IDs
+│   ├── defi_action.go   Reads quest_metadata.target_contract; checks allowlist
+│   ├── alert.go         Stub until Product locks
+│   └── dca.go           Stub until Product locks
+└── eligibility.go       Owned by Stage 1's plan (Stage 1 is first consumer); Stage 4 reuses
+
+internal/api/
+└── tx_proposals.go      (edit) — add the quest hook to SignTxProposal after MarkSigned succeeds
+
+internal/storage/postgres/
+├── migrations/XXXXXXXXXXXXXX_create_agent_quest_events.sql   (shipped by shared-infra plan)
+├── migrations/XXXXXXXXXXXXXX_create_agent_user_quests.sql    (shipped by shared-infra plan)
+└── sqlc/airdrop_quests.sql
+```
+
+---
+
+## Open dependencies
+
+- **MCP team — `quest_metadata` block emitted by `build_swap_tx`, `build_evm_tx`, and any bridge-equivalent tool.** Lock the schema (see "Cross-team contract" above) and ship before this stage can be E2E-tested. **Hard blocker.**
+- **agent-backend team — migration adding `tool_name` + `quest_metadata` to `agent_tx_proposals`, plus the ~10-line scheduler.go change to populate them at proposal-creation time.** **Hard blocker.**
+- **Stage 0 — `INTERNAL_API_KEY` chosen + injected into the deploy.**
+- **Stage 0 — `QUEST_ACTIVATION_TIMESTAMP`, `DEFI_ACTION_CONTRACT_ALLOWLIST` decisions locked.**
+- **Stage 0 — final 5-quest list locked by Product** (specifically the `alert` and `dca` validators).
+- **Stage 0 — `quest_metadata` schema lock signed off** by MCP team + agent-backend team + airdrop eng (decisions row 12).
+- **Stage 1 — status endpoint extension** to include quest fields and `claim_eligible` (done — see Stage 1 spec).
+- **Stage 4 — relayer calls `eligibility.go` directly in-process** (it's a shared helper, not an HTTP boundary).
+
+---
+
+## Done when
+
+- The event endpoint responds with documented shapes against documented status codes.
+- Three live quest validators (swap, bridge, defi_action) implemented and unit-tested for boundary cases against `quest_metadata` fixtures.
+- Stub validators (alert, dca) in place returning "not counting" until Product locks.
+- Idempotency: duplicate `tool_call_id` POSTs result in one event row, both 200 responses.
+- Activation gate: events pre-activation are rejected; post-activation are counted.
+- Eligibility helper returns the correct boolean for all combinations of (won, quests_completed, already_claimed).
+- Hook in `SignTxProposal` fires `/internal/quests/event` correctly; failures are logged but not propagated.
+- E2E confirmation: at least one real `build_swap_tx` flow in staging produces a populated `quest_metadata` block and a `counted` quest event row.

--- a/docs/airdrop-specs/stage-4-claim-relayer.md
+++ b/docs/airdrop-specs/stage-4-claim-relayer.md
@@ -1,0 +1,336 @@
+# Stage 4 — Claim Relayer
+
+## What this stage does
+
+Day 28+. User taps "claim my VULT" in the agent. We pay the gas (the user has no ETH), submit the on-chain claim transaction, watch it confirm, and surface the result back to the user via `/airdrop/status`.
+
+Two invariants must hold:
+
+1. **At most one on-chain claim per user, ever.** Network retries, double-taps, races between threads, restarts mid-submit — none of these can result in two on-chain txs for the same vault.
+2. **No claim is forgotten across service restarts.** If we crash after broadcasting but before recording confirmation, the next process must pick up where we left off.
+
+This is the only stage that touches mainnet. It's also where the operator interface lives — a basic HTML dashboard for monitoring relayer health and triggering manual rebroadcasts on stuck transactions.
+
+---
+
+## The Day 28+ claim flow
+
+1. User taps "claim" in the agent. App POSTs `/airdrop/claim` with their JWT.
+2. Backend validates window, kill switch, eligibility, and "not already claimed."
+3. Backend takes a serializing lock on the relayer state singleton, fetches the next nonce, builds + signs + broadcasts the claim tx via the EVM RPC, inserts the `claim_submissions` row, increments the nonce, commits.
+4. Backend returns `{tx_hash, status: 'submitted', nonce}` — sub-second response.
+5. Background monitor goroutine polls submitted-but-unconfirmed rows every N seconds, asks the RPC for receipts, updates each row to `confirmed` or `failed` as receipts come in.
+6. User polls `/airdrop/status`, sees `already_claimed: true` once their tx is `confirmed`.
+
+Concurrency model: claim handlers serialize through `SELECT FOR UPDATE` on the relayer state singleton. ~700 claims × ~1 sec per claim = ~12 min total processing if every winner claims at once. Confirmation runs in parallel in the background, so user-visible latency is just the submission window.
+
+---
+
+## Auth model
+
+| Surface | Auth |
+|---|---|
+| `POST /airdrop/claim` | JWT (existing middleware) |
+| `GET /ops/*`, `POST /ops/*` | HTTP Basic Auth via `OPS_USERNAME` + `OPS_PASSWORD` env vars |
+
+There are no `/internal/relayer/*` routes. The balance + stuck-claims views are served directly from `/ops/balance` and `/ops/stuck-claims` over Basic Auth — same logic, half the surface, one less auth mechanism.
+
+---
+
+## Endpoints
+
+### `POST /airdrop/claim`
+
+**Purpose:** initiate the on-chain VULT claim for the user identified by the JWT.
+
+**Request:**
+```http
+POST /airdrop/claim
+Authorization: Bearer <jwt>
+```
+
+Empty body. Public key from JWT, recipient + amount from `agent_raffle_winners` lookup. (Recipient + amount are also the source of truth on-chain via the contract's `allowance(recipient)` mapping; the local table is what the relayer reads to build calldata.)
+
+**Response — 200 (fresh submission):**
+```json
+{
+  "tx_hash": "0x...",
+  "status": "submitted",
+  "nonce": 42,
+  "submitted_at": "2026-05-15T18:00:00Z"
+}
+```
+
+**Response — 200 (already submitted, idempotent retry):**
+```json
+{
+  "tx_hash": "0x...",
+  "status": "submitted" | "confirmed",
+  "nonce": 42,
+  "submitted_at": "2026-05-15T18:00:00Z",
+  "confirmed_at": "2026-05-15T18:01:23Z"     // only if confirmed
+}
+```
+
+**Errors:**
+
+| Status | Body | When |
+|---|---|---|
+| 401 | (handled by middleware) | Missing or invalid JWT |
+| 403 | `{"error":"NOT_CLAIM_ELIGIBLE"}` | User isn't a raffle winner OR hasn't completed ≥ QUEST_THRESHOLD quests |
+| 403 | `{"error":"CLAIM_WINDOW_NOT_OPEN"}` | `now() < CLAIM_WINDOW_OPEN_AT` |
+| 403 | `{"error":"CLAIM_DISABLED"}` | `CLAIM_ENABLED == false` (operator kill switch) |
+| 503 | `{"error":"RPC_UNAVAILABLE"}` | EVM RPC didn't respond or returned a non-revert error |
+| 503 | `{"error":"KMS_UNAVAILABLE"}` | KMS Sign API failed (relayer wallet signing) |
+| 503 | `{"error":"BROADCAST_REJECTED","detail":"..."}` | RPC accepted the tx but returned a logical error (e.g. nonce already used, insufficient funds). Relayer state may need ops attention; logged at warn for ops dashboards. |
+
+503 errors are transient — client retries.
+
+**Behavior:**
+
+1. Verify JWT → `public_key`.
+2. Reject if `now() < CLAIM_WINDOW_OPEN_AT`.
+3. Reject if `CLAIM_ENABLED == false`.
+4. Compute eligibility (`raffle won AND quests_completed >= QUEST_THRESHOLD`). Reject 403 if not.
+5. `BEGIN` Postgres transaction.
+6. `SELECT ... FROM agent_relayer_state WHERE id = 1 FOR UPDATE` — serializes all claim handlers.
+7. `SELECT * FROM agent_claim_submissions WHERE public_key = ? AND status IN ('submitted', 'confirmed')`. If a row exists, COMMIT and return it (idempotent retry).
+8. `next_nonce = relayer_state.next_nonce`.
+9. Fetch `(recipient, amount)` from `agent_raffle_winners WHERE public_key = ?`. (No proof — the contract's allowance mapping is the source of truth on-chain.)
+10. Query EVM RPC for current gas estimates: `eth_maxPriorityFeePerGas` for tip, latest block's `baseFeePerGas` for the base. `maxFeePerGas = 2 * baseFee + tip` (standard padded formula).
+11. Build the calldata for `AirdropClaim.claim(recipient)`. Exact ABI from `vultiagent-airdrop`. The `amount` is already locked in the contract's allowance; we record it locally only for display in the status response.
+12. Build EIP-1559 tx with `next_nonce`, gas params from step 10, calldata, chain ID from `EVM_CHAIN_ID`.
+13. Sign the tx via AWS KMS `Sign` with `KMS_RELAYER_KEY_ARN`. Convert returned DER signature to EVM `(r, s, v)` and assemble the signed tx bytes.
+14. Broadcast via RPC (`eth_sendRawTransaction`).
+15. INSERT `agent_claim_submissions` row with `nonce, recipient, amount, tx_hash, status='submitted', submitted_at=NOW(), max_fee_gwei, max_priority_fee_gwei`.
+16. UPDATE `agent_relayer_state SET next_nonce = next_nonce + 1`.
+17. COMMIT.
+18. Return `{tx_hash, status, nonce, submitted_at}`.
+
+If any of steps 9–14 fail, ROLLBACK. The state row's `next_nonce` is unchanged, no `claim_submissions` row is inserted, and the user can retry. The client receives the appropriate 5xx error.
+
+The eligibility check in step 4 calls the shared `eligibility.go` helper from Stage 3 (in-process Go function call, not an HTTP roundtrip — eligibility is a pure DB read with no signing or external calls, so the API-endpoint pattern doesn't apply).
+
+There is no `/internal/relayer/*` route group. Balance and stuck-claims health are served directly from `/ops/balance` and `/ops/stuck-claims` (Basic Auth). The data shapes are documented in the Operator interface section below.
+
+---
+
+## Operator interface
+
+Server-rendered HTML pages using Go's `html/template`. No JS build, no client-side framework. Lives in the same binary, behind HTTP Basic Auth.
+
+| Path | Page |
+|---|---|
+| `GET /ops` | Landing page. Links to balance, stuck-claims. Shows last-refreshed time. |
+| `GET /ops/balance` | Renders relayer health as a styled table. Auto-refreshes every 30s via `<meta http-equiv="refresh">`. Big red banner if `low_balance_warning`. Shape: `relayer_address`, `eth_balance_wei`/`_human`, `vult_contract_balance_wei`/`_human`, `low_balance_warning`, `low_balance_threshold_eth`, `estimated_claims_remaining`, `next_nonce`, `rpc_block_height`. `estimated_claims_remaining = floor(eth_balance / (avg_gas_per_claim * current_gas_price))`. `low_balance_warning = true` when `eth_balance < LOW_BALANCE_THRESHOLD_ETH`. |
+| `GET /ops/stuck-claims` | Table of submitted-but-unconfirmed claims older than `?older_than_minutes=N` (default 10), sorted by minutes-pending descending. Each row shows `public_key` (first 8), `tx_hash` (linked to Etherscan), `nonce`, `submitted_at`, `minutes_pending`, `max_fee_gwei`, `max_priority_fee_gwei`. Each row has a "Rebroadcast (+50 gwei)" button. Empty table is the healthy state. |
+| `POST /ops/rebroadcast` | Form handler. Reads `{public_key, bump_gwei}` (default 50). Calls the rebroadcast service in-process: sign new EIP-1559 tx with **same nonce** + bumped fees, broadcast, update `tx_hash` + gas fields on the row. Returns 404 if no row, 400 if already confirmed, 503 if RPC failed. Renders a success/error page with the new tx hash + Etherscan link. The old tx and new tx race in the mempool — both share the same nonce so only one can confirm. |
+
+Pages query the DB + RPC directly via the relayer service — no internal HTTP roundtrip.
+
+Templates in `internal/api/ops/templates/`. CSS inlined into `<style>` blocks (no separate static asset pipeline). One Go file per route.
+
+---
+
+## Background workers
+
+### Confirmation monitor
+
+A single goroutine started at service boot. Loop:
+
+1. `SELECT * FROM agent_claim_submissions WHERE status = 'submitted' ORDER BY submitted_at LIMIT 100`.
+2. For each row, call `eth_getTransactionReceipt(tx_hash)` via the RPC.
+3. If receipt present and `status = 1` (success) and `blockNumber` is at least `latestBlock - CONFIRMATION_BLOCKS` (default 1, set higher for paranoid safety) blocks back: UPDATE row to `status='confirmed', confirmed_at=NOW(), block_number=...`.
+4. If receipt present and `status = 0` (revert): UPDATE to `status='failed', failed_at=NOW(), failure_reason='reverted'`. (Operator inspects via Etherscan.)
+5. If no receipt: skip — try again next tick.
+6. Sleep `CONFIRMATION_POLL_INTERVAL_SECONDS` (default 15).
+
+On startup, the monitor immediately runs once to pick up any rows still in `submitted` from before a restart — guarantees no claim is forgotten.
+
+Lives in `cmd/scheduler/` alongside the existing `agent_scheduled_tasks` poller (reuses the existing scheduler binary; no new process).
+
+---
+
+## Schema
+
+```sql
+CREATE TYPE airdrop_claim_status AS ENUM ('submitted', 'confirmed', 'failed');
+
+CREATE TABLE agent_claim_submissions (
+    public_key            TEXT                   NOT NULL,
+    nonce                 BIGINT                 NOT NULL UNIQUE,                 -- one nonce, one row, ever
+    recipient             TEXT                   NOT NULL,
+    amount                NUMERIC(78, 0)         NOT NULL,
+    tx_hash               TEXT                   NOT NULL,                          -- updated in place on rebroadcast
+    status                airdrop_claim_status   NOT NULL,
+    max_fee_gwei          INTEGER                NOT NULL,
+    max_priority_fee_gwei INTEGER                NOT NULL,
+    block_number          BIGINT,                                                 -- non-null once confirmed
+    failure_reason        TEXT,                                                   -- non-null when status='failed'
+    submitted_at          TIMESTAMPTZ            NOT NULL,
+    confirmed_at          TIMESTAMPTZ,
+    failed_at             TIMESTAMPTZ
+);
+
+-- "at most one in-flight or completed claim per user"
+CREATE UNIQUE INDEX idx_claim_submissions_one_per_user
+  ON agent_claim_submissions (public_key)
+  WHERE status IN ('submitted', 'confirmed');
+
+-- Confirmation monitor scan
+CREATE INDEX idx_claim_submissions_pending
+  ON agent_claim_submissions (submitted_at)
+  WHERE status = 'submitted';
+
+-- Relayer wallet nonce + general state
+CREATE TABLE agent_relayer_state (
+    id           INT PRIMARY KEY DEFAULT 1 CHECK (id = 1),                       -- singleton
+    next_nonce   BIGINT,                                                         -- NULL until first boot reads it from the chain
+    last_synced  TIMESTAMPTZ     NOT NULL DEFAULT NOW()
+);
+
+INSERT INTO agent_relayer_state (id) VALUES (1);                                 -- next_nonce auto-populated on first boot
+```
+
+On service boot, if `next_nonce` is NULL the relayer queries `eth_getTransactionCount(relayer_address, 'pending')` and writes the result inside a `SELECT FOR UPDATE` transaction. Subsequent boots no-op. Removes the manual `psql UPDATE` that would otherwise be a Day 28 footgun.
+
+`nonce UNIQUE` is the database-level guard against accidental nonce reuse (anywhere — across all users). The partial unique index on `(public_key)` enforces the "one claim per user" invariant. The `(submitted_at) WHERE status='submitted'` partial index makes the monitor's scan O(unconfirmed) rather than O(all_claims).
+
+Rebroadcasts update `tx_hash` in place. Audit trail of prior bumps lives in the structured logs (one log line per rebroadcast tagged with old `tx_hash`, new `tx_hash`, bump amount, operator). Etherscan covers the public chain side. The previous-array column was dropped 2026-04-23 — ops debug from logs instead.
+
+---
+
+## Configuration
+
+| Var | Type | Notes |
+|---|---|---|
+| `KMS_RELAYER_KEY_ARN` | AWS ARN | KMS key signing claim txs (the relayer wallet). Stage 0 procurement. **Single KMS key for the whole airdrop** — no separate quest oracle key. |
+| `EVM_RPC_URL` | URL | Ethereum mainnet RPC. Free public endpoint (PublicNode, llamarpc) is acceptable per the eng-side decision. |
+| `EVM_CHAIN_ID` | int | 1 for mainnet. |
+| `AIRDROP_CLAIM_CONTRACT_ADDRESS` | 0x-address | Same value as Stage 3's `verifyingContract`. |
+| `CLAIM_WINDOW_OPEN_AT` | RFC3339 timestamp | Day 28 wall clock; before this, `/airdrop/claim` returns 403. |
+| `CLAIM_ENABLED` | bool, default true | Operator kill switch. Read on every request — hot-reload by env-var change + service signal, or a redeploy. |
+| `LOW_BALANCE_THRESHOLD_ETH` | decimal, default 0.5 | Triggers `low_balance_warning: true` in `/ops/balance`. |
+| `CONFIRMATION_BLOCKS` | int, default 1 | Required reorg depth before marking a tx `confirmed`. |
+| `CONFIRMATION_POLL_INTERVAL_SECONDS` | int, default 15 | How often the monitor checks for receipts. |
+| `OPS_USERNAME` / `OPS_PASSWORD` | strings | HTTP Basic Auth credentials for the operator UI. |
+| `INTERNAL_API_KEY` | string secret | (Reused from Stage 3.) `X-Internal-Token` header value. |
+
+---
+
+## Observability
+
+Prometheus metrics:
+
+| Metric | Type | Labels |
+|---|---|---|
+| `airdrop_claim_request_total` | Counter | `result` ∈ `{submitted, idempotent_retry, not_eligible, window_not_open, disabled, rpc_error, kms_error, broadcast_rejected}` |
+| `airdrop_claim_submit_duration_seconds` | Histogram | (handler latency end-to-end) |
+| `airdrop_claim_kms_sign_duration_seconds` | Histogram | (KMS Sign call only) |
+| `airdrop_claim_broadcast_duration_seconds` | Histogram | (`eth_sendRawTransaction` only) |
+| `airdrop_claim_confirmation_total` | Counter | `result` ∈ `{confirmed, reverted, monitor_skipped}` |
+| `airdrop_claim_confirmation_lag_seconds` | Histogram | (time from `submitted_at` to `confirmed_at`) |
+| `airdrop_relayer_eth_balance_wei` | Gauge | (refreshed by the monitor on each pass) |
+| `airdrop_relayer_next_nonce` | Gauge | |
+| `airdrop_relayer_rebroadcast_total` | Counter | |
+
+Structured logs include: `public_key` (first 8 chars), `nonce`, `tx_hash`, `request_id`, `result`. KMS errors and broadcast errors carry the underlying error message.
+
+A Prometheus alert on `airdrop_relayer_eth_balance_wei < 0.5e18` pages ops.
+
+---
+
+## Tests
+
+**Unit:**
+- Claim eligibility: every combination of (winner / not winner) × (quests met / not met) × (already claimed / not).
+- Window enforcement: before, exactly at, after `CLAIM_WINDOW_OPEN_AT`.
+- Kill switch: `CLAIM_ENABLED=false` returns `403 CLAIM_DISABLED`.
+- Idempotency: two concurrent calls (simulated via mock `FOR UPDATE` serialization) — one inserts, the other returns the inserted row's `tx_hash`.
+- Rebroadcast: existing row is updated in place (new `tx_hash`, bumped fees), nonce unchanged.
+- KMS DER → EVM signature: golden test against a known-good signature.
+
+**Integration (real Postgres + LocalStack KMS + Anvil mainnet fork):**
+- Full path: synthetic raffle-winners row + on-chain `setWinners` call to Anvil → quest fixtures making user eligible → POST /airdrop/claim → tx confirms on Anvil → confirmation monitor flips status → next status request shows `already_claimed: true`.
+- Restart-safety: kill the service after the broadcast UPDATE but before… (well, the broadcast and UPDATE are in one txn, so there's no in-between state). Test instead: kill the service immediately after broadcast (one tx in `submitted` state in DB), restart, observe monitor pick up the submitted row on its first tick and confirm against Anvil.
+- Concurrency: 50 concurrent /airdrop/claim calls for 50 distinct eligible users → 50 distinct nonces, 50 distinct tx hashes, no DB constraint violations, all submitted within ~50 seconds.
+- Concurrency: 50 concurrent /airdrop/claim calls for the same user → exactly one tx submitted, 49 idempotent-retry responses with the same tx_hash.
+- Stuck-tx flow: tx broadcast at low gas → never confirms → `/ops/stuck-claims` lists it → `POST /ops/rebroadcast` form with bump → new tx confirms → original is dropped (same nonce).
+- Balance endpoint returns expected values; low-balance threshold flips the warning.
+
+**End-to-end (with `vultiagent-airdrop`):**
+- Multisig calls `setWinners` on Foundry-deployed `AirdropClaim.sol` → claim submitted by Stage 4's relayer against the same contract → contract pays VULT to recipient.
+
+---
+
+## Files
+
+```
+cmd/scheduler/
+└── main.go    (edit) — add the confirmation monitor goroutine alongside the existing agent_scheduled_tasks loop
+
+internal/api/airdrop/
+└── claim.go              POST /airdrop/claim handler
+
+internal/api/ops/
+├── handler.go            Routing + inline Basic Auth check (5-line stdlib helper, no shared middleware)
+├── templates/
+│   ├── layout.html
+│   ├── balance.html
+│   ├── stuck_claims.html
+│   └── rebroadcast_result.html
+└── ops.go                One file per page wiring data → template; balance and stuck-claims pages call the relayer service directly; rebroadcast page calls relayer/rebroadcast.go directly
+
+internal/service/airdrop/relayer/
+├── claim.go              Top-level claim flow (validation → tx build → broadcast → DB). Calls eligibility helper from internal/service/airdrop/quests/eligibility.go. Uses the shared kms + ethclient packages below.
+├── nonce.go              Initialise on first boot from chain; SELECT FOR UPDATE singleton; increment
+├── monitor.go            Background confirmation poller
+└── rebroadcast.go        Manual rebroadcast logic (called by the ops form handler)
+
+# Shared (shipped by shared-infra plan — PR #150 — not Stage 4's code):
+internal/service/airdrop/kms/signer.go        AWS KMS Sign + DER → EVM (r,s,v). Shared; Stage 4 imports.
+internal/service/airdrop/ethclient/client.go  go-ethereum wrapper; gas/nonce/receipt/broadcast. Shared; Stage 4 imports.
+
+internal/storage/postgres/
+├── migrations/20260423000005_create_agent_claim_submissions.sql (shipped by shared-infra plan)
+├── migrations/20260423000006_create_agent_relayer_state.sql     (shipped by shared-infra plan)
+└── sqlc/airdrop_claims.sql
+
+docs/runbooks/
+├── relayer-day-28.md            "How to bring up the relayer on Day 28"
+└── relayer-stuck-tx.md          "What to do when /ops/stuck-claims has rows"
+```
+
+---
+
+## Open dependencies
+
+- **Stage 0 — `KMS_RELAYER_KEY_ARN` provisioned, relayer wallet funded with ETH.** Without ETH at the relayer address, every claim 503s.
+- **Stage 0 — `AIRDROP_CLAIM_CONTRACT_ADDRESS` known.** From the contract mission's mainnet deploy.
+- **Stage 0 — `CLAIM_WINDOW_OPEN_AT` decision locked.**
+- **Stage 0 — VULT prize pool funded into `AirdropClaim.sol`.** Without VULT in the contract, claims revert.
+- **`vultisig/vultiagent-airdrop` — `AirdropClaim.sol` deployed to mainnet** with the claim function ABI matching what we encode in step 12 of the claim flow. Tracked at [vultisig/vultiagent-airdrop#1](https://github.com/vultisig/vultiagent-airdrop/issues/1).
+- **Stage 2 — `agent_raffle_winners` populated.** Pre-condition for the claim handler's recipient/amount lookup.
+- **Multisig has called `setWinners(...)` on the contract** for every row in `agent_raffle_winners` before Day 28. Without this, every claim reverts on the contract's `amount == 0` check. Stage 2's `verify-onchain` subcommand is the gate that confirms this.
+- **Stage 3 — `eligibility.go` shared helper available.** Called inline from the claim handler.
+- **EVM RPC chosen** — free public endpoint is acceptable per eng-lead decision.
+- **EVM RPC reachable from the relayer at boot** — needed for the auto nonce-sync on first boot.
+
+---
+
+## Done when
+
+- `/airdrop/claim` returns documented shapes against documented status codes.
+- DB unique partial index enforces "one claim per user" — concurrency test passes (50 concurrent same-user requests yield exactly one tx).
+- 50 concurrent distinct-user requests submit all 50 in ~serialised order, all with distinct nonces.
+- Confirmation monitor flips `submitted` → `confirmed` against Anvil within seconds of the receipt landing.
+- Restart test: kill mid-pipeline, restart, observe monitor pick up unfinished work.
+- Rebroadcast endpoint succeeds with bumped gas; original tx is replaced by the new one.
+- `/ops/balance` returns sane values; low-balance flag flips at the configured threshold.
+- `/ops/stuck-claims` lists pending-too-long rows; empty when none.
+- `/ops` UI is reachable behind Basic Auth and renders all four pages correctly.
+- E2E test against Foundry-deployed `AirdropClaim.sol` passes start-to-finish: register → win raffle → multisig calls setWinners → complete quests → claim → VULT received at recipient.
+- Day 28 runbook drafted (`docs/runbooks/relayer-day-28.md`) covering: deploy steps, smoke test, kill switch flip-on. (No manual nonce sync step — that auto-runs on first boot.)
+- Stuck-tx runbook drafted covering: how to read `/ops/stuck-claims`, decide bump amount, handle "still stuck after rebroadcast" case (probably a free RPC throttling issue → switch RPC URL or pay for one).
+- Top-up runbook drafted (`docs/runbooks/relayer-top-up.md`): when `low_balance_warning` fires (or alert fires below 0.5 ETH), the funding multisig sends ETH to the relayer address (visible at the top of `/ops/balance`). Standard EOA send, no contract interaction. Safe to do mid-campaign at any time; no service restart needed. The relayer wallet is fundable from any wallet — there's no allow-list on the receive side.
+- End-of-campaign runbook drafted (`docs/runbooks/relayer-end-of-campaign.md`): once the claim window has decisively closed (e.g. 90 days past `CLAIM_WINDOW_OPEN_AT` with no recent claims), the multisig flips `CLAIM_ENABLED=false` (kill switch — every claim immediately 403s with `CLAIM_DISABLED`), then calls `recoverERC20(VULT, balance, treasuryAddress)` on the contract to drain the unclaimed VULT back to treasury, then optionally calls `recoverERC20` on the relayer wallet's remaining ETH (sent from the relayer via a one-off KMS-signed tx, or just left to fund a future campaign). Document the multisig signers' steps and which etherscan calls to watch.

--- a/plans/airdrop/2026-04-23-shared-infra.md
+++ b/plans/airdrop/2026-04-23-shared-infra.md
@@ -1,0 +1,1444 @@
+# Vultiverse Airdrop — Shared Infra Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Lay the cross-cutting foundations every airdrop stage will reuse — config, six DB tables, an internal-token middleware, a KMS signer, and an EVM RPC client — inside the existing `agent-backend` Go service.
+
+**Architecture:** Additive only. New config substruct grouped under `cfg.Airdrop`. Six new `agent_*` tables via Goose migrations. New middleware lives in the existing `internal/api/` package. KMS signer + EVM client live under `internal/service/airdrop/` so per-stage code can import them by stable paths. No existing code is modified except the root `Config` struct in `internal/config/config.go`.
+
+**Tech Stack:**
+- Go 1.25, Echo v4
+- PostgreSQL via pgx/v5; sqlc for query generation; Goose for migrations
+- envconfig (`kelseyhightower/envconfig`) for env vars
+- AWS SDK v2 (`aws-sdk-go-v2/service/kms`) — new dependency
+- `go-ethereum/ethclient` and `go-ethereum/crypto` — new dependency
+- Logrus, Prometheus client (existing)
+
+**Spec source of truth:** `docs/airdrop-specs/shared-concerns.md`
+
+**Working directory for all tasks:** `/Users/apotheosis/git/vultisig/agent-backend/` — every `git`, `go`, and `make` command runs from here unless stated otherwise.
+
+**Branch:** Create one branch for the whole shared-infra plan: `feat/airdrop-shared-infra`. Commit after every task. Open the PR once the plan is complete.
+
+---
+
+## Pre-flight (do once before Task 1)
+
+```bash
+cd /Users/apotheosis/git/vultisig/agent-backend
+git checkout main
+git pull
+git checkout -b feat/airdrop-shared-infra
+```
+
+Confirm Postgres is running locally and `DATABASE_DSN` is set in your shell or `.env`. The repo's existing migrations should apply cleanly — verify with:
+
+```bash
+make migrate-up
+```
+
+If that fails, stop and fix the local DB before continuing.
+
+**Test database setup.** The Stage 1 / 3 / 4 plans run integration tests against a real Postgres. The agent-backend repo doesn't currently distinguish a test DB from the dev DB — tests just use `DATABASE_DSN`. Two options:
+- (a) Point `DATABASE_DSN` at a throwaway local DB before running `go test ./...`. Truncates between tests are sufficient.
+- (b) Set `TEST_DATABASE_DSN` to a separate test DB; the helper functions in the per-stage plans fall back to `DATABASE_DSN` if `TEST_DATABASE_DSN` is empty.
+
+Either works. If your dev DB has data you care about, use (b) with a separate test DB.
+
+---
+
+## Task 1: Add `AirdropConfig` substruct to `Config`
+
+**Why:** Every subsequent task reads from `cfg.Airdrop.*`. Establishing the struct first means later tasks just plug in.
+
+**Files:**
+- Modify: `internal/config/config.go` (add new substruct + add to root `Config`)
+- Modify: `.env.example` (add new env vars at the bottom in a clearly-labelled airdrop section)
+- Test: `internal/config/airdrop_test.go` (new file)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/config/airdrop_test.go`:
+
+```go
+package config
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+func TestAirdropConfigLoadsFromEnv(t *testing.T) {
+	envs := map[string]string{
+		"TRANSITION_WINDOW_START":            "2026-04-25T00:00:00Z",
+		"TRANSITION_WINDOW_END":              "2026-04-30T00:00:00Z",
+		"INTERNAL_API_KEY":                   "test-internal-secret",
+		"QUEST_ACTIVATION_TIMESTAMP":         "2026-05-01T00:00:00Z",
+		"QUEST_THRESHOLD":                    "3",
+		"DEFI_ACTION_CONTRACT_ALLOWLIST":     "0xaaa,0xbbb",
+		"SWAP_QUEST_MIN_USD":                 "10",
+		"BRIDGE_QUEST_MIN_USD":               "10",
+		"KMS_RELAYER_KEY_ARN":                "arn:aws:kms:us-east-1:000000000000:key/abc",
+		"EVM_RPC_URL":                        "https://ethereum-rpc.publicnode.com",
+		"EVM_CHAIN_ID":                       "1",
+		"AIRDROP_CLAIM_CONTRACT_ADDRESS":     "0x0000000000000000000000000000000000000001",
+		"CLAIM_WINDOW_OPEN_AT":               "2026-05-15T00:00:00Z",
+		"CLAIM_ENABLED":                      "true",
+		"LOW_BALANCE_THRESHOLD_ETH":          "0.5",
+		"CONFIRMATION_BLOCKS":                "1",
+		"CONFIRMATION_POLL_INTERVAL_SECONDS": "15",
+		"OPS_USERNAME":                       "ops",
+		"OPS_PASSWORD":                       "ops-secret",
+	}
+	for k, v := range envs {
+		t.Setenv(k, v)
+	}
+	// Ensure no stray vars from a real .env interfere
+	defer func() {
+		for k := range envs {
+			os.Unsetenv(k)
+		}
+	}()
+
+	cfg, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+
+	if got := cfg.Airdrop.TransitionWindowStart; !got.Equal(time.Date(2026, 4, 25, 0, 0, 0, 0, time.UTC)) {
+		t.Errorf("TransitionWindowStart = %v, want 2026-04-25T00:00:00Z", got)
+	}
+	if cfg.Airdrop.QuestThreshold != 3 {
+		t.Errorf("QuestThreshold = %d, want 3", cfg.Airdrop.QuestThreshold)
+	}
+	if cfg.Airdrop.InternalAPIKey != "test-internal-secret" {
+		t.Errorf("InternalAPIKey wrong: %q", cfg.Airdrop.InternalAPIKey)
+	}
+	if !cfg.Airdrop.ClaimEnabled {
+		t.Errorf("ClaimEnabled should be true")
+	}
+	if cfg.Airdrop.ConfirmationBlocks != 1 {
+		t.Errorf("ConfirmationBlocks = %d, want 1", cfg.Airdrop.ConfirmationBlocks)
+	}
+	if cfg.Airdrop.LowBalanceThresholdETH != "0.5" {
+		t.Errorf("LowBalanceThresholdETH = %q, want 0.5", cfg.Airdrop.LowBalanceThresholdETH)
+	}
+}
+
+func TestAirdropConfigDefaults(t *testing.T) {
+	// Set only required vars; verify defaults for the rest
+	t.Setenv("TRANSITION_WINDOW_START", "2026-04-25T00:00:00Z")
+	t.Setenv("TRANSITION_WINDOW_END", "2026-04-30T00:00:00Z")
+	t.Setenv("INTERNAL_API_KEY", "x")
+	t.Setenv("QUEST_ACTIVATION_TIMESTAMP", "2026-05-01T00:00:00Z")
+	t.Setenv("KMS_RELAYER_KEY_ARN", "arn")
+	t.Setenv("EVM_RPC_URL", "url")
+	t.Setenv("AIRDROP_CLAIM_CONTRACT_ADDRESS", "0x1")
+	t.Setenv("CLAIM_WINDOW_OPEN_AT", "2026-05-15T00:00:00Z")
+	t.Setenv("OPS_USERNAME", "u")
+	t.Setenv("OPS_PASSWORD", "p")
+
+	cfg, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+
+	if cfg.Airdrop.QuestThreshold != 3 {
+		t.Errorf("QuestThreshold default = %d, want 3", cfg.Airdrop.QuestThreshold)
+	}
+	if cfg.Airdrop.SwapQuestMinUSD != 10 {
+		t.Errorf("SwapQuestMinUSD default = %d, want 10", cfg.Airdrop.SwapQuestMinUSD)
+	}
+	if !cfg.Airdrop.ClaimEnabled {
+		t.Errorf("ClaimEnabled default should be true")
+	}
+	if cfg.Airdrop.EVMChainID != 1 {
+		t.Errorf("EVMChainID default = %d, want 1", cfg.Airdrop.EVMChainID)
+	}
+	if cfg.Airdrop.ConfirmationBlocks != 1 {
+		t.Errorf("ConfirmationBlocks default = %d, want 1", cfg.Airdrop.ConfirmationBlocks)
+	}
+	if cfg.Airdrop.ConfirmationPollIntervalSeconds != 15 {
+		t.Errorf("ConfirmationPollIntervalSeconds default = %d, want 15", cfg.Airdrop.ConfirmationPollIntervalSeconds)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+go test ./internal/config/ -run TestAirdropConfig -v
+```
+
+Expected: compile error — `cfg.Airdrop` undefined.
+
+- [ ] **Step 3: Add the substruct**
+
+In `internal/config/config.go`, add a new field at the bottom of the `Config` struct:
+
+```go
+type Config struct {
+	// ... existing fields ...
+	Airdrop AirdropConfig
+}
+```
+
+Then add the substruct anywhere below `Config` (matching the file's existing style — substructs follow the root struct):
+
+```go
+// AirdropConfig holds Vultiverse Airdrop configuration. Spec:
+// docs/airdrop-specs/shared-concerns.md.
+type AirdropConfig struct {
+	// Stage 1 — boarding window
+	TransitionWindowStart time.Time `envconfig:"TRANSITION_WINDOW_START" required:"true"`
+	TransitionWindowEnd   time.Time `envconfig:"TRANSITION_WINDOW_END" required:"true"`
+
+	// Internal-token shared secret for /internal/* endpoints (Stages 3, 4)
+	InternalAPIKey string `envconfig:"INTERNAL_API_KEY" required:"true"`
+
+	// Stage 3 — quest tracking
+	QuestActivationTimestamp     time.Time `envconfig:"QUEST_ACTIVATION_TIMESTAMP" required:"true"`
+	QuestThreshold               int       `envconfig:"QUEST_THRESHOLD" default:"3"`
+	DefiActionContractAllowlist  string    `envconfig:"DEFI_ACTION_CONTRACT_ALLOWLIST" default:""`
+	SwapQuestMinUSD              int       `envconfig:"SWAP_QUEST_MIN_USD" default:"10"`
+	BridgeQuestMinUSD            int       `envconfig:"BRIDGE_QUEST_MIN_USD" default:"10"`
+
+	// Stage 4 — claim relayer
+	KMSRelayerKeyARN              string `envconfig:"KMS_RELAYER_KEY_ARN" required:"true"`
+	EVMRPCURL                     string `envconfig:"EVM_RPC_URL" required:"true"`
+	EVMChainID                    int    `envconfig:"EVM_CHAIN_ID" default:"1"`
+	AirdropClaimContractAddress   string `envconfig:"AIRDROP_CLAIM_CONTRACT_ADDRESS" required:"true"`
+	ClaimWindowOpenAt             time.Time `envconfig:"CLAIM_WINDOW_OPEN_AT" required:"true"`
+	ClaimEnabled                  bool   `envconfig:"CLAIM_ENABLED" default:"true"`
+	LowBalanceThresholdETH        string `envconfig:"LOW_BALANCE_THRESHOLD_ETH" default:"0.5"`
+	ConfirmationBlocks            int    `envconfig:"CONFIRMATION_BLOCKS" default:"1"`
+	ConfirmationPollIntervalSeconds int  `envconfig:"CONFIRMATION_POLL_INTERVAL_SECONDS" default:"15"`
+
+	// Stage 4 — operator UI Basic Auth
+	OpsUsername string `envconfig:"OPS_USERNAME" required:"true"`
+	OpsPassword string `envconfig:"OPS_PASSWORD" required:"true"`
+}
+```
+
+Add `"time"` to the import block if it isn't already there (it likely is — check).
+
+`LowBalanceThresholdETH` is intentionally a `string` not a `float64` — it's a decimal value that we'll parse into a `*big.Int` (wei) at the use site to avoid float precision issues. Same approach as the spec's NUMERIC(78,0) database column.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+go test ./internal/config/ -run TestAirdropConfig -v
+```
+
+Expected: PASS for both subtests.
+
+- [ ] **Step 5: Document the new vars in `.env.example`**
+
+Append to the end of `.env.example`:
+
+```bash
+# ====================================================================
+# Vultiverse Airdrop (specs in docs/airdrop-specs/)
+# ====================================================================
+
+# Stage 1 — boarding window. RFC3339 timestamps.
+TRANSITION_WINDOW_START=2026-04-25T00:00:00Z
+TRANSITION_WINDOW_END=2026-04-30T00:00:00Z
+
+# Stages 3 + 4 — shared secret for /internal/* endpoints (X-Internal-Token header)
+INTERNAL_API_KEY=change-me
+
+# Stage 3 — quest tracking
+QUEST_ACTIVATION_TIMESTAMP=2026-05-01T00:00:00Z
+QUEST_THRESHOLD=3
+DEFI_ACTION_CONTRACT_ALLOWLIST=
+SWAP_QUEST_MIN_USD=10
+BRIDGE_QUEST_MIN_USD=10
+
+# Stage 4 — claim relayer
+KMS_RELAYER_KEY_ARN=arn:aws:kms:us-east-1:000000000000:key/REPLACE
+EVM_RPC_URL=https://ethereum-rpc.publicnode.com
+EVM_CHAIN_ID=1
+AIRDROP_CLAIM_CONTRACT_ADDRESS=0x0000000000000000000000000000000000000000
+CLAIM_WINDOW_OPEN_AT=2026-05-15T00:00:00Z
+CLAIM_ENABLED=true
+LOW_BALANCE_THRESHOLD_ETH=0.5
+CONFIRMATION_BLOCKS=1
+CONFIRMATION_POLL_INTERVAL_SECONDS=15
+
+# Stage 4 — operator UI Basic Auth
+OPS_USERNAME=ops
+OPS_PASSWORD=change-me
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/config/config.go internal/config/airdrop_test.go .env.example
+git commit -m "feat(airdrop): add AirdropConfig substruct with 19 env vars"
+```
+
+---
+
+## Task 2: Six Goose migrations for the airdrop tables
+
+**Why:** Stage 1's status endpoint, the raffle CLI, the quest tracker, and the relayer all need their tables to exist before they can be developed. Bundling all six up front avoids the engineer who picks up Stage 4 having to write Stage 2's migration as a side-quest.
+
+**Files (all new):**
+- Create: `internal/storage/postgres/migrations/20260423000001_create_agent_airdrop_registrations.sql`
+- Create: `internal/storage/postgres/migrations/20260423000002_create_agent_raffle_winners.sql`
+- Create: `internal/storage/postgres/migrations/20260423000003_create_agent_quest_events.sql`
+- Create: `internal/storage/postgres/migrations/20260423000004_create_agent_user_quests.sql`
+- Create: `internal/storage/postgres/migrations/20260423000005_create_agent_claim_submissions.sql`
+- Create: `internal/storage/postgres/migrations/20260423000006_create_agent_relayer_state.sql`
+
+Pattern matches the existing `20260224000001_create_scheduled_tasks.sql` template — `-- +goose Up` and `-- +goose Down` blocks wrapped in `-- +goose StatementBegin/End` directives.
+
+- [ ] **Step 1: Create migration 1 — `agent_airdrop_registrations`**
+
+```sql
+-- +goose Up
+-- +goose StatementBegin
+
+CREATE TYPE airdrop_registration_source AS ENUM ('seed', 'vault_share');
+
+CREATE TABLE agent_airdrop_registrations (
+    public_key        TEXT                        PRIMARY KEY,
+    source            airdrop_registration_source NOT NULL,
+    recipient_address TEXT                        NOT NULL,
+    registered_at     TIMESTAMPTZ                 NOT NULL DEFAULT NOW()
+);
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+DROP TABLE IF EXISTS agent_airdrop_registrations;
+DROP TYPE IF EXISTS airdrop_registration_source;
+
+-- +goose StatementEnd
+```
+
+- [ ] **Step 2: Create migration 2 — `agent_raffle_winners`**
+
+```sql
+-- +goose Up
+-- +goose StatementBegin
+
+CREATE TABLE agent_raffle_winners (
+    public_key TEXT          PRIMARY KEY,
+    recipient  TEXT          NOT NULL,
+    amount     NUMERIC(78,0) NOT NULL,
+    loaded_at  TIMESTAMPTZ   NOT NULL DEFAULT NOW()
+);
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+DROP TABLE IF EXISTS agent_raffle_winners;
+
+-- +goose StatementEnd
+```
+
+- [ ] **Step 3: Create migration 3 — `agent_quest_events`**
+
+```sql
+-- +goose Up
+-- +goose StatementBegin
+
+CREATE TYPE airdrop_quest_id AS ENUM ('swap', 'bridge', 'defi_action', 'alert', 'dca');
+
+CREATE TABLE agent_quest_events (
+    tool_call_id   TEXT             PRIMARY KEY,
+    public_key     TEXT             NOT NULL,
+    quest_id       airdrop_quest_id NOT NULL,
+    tx_hash        TEXT             NOT NULL,
+    counted        BOOLEAN          NOT NULL,
+    reject_reason  TEXT,
+    tx_proposal_id UUID,
+    created_at     TIMESTAMPTZ      NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_quest_events_public_key ON agent_quest_events (public_key);
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+DROP TABLE IF EXISTS agent_quest_events;
+DROP TYPE IF EXISTS airdrop_quest_id;
+
+-- +goose StatementEnd
+```
+
+- [ ] **Step 4: Create migration 4 — `agent_user_quests`**
+
+```sql
+-- +goose Up
+-- +goose StatementBegin
+
+CREATE TABLE agent_user_quests (
+    public_key   TEXT             NOT NULL,
+    quest_id     airdrop_quest_id NOT NULL,
+    completed_at TIMESTAMPTZ      NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (public_key, quest_id)
+);
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+DROP TABLE IF EXISTS agent_user_quests;
+
+-- +goose StatementEnd
+```
+
+Note: `airdrop_quest_id` enum is created in migration 3 — this migration depends on it. Goose applies in filename order, so this is fine.
+
+- [ ] **Step 5: Create migration 5 — `agent_claim_submissions`**
+
+```sql
+-- +goose Up
+-- +goose StatementBegin
+
+CREATE TYPE airdrop_claim_status AS ENUM ('submitted', 'confirmed', 'failed');
+
+CREATE TABLE agent_claim_submissions (
+    public_key            TEXT                 NOT NULL,
+    nonce                 BIGINT               NOT NULL UNIQUE,
+    recipient             TEXT                 NOT NULL,
+    amount                NUMERIC(78, 0)       NOT NULL,
+    tx_hash               TEXT                 NOT NULL,
+    status                airdrop_claim_status NOT NULL,
+    max_fee_gwei          INTEGER              NOT NULL,
+    max_priority_fee_gwei INTEGER              NOT NULL,
+    block_number          BIGINT,
+    failure_reason        TEXT,
+    submitted_at          TIMESTAMPTZ          NOT NULL,
+    confirmed_at          TIMESTAMPTZ,
+    failed_at             TIMESTAMPTZ
+);
+
+CREATE UNIQUE INDEX idx_claim_submissions_one_per_user
+  ON agent_claim_submissions (public_key)
+  WHERE status IN ('submitted', 'confirmed');
+
+CREATE INDEX idx_claim_submissions_pending
+  ON agent_claim_submissions (submitted_at)
+  WHERE status = 'submitted';
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+DROP TABLE IF EXISTS agent_claim_submissions;
+DROP TYPE IF EXISTS airdrop_claim_status;
+
+-- +goose StatementEnd
+```
+
+- [ ] **Step 6: Create migration 6 — `agent_relayer_state`**
+
+```sql
+-- +goose Up
+-- +goose StatementBegin
+
+CREATE TABLE agent_relayer_state (
+    id          INT PRIMARY KEY DEFAULT 1 CHECK (id = 1),
+    next_nonce  BIGINT,
+    last_synced TIMESTAMPTZ     NOT NULL DEFAULT NOW()
+);
+
+INSERT INTO agent_relayer_state (id) VALUES (1);
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+DROP TABLE IF EXISTS agent_relayer_state;
+
+-- +goose StatementEnd
+```
+
+`next_nonce` is intentionally nullable — it gets populated on first boot of the relayer (Stage 4) via `eth_getTransactionCount`.
+
+- [ ] **Step 7: Apply all six migrations against local DB**
+
+```bash
+make migrate-up
+```
+
+Expected output: `OK   20260423000006_create_agent_relayer_state.sql` (or similar — final line should reference migration 6).
+
+Confirm tables exist:
+
+```bash
+psql "$DATABASE_DSN" -c "\dt agent_*"
+```
+
+Expected: lists all six new `agent_*` tables alongside the pre-existing ones.
+
+- [ ] **Step 8: Test rollback**
+
+```bash
+make migrate-down
+make migrate-down
+make migrate-down
+make migrate-down
+make migrate-down
+make migrate-down
+```
+
+Each call rolls back one migration. After six calls, all six new tables should be gone:
+
+```bash
+psql "$DATABASE_DSN" -c "\dt agent_airdrop_registrations agent_raffle_winners agent_quest_events agent_user_quests agent_claim_submissions agent_relayer_state"
+```
+
+Expected: `Did not find any relation named ...` for each.
+
+- [ ] **Step 9: Re-apply for the rest of the plan**
+
+```bash
+make migrate-up
+```
+
+Subsequent tasks will assume the tables exist.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add internal/storage/postgres/migrations/20260423000001_create_agent_airdrop_registrations.sql \
+         internal/storage/postgres/migrations/20260423000002_create_agent_raffle_winners.sql \
+         internal/storage/postgres/migrations/20260423000003_create_agent_quest_events.sql \
+         internal/storage/postgres/migrations/20260423000004_create_agent_user_quests.sql \
+         internal/storage/postgres/migrations/20260423000005_create_agent_claim_submissions.sql \
+         internal/storage/postgres/migrations/20260423000006_create_agent_relayer_state.sql
+git commit -m "feat(airdrop): add six migrations for airdrop tables"
+```
+
+---
+
+## Task 3: Internal-token middleware
+
+**Why:** Stages 3 and 4 expose `/internal/*` endpoints called from elsewhere in this same binary plus by ops curl. They need a shared-secret header check separate from the user-facing JWT middleware.
+
+**Files:**
+- Create: `internal/api/internal_token_middleware.go`
+- Create: `internal/api/internal_token_middleware_test.go`
+
+Pattern matches the existing `internal/api/middleware.go` — function on `Server` struct, returns `echo.HandlerFunc`. Use Go's `crypto/subtle` for constant-time comparison so timing attacks against the secret aren't possible.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/api/internal_token_middleware_test.go`:
+
+```go
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+)
+
+func TestInternalTokenMiddleware(t *testing.T) {
+	const secret = "test-internal-secret"
+	server := &Server{internalToken: secret, logger: testLogger(t)}
+	mw := server.InternalTokenMiddleware
+
+	handler := func(c echo.Context) error {
+		return c.String(http.StatusOK, "ok")
+	}
+
+	cases := []struct {
+		name       string
+		header     string
+		wantStatus int
+	}{
+		{"valid token", secret, http.StatusOK},
+		{"missing header", "", http.StatusUnauthorized},
+		{"wrong token", "nope", http.StatusUnauthorized},
+		{"empty token", "", http.StatusUnauthorized},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodGet, "/internal/anything", nil)
+			if tc.header != "" {
+				req.Header.Set("X-Internal-Token", tc.header)
+			}
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+			err := mw(handler)(c)
+			if err != nil {
+				t.Fatalf("middleware returned error: %v", err)
+			}
+			if rec.Code != tc.wantStatus {
+				t.Errorf("status = %d, want %d", rec.Code, tc.wantStatus)
+			}
+		})
+	}
+}
+```
+
+You'll need a small `testLogger` helper if the package doesn't already have one. Check `internal/api/auth_logout_test.go` for the existing test-helper pattern — re-use whatever it uses (almost certainly `logrus.New()` set to `logrus.PanicLevel` to silence test output). If no helper exists, add one in this same test file:
+
+```go
+func testLogger(t *testing.T) *logrus.Logger {
+	t.Helper()
+	l := logrus.New()
+	l.SetLevel(logrus.PanicLevel)
+	return l
+}
+```
+
+(Add `"github.com/sirupsen/logrus"` to imports if you add the helper.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+go test ./internal/api/ -run TestInternalTokenMiddleware -v
+```
+
+Expected: compile error — `InternalTokenMiddleware` undefined; `internalToken` field undefined on `Server`.
+
+- [ ] **Step 3: Add the `internalToken` field to the Server struct**
+
+In `internal/api/server.go` (or wherever the `Server` struct is declared — `grep -n "type Server struct" internal/api/*.go` to find it), add a field:
+
+```go
+type Server struct {
+	// ... existing fields ...
+	internalToken string
+}
+```
+
+And in the `NewServer` (or equivalent constructor), wire it from config:
+
+```go
+func NewServer(cfg *config.Config, /* other deps */) *Server {
+	return &Server{
+		// ... existing fields ...
+		internalToken: cfg.Airdrop.InternalAPIKey,
+	}
+}
+```
+
+Match whatever constructor pattern the existing code uses. If the constructor takes a config ref, just add the line. If it doesn't, pass `cfg.Airdrop.InternalAPIKey` from `cmd/server/main.go` where the server is constructed.
+
+- [ ] **Step 4: Implement the middleware**
+
+Create `internal/api/internal_token_middleware.go`:
+
+```go
+package api
+
+import (
+	"crypto/subtle"
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+)
+
+// InternalTokenMiddleware authenticates requests against the shared
+// X-Internal-Token secret. Used by /internal/* routes that are called
+// from other parts of this same binary or by ops curl. Constant-time
+// compare to defeat timing attacks against the secret.
+func (s *Server) InternalTokenMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		got := c.Request().Header.Get("X-Internal-Token")
+		if got == "" || subtle.ConstantTimeCompare([]byte(got), []byte(s.internalToken)) != 1 {
+			return c.JSON(http.StatusUnauthorized, ErrorResponse{Error: "unauthorized"})
+		}
+		return next(c)
+	}
+}
+```
+
+The `ErrorResponse` type already exists in this package — see how `AuthMiddleware` uses it.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+```bash
+go test ./internal/api/ -run TestInternalTokenMiddleware -v
+```
+
+Expected: PASS for all four subtests.
+
+- [ ] **Step 6: Run the full api test suite to confirm no regressions**
+
+```bash
+go test ./internal/api/...
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/api/internal_token_middleware.go \
+         internal/api/internal_token_middleware_test.go \
+         internal/api/server.go
+# (or wherever you wired the field in Step 3)
+git commit -m "feat(airdrop): add internal-token middleware for /internal/* routes"
+```
+
+---
+
+## Task 4: KMS signer
+
+**Why:** Stage 4 signs every claim transaction via AWS KMS. The signer wraps the KMS `Sign` API and handles the DER → EVM `(r, s, v)` conversion. Splitting this into pure functions and an interface lets unit tests cover the conversion logic without LocalStack.
+
+**Files:**
+- Create: `internal/service/airdrop/kms/signer.go`
+- Create: `internal/service/airdrop/kms/signer_test.go`
+- Modify: `go.mod`, `go.sum` (added by `go mod tidy`)
+
+**Dependencies (added by `go get` below):**
+- `github.com/aws/aws-sdk-go-v2/config`
+- `github.com/aws/aws-sdk-go-v2/service/kms`
+- `github.com/ethereum/go-ethereum/crypto`
+- `github.com/ethereum/go-ethereum/common`
+
+- [ ] **Step 1: Add dependencies**
+
+```bash
+go get github.com/aws/aws-sdk-go-v2/config
+go get github.com/aws/aws-sdk-go-v2/service/kms
+go get github.com/ethereum/go-ethereum
+go mod tidy
+```
+
+- [ ] **Step 2: Write the failing test for DER decoding**
+
+Create `internal/service/airdrop/kms/signer_test.go`:
+
+```go
+package kms
+
+import (
+	"bytes"
+	"encoding/hex"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+// TestParseDERSignature confirms the helper extracts (r, s) from an
+// ASN.1 DER-encoded ECDSA signature in the shape KMS returns.
+func TestParseDERSignature(t *testing.T) {
+	// Sample DER signature: SEQUENCE { INTEGER r, INTEGER s }
+	// r = 0x01, s = 0x02 (one-byte values padded). Constructed by hand
+	// so we can assert the parser without depending on real KMS output.
+	der, _ := hex.DecodeString("3006020101020102")
+
+	r, s, err := parseDERSignature(der)
+	if err != nil {
+		t.Fatalf("parseDERSignature: %v", err)
+	}
+	if r.Cmp(big.NewInt(1)) != 0 {
+		t.Errorf("r = %s, want 1", r.String())
+	}
+	if s.Cmp(big.NewInt(2)) != 0 {
+		t.Errorf("s = %s, want 2", s.String())
+	}
+}
+
+// TestRecoverEVMAddress confirms we can reconstruct the relayer's EVM
+// address from a known compressed/uncompressed public key. Uses go-ethereum's
+// own derivation as the source of truth — if these match, our path is correct.
+func TestRecoverEVMAddress(t *testing.T) {
+	// Generate a fresh keypair, take its uncompressed public key, then
+	// confirm addressFromPublicKey() matches go-ethereum's PubkeyToAddress.
+	priv, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	expected := crypto.PubkeyToAddress(priv.PublicKey)
+
+	pubBytes := crypto.FromECDSAPub(&priv.PublicKey) // uncompressed: 0x04 || X || Y
+
+	got, err := addressFromPublicKey(pubBytes)
+	if err != nil {
+		t.Fatalf("addressFromPublicKey: %v", err)
+	}
+	if !bytes.Equal(got.Bytes(), expected.Bytes()) {
+		t.Errorf("address = %s, want %s", got.Hex(), expected.Hex())
+	}
+}
+
+// TestNormalizeS confirms low-S enforcement (EIP-2 / Ethereum yellow paper).
+// KMS may return high-S; Ethereum tx submission rejects it.
+func TestNormalizeS(t *testing.T) {
+	// secp256k1 curve order N (from go-ethereum source)
+	n, _ := new(big.Int).SetString("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141", 16)
+	halfN := new(big.Int).Rsh(n, 1)
+
+	// A high-S value (just above halfN)
+	highS := new(big.Int).Add(halfN, big.NewInt(1))
+
+	got := normalizeS(highS)
+	if got.Cmp(halfN) > 0 {
+		t.Errorf("normalized s should be <= n/2; got %s > %s", got.String(), halfN.String())
+	}
+	expected := new(big.Int).Sub(n, highS)
+	if got.Cmp(expected) != 0 {
+		t.Errorf("normalized s = %s, want %s (n - highS)", got.String(), expected.String())
+	}
+
+	// Already-low s should pass through unchanged
+	lowS := big.NewInt(42)
+	if normalizeS(lowS).Cmp(lowS) != 0 {
+		t.Errorf("low s should pass through unchanged")
+	}
+}
+
+var _ = common.Address{} // keep import live until full Signer test is added
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+```bash
+go test ./internal/service/airdrop/kms/ -v
+```
+
+Expected: compile error — `parseDERSignature`, `addressFromPublicKey`, `normalizeS` undefined.
+
+- [ ] **Step 4: Implement signer.go**
+
+Create `internal/service/airdrop/kms/signer.go`:
+
+```go
+package kms
+
+import (
+	"context"
+	"encoding/asn1"
+	"errors"
+	"fmt"
+	"math/big"
+
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	awskms "github.com/aws/aws-sdk-go-v2/service/kms"
+	kmstypes "github.com/aws/aws-sdk-go-v2/service/kms/types"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+// Signer signs 32-byte digests with an AWS KMS key. The returned
+// signature is a 65-byte EVM-format (r || s || v) suitable for
+// EIP-1559 transaction signing.
+type Signer interface {
+	SignDigest(ctx context.Context, digest []byte) (signature []byte, err error)
+	Address() common.Address
+}
+
+// kmsSigner is the production implementation; backed by AWS KMS.
+type kmsSigner struct {
+	client  *awskms.Client
+	keyARN  string
+	address common.Address // recovered once at construction from the key's public key
+	pubBytes []byte         // uncompressed public key, used for recovery byte selection
+}
+
+// NewKMSSigner constructs a Signer backed by the KMS key at keyARN.
+// At construction it fetches the key's public key, computes the EVM
+// address, and stashes both for later use.
+func NewKMSSigner(ctx context.Context, keyARN string) (Signer, error) {
+	awsCfg, err := awsconfig.LoadDefaultConfig(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("load aws config: %w", err)
+	}
+	client := awskms.NewFromConfig(awsCfg)
+
+	// Fetch the key's public key. KMS returns DER-encoded SubjectPublicKeyInfo.
+	out, err := client.GetPublicKey(ctx, &awskms.GetPublicKeyInput{KeyId: &keyARN})
+	if err != nil {
+		return nil, fmt.Errorf("get kms public key: %w", err)
+	}
+
+	pubBytes, err := publicKeyFromSPKI(out.PublicKey)
+	if err != nil {
+		return nil, fmt.Errorf("parse spki: %w", err)
+	}
+	addr, err := addressFromPublicKey(pubBytes)
+	if err != nil {
+		return nil, fmt.Errorf("derive address: %w", err)
+	}
+	return &kmsSigner{
+		client:   client,
+		keyARN:   keyARN,
+		address:  addr,
+		pubBytes: pubBytes,
+	}, nil
+}
+
+func (s *kmsSigner) Address() common.Address { return s.address }
+
+func (s *kmsSigner) SignDigest(ctx context.Context, digest []byte) ([]byte, error) {
+	if len(digest) != 32 {
+		return nil, fmt.Errorf("digest must be 32 bytes, got %d", len(digest))
+	}
+
+	out, err := s.client.Sign(ctx, &awskms.SignInput{
+		KeyId:            &s.keyARN,
+		Message:          digest,
+		MessageType:      kmstypes.MessageTypeDigest,
+		SigningAlgorithm: kmstypes.SigningAlgorithmSpecEcdsaSha256,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("kms sign: %w", err)
+	}
+
+	r, sVal, err := parseDERSignature(out.Signature)
+	if err != nil {
+		return nil, fmt.Errorf("parse signature: %w", err)
+	}
+	sVal = normalizeS(sVal)
+
+	// Recover v: try both possibilities and pick the one whose recovered
+	// public key matches our stashed pubBytes.
+	v, err := recoveryByte(digest, r, sVal, s.pubBytes)
+	if err != nil {
+		return nil, fmt.Errorf("recovery byte: %w", err)
+	}
+
+	out2 := make([]byte, 65)
+	r.FillBytes(out2[0:32])
+	sVal.FillBytes(out2[32:64])
+	out2[64] = v
+	return out2, nil
+}
+
+// parseDERSignature decodes an ASN.1 DER `SEQUENCE { INTEGER, INTEGER }`
+// into (r, s) big.Ints — the format AWS KMS returns from `Sign`.
+func parseDERSignature(der []byte) (r, s *big.Int, err error) {
+	var sig struct{ R, S *big.Int }
+	if _, err := asn1.Unmarshal(der, &sig); err != nil {
+		return nil, nil, err
+	}
+	if sig.R == nil || sig.S == nil {
+		return nil, nil, errors.New("nil r or s")
+	}
+	return sig.R, sig.S, nil
+}
+
+// publicKeyFromSPKI extracts the uncompressed secp256k1 public key
+// (65 bytes: 0x04 || X || Y) from a KMS SubjectPublicKeyInfo blob.
+func publicKeyFromSPKI(spki []byte) ([]byte, error) {
+	// SubjectPublicKeyInfo = SEQUENCE { algorithm, BIT STRING }.
+	// The bit string IS the uncompressed public key.
+	var info struct {
+		Algorithm asn1.RawValue
+		PublicKey asn1.BitString
+	}
+	if _, err := asn1.Unmarshal(spki, &info); err != nil {
+		return nil, err
+	}
+	if len(info.PublicKey.Bytes) != 65 || info.PublicKey.Bytes[0] != 0x04 {
+		return nil, fmt.Errorf("expected 65-byte uncompressed key, got %d bytes prefix=0x%x",
+			len(info.PublicKey.Bytes), info.PublicKey.Bytes[0])
+	}
+	return info.PublicKey.Bytes, nil
+}
+
+// addressFromPublicKey computes the EVM address from a 65-byte uncompressed
+// secp256k1 public key (0x04 || X || Y). Address = last 20 bytes of
+// keccak256(X || Y).
+func addressFromPublicKey(pub []byte) (common.Address, error) {
+	if len(pub) != 65 || pub[0] != 0x04 {
+		return common.Address{}, fmt.Errorf("expected 65-byte uncompressed key")
+	}
+	return common.BytesToAddress(crypto.Keccak256(pub[1:])[12:]), nil
+}
+
+// secp256k1 curve order, from go-ethereum.
+var (
+	secp256k1N    *big.Int
+	secp256k1HalfN *big.Int
+)
+
+func init() {
+	secp256k1N, _ = new(big.Int).SetString(
+		"FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141", 16)
+	secp256k1HalfN = new(big.Int).Rsh(secp256k1N, 1)
+}
+
+// normalizeS enforces low-S form (EIP-2). If s > n/2, replace with n - s.
+func normalizeS(s *big.Int) *big.Int {
+	if s.Cmp(secp256k1HalfN) > 0 {
+		return new(big.Int).Sub(secp256k1N, s)
+	}
+	return s
+}
+
+// recoveryByte tries v=0 and v=1 (Ethereum's recovery byte values for raw sigs);
+// returns whichever recovers to a public key matching expectedPub. Caller is
+// responsible for adjusting the recovery byte for chain ID where needed
+// (EIP-1559 / EIP-155 use the raw 0/1 form; legacy txs use 27/28 + chainID*2).
+func recoveryByte(digest []byte, r, s *big.Int, expectedPub []byte) (byte, error) {
+	sigBytes := make([]byte, 65)
+	r.FillBytes(sigBytes[0:32])
+	s.FillBytes(sigBytes[32:64])
+	for v := byte(0); v <= 1; v++ {
+		sigBytes[64] = v
+		recovered, err := crypto.Ecrecover(digest, sigBytes)
+		if err != nil {
+			continue
+		}
+		// Ecrecover returns the uncompressed pub key (65 bytes incl. 0x04 prefix)
+		if len(recovered) == 65 && bytesEqual(recovered, expectedPub) {
+			return v, nil
+		}
+	}
+	return 0, errors.New("could not recover pub key from signature")
+}
+
+func bytesEqual(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+go test ./internal/service/airdrop/kms/ -v
+```
+
+Expected: PASS for `TestParseDERSignature`, `TestRecoverEVMAddress`, `TestNormalizeS`.
+
+- [ ] **Step 6: Add a sign-and-recover round-trip test using a Go-native ECDSA key**
+
+This test exercises the full flow except the actual KMS call — it produces a signature with go-ethereum's signing primitives, decodes it through `parseDERSignature` (after we DER-encode it), and confirms `recoveryByte` finds the correct `v`. Append to `signer_test.go`:
+
+```go
+import (
+	"crypto/ecdsa"
+	"encoding/asn1"
+)
+
+// TestSignRoundTrip generates a keypair, signs a digest with go-ethereum
+// directly, encodes the signature in DER (matching what KMS returns), then
+// runs it through the same pipeline our SignDigest uses. End result should
+// be a 65-byte (r || s || v) signature that ecrecover validates.
+func TestSignRoundTrip(t *testing.T) {
+	priv, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	pubBytes := crypto.FromECDSAPub(&priv.PublicKey)
+
+	digest := crypto.Keccak256([]byte("hello world"))
+
+	// Native sign returns 65 bytes (r || s || v); we strip v and re-encode
+	// (r, s) as DER to mimic what KMS returns.
+	rsv, err := crypto.Sign(digest, priv)
+	if err != nil {
+		t.Fatalf("crypto.Sign: %v", err)
+	}
+	r := new(big.Int).SetBytes(rsv[0:32])
+	s := new(big.Int).SetBytes(rsv[32:64])
+	derBytes, err := asn1.Marshal(struct{ R, S *big.Int }{R: r, S: s})
+	if err != nil {
+		t.Fatalf("asn1.Marshal: %v", err)
+	}
+
+	// Now run through our parsing path
+	r2, s2, err := parseDERSignature(derBytes)
+	if err != nil {
+		t.Fatalf("parseDERSignature: %v", err)
+	}
+	s2 = normalizeS(s2)
+
+	v, err := recoveryByte(digest, r2, s2, pubBytes)
+	if err != nil {
+		t.Fatalf("recoveryByte: %v", err)
+	}
+
+	// Reassemble and recover; should match
+	out := make([]byte, 65)
+	r2.FillBytes(out[0:32])
+	s2.FillBytes(out[32:64])
+	out[64] = v
+	recovered, err := crypto.Ecrecover(digest, out)
+	if err != nil {
+		t.Fatalf("Ecrecover: %v", err)
+	}
+	if !bytes.Equal(recovered, pubBytes) {
+		t.Errorf("recovered pubkey doesn't match")
+	}
+
+	// And verify priv → expected address
+	_ = ecdsa.PublicKey{} // silence unused-import if you didn't add ecdsa elsewhere
+	expected := crypto.PubkeyToAddress(priv.PublicKey)
+	addr, _ := addressFromPublicKey(pubBytes)
+	if addr != expected {
+		t.Errorf("address mismatch: %s vs %s", addr.Hex(), expected.Hex())
+	}
+}
+```
+
+- [ ] **Step 7: Run round-trip test**
+
+```bash
+go test ./internal/service/airdrop/kms/ -run TestSignRoundTrip -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add internal/service/airdrop/kms/ go.mod go.sum
+git commit -m "feat(airdrop): add KMS signer with DER decode + EVM signature recovery"
+```
+
+**Note on integration test deferred:** The spec's "Done when" includes "KMS signer can sign a no-op digest against a real (LocalStack) KMS key and the recovered EVM address matches." That's a LocalStack-dependent integration test that can ship in Stage 4's plan (where we'll actually wire LocalStack into the test setup). The pure-Go round-trip above proves the math; the LocalStack test will prove the AWS SDK glue.
+
+---
+
+## Task 5: EVM client wrapper
+
+**Why:** Stage 4 reads gas estimates and broadcasts transactions through this. Wrapping go-ethereum's `ethclient.Client` exposes only the methods we actually need — nothing accidentally leaks; retry policy + timeout + future RPC rotation live in one place.
+
+**Files:**
+- Create: `internal/service/airdrop/ethclient/client.go`
+- Create: `internal/service/airdrop/ethclient/client_test.go`
+
+- [ ] **Step 1: Write the failing test for the wrapper interface**
+
+Create `internal/service/airdrop/ethclient/client_test.go`:
+
+```go
+package ethclient
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// TestClientInterface confirms the package exposes the exact set of methods
+// the Stage 4 spec requires. The bodies are not exercised here — that's
+// integration territory — but the type assertion catches API drift early.
+func TestClientInterface(t *testing.T) {
+	var c Client = nil
+	_ = c
+
+	// Method surface — these calls won't compile if the interface changes
+	if false {
+		ctx := context.Background()
+		var iface Client
+		_, _ = iface.LatestBaseFee(ctx)
+		_, _ = iface.SuggestGasTipCap(ctx)
+		_, _ = iface.NonceAt(ctx, common.Address{}, nil)
+		_, _ = iface.SendRawTransaction(ctx, nil)
+		_, _ = iface.GetTransactionReceipt(ctx, common.Hash{})
+		_, _ = iface.BalanceOf(ctx, common.Address{}, common.Address{})
+		_, _ = iface.Balance(ctx, common.Address{})
+		_, _ = iface.BlockNumber(ctx)
+	}
+}
+
+// TestNewClientRejectsBadURL confirms the constructor surfaces dial errors.
+func TestNewClientRejectsBadURL(t *testing.T) {
+	_, err := NewClient("not-a-url")
+	if err == nil {
+		t.Errorf("expected error for invalid URL, got nil")
+	}
+}
+
+// (Round-trip tests against an Anvil instance live in Stage 4's plan, where
+// the dev-time Anvil dependency will be set up.)
+var _ = big.NewInt
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+go test ./internal/service/airdrop/ethclient/ -v
+```
+
+Expected: compile error — `Client`, `NewClient` undefined.
+
+- [ ] **Step 3: Implement the wrapper**
+
+Create `internal/service/airdrop/ethclient/client.go`:
+
+```go
+package ethclient
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	geth "github.com/ethereum/go-ethereum/ethclient"
+)
+
+// Client exposes only the EVM RPC methods the airdrop relayer needs.
+// Backed by go-ethereum's ethclient under the hood; centralised here so
+// retry/timeout/RPC-rotation policy lives in one place.
+type Client interface {
+	// LatestBaseFee returns the most recent block's baseFeePerGas.
+	LatestBaseFee(ctx context.Context) (*big.Int, error)
+	// SuggestGasTipCap returns the RPC's suggested priority fee (eth_maxPriorityFeePerGas).
+	SuggestGasTipCap(ctx context.Context) (*big.Int, error)
+	// NonceAt returns the nonce at blockNumber (nil = latest).
+	NonceAt(ctx context.Context, address common.Address, blockNumber *big.Int) (uint64, error)
+	// SendRawTransaction broadcasts a signed tx; returns the tx hash.
+	SendRawTransaction(ctx context.Context, signedTxBytes []byte) (common.Hash, error)
+	// GetTransactionReceipt returns the receipt or ethereum.NotFound.
+	GetTransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error)
+	// BalanceOf returns an ERC-20 balance of `account` for `token` (calls token.balanceOf(account)).
+	BalanceOf(ctx context.Context, token, account common.Address) (*big.Int, error)
+	// Balance returns the native ETH balance of `account` at the latest block.
+	Balance(ctx context.Context, account common.Address) (*big.Int, error)
+	// BlockNumber returns the most recent block number. Used by Stage 4's
+	// /internal/relayer/balance for the rpc_block_height health field.
+	BlockNumber(ctx context.Context) (uint64, error)
+}
+
+type client struct {
+	rpc *geth.Client
+}
+
+// NewClient dials the RPC URL and returns a wrapped client.
+func NewClient(rpcURL string) (Client, error) {
+	c, err := geth.Dial(rpcURL)
+	if err != nil {
+		return nil, fmt.Errorf("dial %s: %w", rpcURL, err)
+	}
+	return &client{rpc: c}, nil
+}
+
+func (c *client) LatestBaseFee(ctx context.Context) (*big.Int, error) {
+	header, err := c.rpc.HeaderByNumber(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("header: %w", err)
+	}
+	if header.BaseFee == nil {
+		return nil, fmt.Errorf("base fee unavailable (pre-EIP-1559 chain?)")
+	}
+	return new(big.Int).Set(header.BaseFee), nil
+}
+
+func (c *client) SuggestGasTipCap(ctx context.Context) (*big.Int, error) {
+	return c.rpc.SuggestGasTipCap(ctx)
+}
+
+func (c *client) NonceAt(ctx context.Context, address common.Address, blockNumber *big.Int) (uint64, error) {
+	return c.rpc.NonceAt(ctx, address, blockNumber)
+}
+
+func (c *client) SendRawTransaction(ctx context.Context, signedTxBytes []byte) (common.Hash, error) {
+	tx := new(types.Transaction)
+	if err := tx.UnmarshalBinary(signedTxBytes); err != nil {
+		return common.Hash{}, fmt.Errorf("unmarshal tx: %w", err)
+	}
+	if err := c.rpc.SendTransaction(ctx, tx); err != nil {
+		return common.Hash{}, fmt.Errorf("send tx: %w", err)
+	}
+	return tx.Hash(), nil
+}
+
+func (c *client) GetTransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error) {
+	r, err := c.rpc.TransactionReceipt(ctx, txHash)
+	if err == ethereum.NotFound {
+		return nil, ethereum.NotFound
+	}
+	return r, err
+}
+
+// erc20BalanceOfSelector is the keccak256("balanceOf(address)") method ID.
+var erc20BalanceOfSelector = []byte{0x70, 0xa0, 0x82, 0x31}
+
+func (c *client) BalanceOf(ctx context.Context, token, account common.Address) (*big.Int, error) {
+	calldata := make([]byte, 0, 36)
+	calldata = append(calldata, erc20BalanceOfSelector...)
+	// pad address to 32 bytes
+	calldata = append(calldata, make([]byte, 12)...)
+	calldata = append(calldata, account.Bytes()...)
+
+	out, err := c.rpc.CallContract(ctx, ethereum.CallMsg{
+		To:   &token,
+		Data: calldata,
+	}, nil)
+	if err != nil {
+		return nil, fmt.Errorf("eth_call balanceOf: %w", err)
+	}
+	if len(out) != 32 {
+		return nil, fmt.Errorf("expected 32-byte response, got %d", len(out))
+	}
+	return new(big.Int).SetBytes(out), nil
+}
+
+func (c *client) Balance(ctx context.Context, account common.Address) (*big.Int, error) {
+	return c.rpc.BalanceAt(ctx, account, nil)
+}
+
+func (c *client) BlockNumber(ctx context.Context) (uint64, error) {
+	return c.rpc.BlockNumber(ctx)
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+go test ./internal/service/airdrop/ethclient/ -v
+```
+
+Expected: PASS for both subtests. Note that `TestClientInterface` only verifies the API surface compiles; live RPC tests are deferred to Stage 4.
+
+- [ ] **Step 5: Run a smoke check against a public mainnet RPC** *(manual gate, not committed)*
+
+```bash
+cat > /tmp/ethclient_smoke_test.go <<'EOF'
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/vultisig/agent-backend/internal/service/airdrop/ethclient"
+)
+
+func main() {
+	c, err := ethclient.NewClient("https://ethereum-rpc.publicnode.com")
+	if err != nil {
+		fmt.Println("dial:", err)
+		os.Exit(1)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	bf, err := c.LatestBaseFee(ctx)
+	if err != nil {
+		fmt.Println("base fee:", err)
+		os.Exit(1)
+	}
+	fmt.Printf("latest base fee: %s wei (~%.1f gwei)\n", bf.String(), float64(bf.Int64())/1e9)
+}
+EOF
+go run /tmp/ethclient_smoke_test.go
+rm /tmp/ethclient_smoke_test.go
+```
+
+Expected: prints a sensible base-fee value (typically 0.5–50 gwei). Confirms the wrapper works against a real public RPC. **Don't commit this file.**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/service/airdrop/ethclient/ go.mod go.sum
+git commit -m "feat(airdrop): add EVM RPC client wrapper for the relayer"
+```
+
+---
+
+## Task 6: Push branch and open PR
+
+- [ ] **Step 1: Run the full test suite**
+
+```bash
+go test ./...
+```
+
+Expected: PASS. If anything outside `internal/service/airdrop/...` and `internal/api/internal_token_middleware_test.go` and `internal/config/airdrop_test.go` fails, you've regressed something — investigate before pushing.
+
+- [ ] **Step 2: Run linter**
+
+```bash
+make lint
+```
+
+Expected: no errors. Fix any lints flagged in the new files.
+
+- [ ] **Step 3: Push the branch**
+
+```bash
+git push -u origin feat/airdrop-shared-infra
+```
+
+- [ ] **Step 4: Open the PR**
+
+```bash
+gh pr create --title "feat(airdrop): shared infrastructure for the Vultiverse Airdrop pipeline" --body "$(cat <<'EOF'
+## Summary
+
+Lays down the cross-cutting foundations for the Vultiverse Airdrop campaign — config substruct, six DB migrations, internal-token middleware, KMS signer, EVM RPC client wrapper. No business logic; subsequent stage-specific PRs build on this.
+
+Spec source of truth: \`docs/airdrop-specs/shared-concerns.md\`.
+
+## What's added
+- \`AirdropConfig\` substruct under \`Config\` covering all 19 airdrop env vars
+- Six Goose migrations under \`internal/storage/postgres/migrations/2026042300000{1..6}_*.sql\` for the airdrop \`agent_*\` tables
+- \`internal/api/internal_token_middleware.go\` — \`X-Internal-Token\` shared-secret check for /internal/* routes
+- \`internal/service/airdrop/kms/signer.go\` — KMS-backed signer with DER → EVM (r, s, v) conversion
+- \`internal/service/airdrop/ethclient/client.go\` — go-ethereum/ethclient wrapper exposing only what the relayer needs
+
+## Spec coverage
+Maps to the "Done when" section of \`shared-concerns.md\`:
+- ✅ Three of the four shared Go packages (KMS signer, ETH client wrapper, internal-token middleware). Eligibility helper deferred to Stage 1's plan since it depends on tables consumed there.
+- ✅ Six migrations apply cleanly on a fresh DB in order; rollback works.
+- ✅ 19 env vars loadable via envconfig.
+- ✅ Internal-token middleware: 401 on missing/wrong, OK on correct.
+- ⏭ KMS LocalStack integration test — deferred to Stage 4 plan where LocalStack will be wired into the test setup. Pure-Go round-trip test in this PR proves the DER + recovery math.
+- ✅ ETH client reads latest base fee against a real public RPC (manual smoke test).
+
+## Test plan
+- [ ] \`go test ./...\` passes
+- [ ] \`make migrate-up && make migrate-down ...×6 && make migrate-up\` round-trips cleanly
+- [ ] Manual ETH client smoke test against a public RPC reports a sensible base fee
+- [ ] \`make lint\` clean
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Capture and report the PR URL.
+
+---
+
+## Self-review notes
+
+This plan was reviewed against `shared-concerns.md` after writing. Items confirmed:
+- All 19 env vars present in Task 1's struct + `.env.example` block.
+- All six migrations present in Task 2.
+- Internal-token middleware in Task 3, with the constant-time compare the spec implies.
+- KMS signer in Task 4 — DER decoding + low-S normalisation + recovery byte. LocalStack integration test deferred (noted in PR body).
+- EVM client in Task 5 — exact method set from `shared-concerns.md`.
+
+Items intentionally NOT in this plan:
+- **Eligibility helper** (`internal/service/airdrop/quests/eligibility.go`) — depends on Stage 2/3 tables AND is the first consumer in Stage 1's status endpoint. Lives in Stage 1's plan.
+- **Inline Basic Auth check** for ops UI — single-use code, lives in Stage 4's plan with the rest of the ops handler.
+
+Stage 1's plan can begin once this PR merges — it consumes `cfg.Airdrop.TransitionWindowStart/End` and the `agent_airdrop_registrations` + `agent_raffle_winners` tables, all delivered here.

--- a/plans/airdrop/2026-04-23-stage-1-boarding.md
+++ b/plans/airdrop/2026-04-23-stage-1-boarding.md
@@ -1,0 +1,1925 @@
+# Vultiverse Airdrop — Stage 1 (Boarding) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Three HTTP endpoints (`POST /airdrop/register`, `GET /airdrop/status`, `GET /airdrop/stats`) that record vault entries, drive the in-app pending screen, and expose a marketing counter — all backed by the `agent_airdrop_registrations` table delivered in shared infra.
+
+**Architecture:** Each endpoint is one Echo handler in `internal/api/airdrop_*.go`. Pure business logic lives in `internal/service/airdrop/registration.go` so unit tests can run without HTTP. Postgres access goes through a new `RegistrationRepository` in `internal/storage/postgres/airdrop_registration.go` wrapping sqlc-generated queries. The shared eligibility helper that Stage 1's status endpoint needs (and Stage 4's claim handler will too) ships here as `internal/service/airdrop/quests/eligibility.go`. No Redis — `/airdrop/stats` is a direct DB query.
+
+**Tech Stack:**
+- Go 1.25, Echo v4
+- pgx/v5 + sqlc (existing)
+- Existing `AuthMiddleware` from `internal/api/middleware.go` for JWT-scoped routes
+- Existing `GetPublicKey(c)` helper to pull public key from JWT context
+
+**Spec source of truth:** `docs/airdrop-specs/stage-1-boarding.md`
+
+**Working directory for all tasks:** `/Users/apotheosis/git/vultisig/agent-backend/`
+
+**Branch:** `feat/airdrop-stage-1-boarding`. Branch off `feat/airdrop-shared-infra` once that PR merges to `main`. Commit after every task.
+
+**Hard deadline:** All three endpoints live in staging by Day 8 (see Stage 0 decisions table for the wall-clock date). This plan should be executable in 1–2 days of focused work.
+
+---
+
+## Pre-flight (do once before Task 1)
+
+Confirm the shared-infra PR has merged to `main` and the migrations have applied locally:
+
+```bash
+cd /Users/apotheosis/git/vultisig/agent-backend
+git checkout main && git pull
+psql "$DATABASE_DSN" -c "\d agent_airdrop_registrations"
+psql "$DATABASE_DSN" -c "\d agent_raffle_winners"
+psql "$DATABASE_DSN" -c "\d agent_user_quests"
+psql "$DATABASE_DSN" -c "\d agent_claim_submissions"
+```
+
+All four `\d` calls should describe the tables. If any returns "Did not find any relation," run `make migrate-up` first.
+
+```bash
+git checkout -b feat/airdrop-stage-1-boarding
+```
+
+---
+
+## Task 1: sqlc queries for registrations + winners + eligibility reads
+
+**Why:** All five queries Stage 1 needs in one file. Generated code lands in `internal/storage/postgres/queries/airdrop_registrations.sql.go` automatically when sqlc runs.
+
+**Files:**
+- Create: `internal/storage/postgres/sqlc/airdrop_registrations.sql`
+- Create: `internal/storage/postgres/sqlc/airdrop_eligibility.sql`
+- Generated: `internal/storage/postgres/queries/airdrop_registrations.sql.go` (do not hand-edit)
+- Generated: `internal/storage/postgres/queries/airdrop_eligibility.sql.go` (do not hand-edit)
+
+- [ ] **Step 1: Write the registration queries**
+
+Create `internal/storage/postgres/sqlc/airdrop_registrations.sql`:
+
+```sql
+-- name: InsertAirdropRegistration :one
+-- Idempotent insert. If a row already exists for this public_key, returns the existing row;
+-- source and recipient_address are immutable after first registration.
+WITH ins AS (
+    INSERT INTO agent_airdrop_registrations (public_key, source, recipient_address)
+    VALUES ($1, $2, $3)
+    ON CONFLICT (public_key) DO NOTHING
+    RETURNING *
+)
+SELECT * FROM ins
+UNION ALL
+SELECT * FROM agent_airdrop_registrations
+WHERE public_key = $1
+LIMIT 1;
+
+-- name: GetAirdropRegistration :one
+SELECT * FROM agent_airdrop_registrations
+WHERE public_key = $1;
+
+-- name: CountAirdropRegistrationsBySource :many
+SELECT source, COUNT(*)::bigint AS count
+FROM agent_airdrop_registrations
+GROUP BY source;
+
+-- name: CountAirdropRegistrations :one
+SELECT COUNT(*)::bigint FROM agent_airdrop_registrations;
+```
+
+- [ ] **Step 2: Write the eligibility-read queries**
+
+Create `internal/storage/postgres/sqlc/airdrop_eligibility.sql`:
+
+```sql
+-- name: AirdropRaffleWinByPublicKey :one
+-- Returns the winner row if this public_key won the raffle; pgx.ErrNoRows otherwise.
+SELECT * FROM agent_raffle_winners
+WHERE public_key = $1;
+
+-- name: AirdropRaffleHasAnyWinners :one
+-- Cheap "raffle has been drawn" probe. Used by Stage 1's status state machine
+-- to distinguish 'awaiting_draw' from 'lost'.
+SELECT EXISTS(SELECT 1 FROM agent_raffle_winners LIMIT 1)::bool AS exists;
+
+-- name: AirdropQuestsCompleted :one
+-- Returns the count of distinct quests a user has completed.
+SELECT COUNT(*)::bigint AS count
+FROM agent_user_quests
+WHERE public_key = $1;
+
+-- name: AirdropQuestsCompletedMap :many
+-- Returns the per-quest completion state for status display. Stage 1's status
+-- handler maps this into the {swap, bridge, defi_action, alert, dca} response shape.
+SELECT quest_id FROM agent_user_quests
+WHERE public_key = $1;
+
+-- name: AirdropLatestClaim :one
+-- Returns the user's most recent claim submission (if any) for the status response's
+-- already_claimed + claim_tx_hash fields. Sorted by submitted_at DESC so the latest
+-- attempt wins (covers the rebroadcast case).
+SELECT * FROM agent_claim_submissions
+WHERE public_key = $1
+ORDER BY submitted_at DESC
+LIMIT 1;
+```
+
+- [ ] **Step 3: Run sqlc generation**
+
+The repo's sqlc config lives at the repo root or under `internal/storage/postgres/`. Find it:
+
+```bash
+ls sqlc.yaml sqlc.yml internal/storage/postgres/sqlc.yaml internal/storage/postgres/sqlc.yml 2>/dev/null
+```
+
+Run sqlc (the existing Makefile may have a target — check first):
+
+```bash
+grep -n sqlc Makefile
+```
+
+If a `make sqlc` target exists, use it. Otherwise:
+
+```bash
+sqlc generate
+```
+
+Expected: two new files appear in `internal/storage/postgres/queries/`:
+- `airdrop_registrations.sql.go`
+- `airdrop_eligibility.sql.go`
+
+If sqlc is not installed locally:
+
+```bash
+go install github.com/sqlc-dev/sqlc/cmd/sqlc@latest
+```
+
+- [ ] **Step 4: Verify the generated code compiles**
+
+```bash
+go build ./internal/storage/postgres/...
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/storage/postgres/sqlc/airdrop_registrations.sql \
+         internal/storage/postgres/sqlc/airdrop_eligibility.sql \
+         internal/storage/postgres/queries/airdrop_registrations.sql.go \
+         internal/storage/postgres/queries/airdrop_eligibility.sql.go
+git commit -m "feat(airdrop): add sqlc queries for registrations + eligibility reads"
+```
+
+---
+
+## Task 2: `RegistrationRepository`
+
+**Why:** Wraps the sqlc Queries with domain types, mapping pgtype values to plain Go types — same pattern as `internal/storage/postgres/conversation.go`.
+
+**Files:**
+- Create: `internal/storage/postgres/airdrop_registration.go`
+- Create: `internal/storage/postgres/airdrop_registration_test.go`
+
+- [ ] **Step 1: Define the domain types**
+
+The Stage 1 spec uses three domain types: `AirdropRegistration`, `RegistrationSource`, and a `SourceCount` for the stats endpoint. Add them to `internal/types/airdrop.go` (new file):
+
+```go
+package types
+
+import "time"
+
+type RegistrationSource string
+
+const (
+	SourceSeed       RegistrationSource = "seed"
+	SourceVaultShare RegistrationSource = "vault_share"
+)
+
+func (s RegistrationSource) Valid() bool {
+	return s == SourceSeed || s == SourceVaultShare
+}
+
+type AirdropRegistration struct {
+	PublicKey        string
+	Source           RegistrationSource
+	RecipientAddress string
+	RegisteredAt     time.Time
+}
+
+type SourceCount struct {
+	Source RegistrationSource
+	Count  int64
+}
+```
+
+- [ ] **Step 2: Write the repo test**
+
+Create `internal/storage/postgres/airdrop_registration_test.go`. This is an integration test against a real Postgres — copy the test-DB setup from whichever existing test file is closest (likely `internal/api/auth_logout_test.go` or a `conversation_test.go` if it exists; if neither does, use a plain `pgxpool.New(ctx, dsn)` against `TEST_DATABASE_DSN`):
+
+```go
+package postgres_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/vultisig/agent-backend/internal/storage/postgres"
+	"github.com/vultisig/agent-backend/internal/types"
+)
+
+func newTestPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	dsn := os.Getenv("TEST_DATABASE_DSN")
+	if dsn == "" {
+		dsn = os.Getenv("DATABASE_DSN")
+	}
+	if dsn == "" {
+		t.Skip("TEST_DATABASE_DSN or DATABASE_DSN not set; skipping integration test")
+	}
+	pool, err := pgxpool.New(context.Background(), dsn)
+	if err != nil {
+		t.Fatalf("pgxpool.New: %v", err)
+	}
+	t.Cleanup(func() { pool.Close() })
+	// Reset state for this test
+	_, err = pool.Exec(context.Background(), `
+		TRUNCATE agent_airdrop_registrations;
+	`)
+	if err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+	return pool
+}
+
+func TestRegistrationRepo_InsertIsIdempotent(t *testing.T) {
+	pool := newTestPool(t)
+	repo := postgres.NewRegistrationRepository(pool)
+	ctx := context.Background()
+
+	first, err := repo.Insert(ctx, "pk1", types.SourceSeed, "0xaaa")
+	if err != nil {
+		t.Fatalf("first insert: %v", err)
+	}
+	if first.PublicKey != "pk1" || first.Source != types.SourceSeed {
+		t.Errorf("unexpected first row: %+v", first)
+	}
+
+	// Second insert with different source + address should be a no-op
+	second, err := repo.Insert(ctx, "pk1", types.SourceVaultShare, "0xbbb")
+	if err != nil {
+		t.Fatalf("second insert: %v", err)
+	}
+	if second.Source != types.SourceSeed {
+		t.Errorf("source should be immutable; got %v", second.Source)
+	}
+	if second.RecipientAddress != "0xaaa" {
+		t.Errorf("recipient should be immutable; got %s", second.RecipientAddress)
+	}
+	if !second.RegisteredAt.Equal(first.RegisteredAt) {
+		t.Errorf("registered_at should be unchanged on retry")
+	}
+}
+
+func TestRegistrationRepo_Get(t *testing.T) {
+	pool := newTestPool(t)
+	repo := postgres.NewRegistrationRepository(pool)
+	ctx := context.Background()
+
+	_, err := repo.Get(ctx, "missing")
+	if err != postgres.ErrNotFound {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+
+	_, _ = repo.Insert(ctx, "pk1", types.SourceSeed, "0xaaa")
+	got, err := repo.Get(ctx, "pk1")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.PublicKey != "pk1" {
+		t.Errorf("got %q, want pk1", got.PublicKey)
+	}
+}
+
+func TestRegistrationRepo_CountBySource(t *testing.T) {
+	pool := newTestPool(t)
+	repo := postgres.NewRegistrationRepository(pool)
+	ctx := context.Background()
+
+	_, _ = repo.Insert(ctx, "pk1", types.SourceSeed, "0x1")
+	_, _ = repo.Insert(ctx, "pk2", types.SourceSeed, "0x2")
+	_, _ = repo.Insert(ctx, "pk3", types.SourceVaultShare, "0x3")
+
+	counts, total, err := repo.CountBySource(ctx)
+	if err != nil {
+		t.Fatalf("CountBySource: %v", err)
+	}
+	if total != 3 {
+		t.Errorf("total = %d, want 3", total)
+	}
+	got := map[types.RegistrationSource]int64{}
+	for _, c := range counts {
+		got[c.Source] = c.Count
+	}
+	if got[types.SourceSeed] != 2 || got[types.SourceVaultShare] != 1 {
+		t.Errorf("counts = %+v, want {seed:2, vault_share:1}", got)
+	}
+}
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+```bash
+go test ./internal/storage/postgres/ -run TestRegistrationRepo -v
+```
+
+Expected: compile error — `NewRegistrationRepository` undefined.
+
+- [ ] **Step 4: Implement the repository**
+
+Create `internal/storage/postgres/airdrop_registration.go`. Match the pattern in `conversation.go` exactly — same struct shape, same `pool` + `q` fields, same `New...Repository(pool)` constructor.
+
+```go
+package postgres
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/vultisig/agent-backend/internal/storage/postgres/queries"
+	"github.com/vultisig/agent-backend/internal/types"
+)
+
+type RegistrationRepository struct {
+	pool *pgxpool.Pool
+	q    *queries.Queries
+}
+
+func NewRegistrationRepository(pool *pgxpool.Pool) *RegistrationRepository {
+	return &RegistrationRepository{
+		pool: pool,
+		q:    queries.New(pool),
+	}
+}
+
+// Insert is idempotent — re-inserting the same public_key returns the existing row;
+// source and recipient_address are immutable after first registration.
+func (r *RegistrationRepository) Insert(
+	ctx context.Context,
+	publicKey string,
+	source types.RegistrationSource,
+	recipientAddress string,
+) (*types.AirdropRegistration, error) {
+	row, err := r.q.InsertAirdropRegistration(ctx, &queries.InsertAirdropRegistrationParams{
+		PublicKey:        publicKey,
+		Source:           queries.AirdropRegistrationSource(source),
+		RecipientAddress: recipientAddress,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("insert airdrop registration: %w", err)
+	}
+	return registrationFromDB(row), nil
+}
+
+func (r *RegistrationRepository) Get(ctx context.Context, publicKey string) (*types.AirdropRegistration, error) {
+	row, err := r.q.GetAirdropRegistration(ctx, publicKey)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("get airdrop registration: %w", err)
+	}
+	return registrationFromDB(row), nil
+}
+
+// CountBySource returns the per-source counts plus the total. Total is computed
+// in Go to save a round-trip — the caller almost always wants both.
+func (r *RegistrationRepository) CountBySource(ctx context.Context) ([]types.SourceCount, int64, error) {
+	rows, err := r.q.CountAirdropRegistrationsBySource(ctx)
+	if err != nil {
+		return nil, 0, fmt.Errorf("count by source: %w", err)
+	}
+	out := make([]types.SourceCount, 0, len(rows))
+	var total int64
+	for _, row := range rows {
+		out = append(out, types.SourceCount{
+			Source: types.RegistrationSource(row.Source),
+			Count:  row.Count,
+		})
+		total += row.Count
+	}
+	return out, total, nil
+}
+
+func registrationFromDB(row *queries.AgentAirdropRegistration) *types.AirdropRegistration {
+	return &types.AirdropRegistration{
+		PublicKey:        row.PublicKey,
+		Source:           types.RegistrationSource(row.Source),
+		RecipientAddress: row.RecipientAddress,
+		RegisteredAt:     pgtimestamptzToTime(row.RegisteredAt),
+	}
+}
+```
+
+The exact name of the sqlc-generated enum type (e.g. `queries.AirdropRegistrationSource`) and the timestamp helper (`pgtimestamptzToTime`) depend on what sqlc generated and what the existing repos use. Open `internal/storage/postgres/queries/airdrop_registrations.sql.go` to confirm the type name; copy the timestamp helper from `conversation.go` if it isn't already exported.
+
+`ErrNotFound` is defined elsewhere in the `postgres` package — see `conversation.go` for the existing definition.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+go test ./internal/storage/postgres/ -run TestRegistrationRepo -v
+```
+
+Expected: PASS for all three subtests, given `DATABASE_DSN` is set.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/storage/postgres/airdrop_registration.go \
+         internal/storage/postgres/airdrop_registration_test.go \
+         internal/types/airdrop.go
+git commit -m "feat(airdrop): add RegistrationRepository wrapping sqlc queries"
+```
+
+---
+
+## Task 3: Eligibility helper (`internal/service/airdrop/quests/eligibility.go`)
+
+**Why:** Stage 1's status handler and (later) Stage 4's claim handler both need the same composite check: `won_raffle AND quests_completed >= threshold AND not_already_claimed`. One pure helper, called inline by both — no HTTP boundary, just a DB read.
+
+**Files:**
+- Create: `internal/service/airdrop/quests/eligibility.go`
+- Create: `internal/service/airdrop/quests/eligibility_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/service/airdrop/quests/eligibility_test.go`:
+
+```go
+package quests_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/vultisig/agent-backend/internal/service/airdrop/quests"
+)
+
+func newTestPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	dsn := os.Getenv("TEST_DATABASE_DSN")
+	if dsn == "" {
+		dsn = os.Getenv("DATABASE_DSN")
+	}
+	if dsn == "" {
+		t.Skip("TEST_DATABASE_DSN or DATABASE_DSN not set")
+	}
+	pool, err := pgxpool.New(context.Background(), dsn)
+	if err != nil {
+		t.Fatalf("pgxpool: %v", err)
+	}
+	t.Cleanup(func() { pool.Close() })
+	_, err = pool.Exec(context.Background(), `
+		TRUNCATE agent_raffle_winners;
+		TRUNCATE agent_user_quests;
+		TRUNCATE agent_claim_submissions;
+	`)
+	if err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+	return pool
+}
+
+func seedWinner(t *testing.T, pool *pgxpool.Pool, pk string) {
+	t.Helper()
+	_, err := pool.Exec(context.Background(),
+		`INSERT INTO agent_raffle_winners (public_key, recipient, amount) VALUES ($1, $2, 1500)`,
+		pk, "0xaaa")
+	if err != nil {
+		t.Fatalf("seed winner: %v", err)
+	}
+}
+
+func seedQuestComplete(t *testing.T, pool *pgxpool.Pool, pk, questID string) {
+	t.Helper()
+	_, err := pool.Exec(context.Background(),
+		`INSERT INTO agent_user_quests (public_key, quest_id) VALUES ($1, $2)`, pk, questID)
+	if err != nil {
+		t.Fatalf("seed quest: %v", err)
+	}
+}
+
+func seedClaim(t *testing.T, pool *pgxpool.Pool, pk, status string) {
+	t.Helper()
+	_, err := pool.Exec(context.Background(), `
+		INSERT INTO agent_claim_submissions
+		(public_key, nonce, recipient, amount, tx_hash, status, max_fee_gwei, max_priority_fee_gwei, submitted_at)
+		VALUES ($1, $2, $3, 1500, $4, $5, 50, 2, NOW())`,
+		pk, randomNonce(), "0xaaa", "0xtx", status)
+	if err != nil {
+		t.Fatalf("seed claim: %v", err)
+	}
+}
+
+var nonceCounter int64
+
+func randomNonce() int64 {
+	nonceCounter++
+	return nonceCounter
+}
+
+func TestIsClaimEligible_AllPaths(t *testing.T) {
+	pool := newTestPool(t)
+	ctx := context.Background()
+
+	cases := []struct {
+		name           string
+		setup          func(t *testing.T, pool *pgxpool.Pool, pk string)
+		threshold      int
+		wantEligible   bool
+		wantReason     string
+	}{
+		{
+			name: "won + 3 quests + not claimed → eligible",
+			setup: func(t *testing.T, pool *pgxpool.Pool, pk string) {
+				seedWinner(t, pool, pk)
+				seedQuestComplete(t, pool, pk, "swap")
+				seedQuestComplete(t, pool, pk, "bridge")
+				seedQuestComplete(t, pool, pk, "defi_action")
+			},
+			threshold:    3,
+			wantEligible: true,
+			wantReason:   "",
+		},
+		{
+			name: "won + 2 quests → not eligible (only_2_quests_complete)",
+			setup: func(t *testing.T, pool *pgxpool.Pool, pk string) {
+				seedWinner(t, pool, pk)
+				seedQuestComplete(t, pool, pk, "swap")
+				seedQuestComplete(t, pool, pk, "bridge")
+			},
+			threshold:    3,
+			wantEligible: false,
+			wantReason:   "only_2_quests_complete",
+		},
+		{
+			name: "lost raffle + 3 quests → not eligible (not_a_winner)",
+			setup: func(t *testing.T, pool *pgxpool.Pool, pk string) {
+				seedQuestComplete(t, pool, pk, "swap")
+				seedQuestComplete(t, pool, pk, "bridge")
+				seedQuestComplete(t, pool, pk, "defi_action")
+			},
+			threshold:    3,
+			wantEligible: false,
+			wantReason:   "not_a_winner",
+		},
+		{
+			name: "won + 3 quests + claim submitted → not eligible (already_claimed)",
+			setup: func(t *testing.T, pool *pgxpool.Pool, pk string) {
+				seedWinner(t, pool, pk)
+				seedQuestComplete(t, pool, pk, "swap")
+				seedQuestComplete(t, pool, pk, "bridge")
+				seedQuestComplete(t, pool, pk, "defi_action")
+				seedClaim(t, pool, pk, "submitted")
+			},
+			threshold:    3,
+			wantEligible: false,
+			wantReason:   "already_claimed",
+		},
+		{
+			name: "won + 3 quests + claim confirmed → not eligible (already_claimed)",
+			setup: func(t *testing.T, pool *pgxpool.Pool, pk string) {
+				seedWinner(t, pool, pk)
+				seedQuestComplete(t, pool, pk, "swap")
+				seedQuestComplete(t, pool, pk, "bridge")
+				seedQuestComplete(t, pool, pk, "defi_action")
+				seedClaim(t, pool, pk, "confirmed")
+			},
+			threshold:    3,
+			wantEligible: false,
+			wantReason:   "already_claimed",
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Reset between cases
+			_, err := pool.Exec(ctx, `
+				TRUNCATE agent_raffle_winners;
+				TRUNCATE agent_user_quests;
+				TRUNCATE agent_claim_submissions;
+			`)
+			if err != nil {
+				t.Fatalf("truncate: %v", err)
+			}
+			pk := "pk-" + string(rune('a'+i))
+			tc.setup(t, pool, pk)
+
+			eligible, reason, err := quests.IsClaimEligible(ctx, pool, pk, tc.threshold)
+			if err != nil {
+				t.Fatalf("IsClaimEligible: %v", err)
+			}
+			if eligible != tc.wantEligible {
+				t.Errorf("eligible = %v, want %v", eligible, tc.wantEligible)
+			}
+			if reason != tc.wantReason {
+				t.Errorf("reason = %q, want %q", reason, tc.wantReason)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+go test ./internal/service/airdrop/quests/ -v
+```
+
+Expected: compile error — package or function undefined.
+
+- [ ] **Step 3: Implement the helper**
+
+Create `internal/service/airdrop/quests/eligibility.go`:
+
+```go
+package quests
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/vultisig/agent-backend/internal/storage/postgres/queries"
+)
+
+// QuestState captures whether a single quest has been completed by the user,
+// for status-display purposes.
+type QuestState struct {
+	QuestID    string // "swap", "bridge", "defi_action", "alert", "dca"
+	Completed  bool
+}
+
+// AllQuestIDs is the canonical list, in display order. Stage 1's status response
+// returns one entry per quest in this order regardless of completion.
+var AllQuestIDs = []string{"swap", "bridge", "defi_action", "alert", "dca"}
+
+// EligibilityResult wraps the rich state Stage 1's status handler needs.
+// Stage 4's claim handler ignores everything except Eligible + Reason.
+type EligibilityResult struct {
+	WonRaffle        bool
+	QuestsCompleted  int
+	QuestStates      []QuestState
+	AlreadyClaimed   bool
+	ClaimTxHash      string // empty if !AlreadyClaimed
+	Eligible         bool
+	Reason           string // "" when Eligible == true
+}
+
+// IsClaimEligible computes the eligibility composite for the given public_key
+// against the live state of agent_raffle_winners, agent_user_quests, and
+// agent_claim_submissions. Threshold is the number of completed quests required
+// (typically cfg.Airdrop.QuestThreshold = 3).
+//
+// Returns (eligible, reason, err). On err, the other return values are zero.
+// Reason is one of:
+//   - ""                       — eligible
+//   - "not_a_winner"           — no row in agent_raffle_winners
+//   - "only_N_quests_complete" — fewer than threshold quests done
+//   - "already_claimed"        — has a row in agent_claim_submissions with status submitted|confirmed
+func IsClaimEligible(ctx context.Context, pool *pgxpool.Pool, publicKey string, threshold int) (bool, string, error) {
+	q := queries.New(pool)
+
+	// Win check
+	_, err := q.AirdropRaffleWinByPublicKey(ctx, publicKey)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return false, "not_a_winner", nil
+		}
+		return false, "", fmt.Errorf("raffle win check: %w", err)
+	}
+
+	// Already-claimed check (against most recent submission)
+	_, err = q.AirdropLatestClaim(ctx, publicKey)
+	if err == nil {
+		// A row exists; status is either submitted, confirmed, or failed. Only
+		// submitted | confirmed count as "already claimed."
+		row, _ := q.AirdropLatestClaim(ctx, publicKey)
+		if row != nil && (string(row.Status) == "submitted" || string(row.Status) == "confirmed") {
+			return false, "already_claimed", nil
+		}
+	} else if !errors.Is(err, pgx.ErrNoRows) {
+		return false, "", fmt.Errorf("claim check: %w", err)
+	}
+
+	// Quest count check
+	completed, err := q.AirdropQuestsCompleted(ctx, publicKey)
+	if err != nil {
+		return false, "", fmt.Errorf("quest count: %w", err)
+	}
+	if completed < int64(threshold) {
+		return false, fmt.Sprintf("only_%d_quests_complete", completed), nil
+	}
+
+	return true, "", nil
+}
+
+// FullStatus returns the rich EligibilityResult Stage 1's status endpoint
+// renders. Single round-trip across all three tables; cheaper than calling
+// IsClaimEligible plus separate queries for the display fields.
+func FullStatus(ctx context.Context, pool *pgxpool.Pool, publicKey string, threshold int) (*EligibilityResult, error) {
+	q := queries.New(pool)
+	out := &EligibilityResult{}
+
+	// Win
+	_, err := q.AirdropRaffleWinByPublicKey(ctx, publicKey)
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		out.WonRaffle = false
+	case err != nil:
+		return nil, fmt.Errorf("raffle win: %w", err)
+	default:
+		out.WonRaffle = true
+	}
+
+	// Per-quest state
+	rows, err := q.AirdropQuestsCompletedMap(ctx, publicKey)
+	if err != nil {
+		return nil, fmt.Errorf("quest map: %w", err)
+	}
+	doneSet := map[string]bool{}
+	for _, r := range rows {
+		doneSet[string(r)] = true
+	}
+	for _, qID := range AllQuestIDs {
+		out.QuestStates = append(out.QuestStates, QuestState{
+			QuestID:   qID,
+			Completed: doneSet[qID],
+		})
+	}
+	out.QuestsCompleted = len(doneSet)
+
+	// Latest claim
+	claim, err := q.AirdropLatestClaim(ctx, publicKey)
+	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		return nil, fmt.Errorf("latest claim: %w", err)
+	}
+	if err == nil && claim != nil {
+		status := string(claim.Status)
+		if status == "submitted" || status == "confirmed" {
+			out.AlreadyClaimed = true
+			out.ClaimTxHash = claim.TxHash
+		}
+	}
+
+	// Composite
+	switch {
+	case !out.WonRaffle:
+		out.Eligible, out.Reason = false, "not_a_winner"
+	case out.AlreadyClaimed:
+		out.Eligible, out.Reason = false, "already_claimed"
+	case out.QuestsCompleted < threshold:
+		out.Eligible, out.Reason = false, fmt.Sprintf("only_%d_quests_complete", out.QuestsCompleted)
+	default:
+		out.Eligible, out.Reason = true, ""
+	}
+	return out, nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+go test ./internal/service/airdrop/quests/ -v
+```
+
+Expected: PASS for all subtests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/service/airdrop/quests/
+git commit -m "feat(airdrop): add eligibility helper for status + claim"
+```
+
+---
+
+## Task 4: `POST /airdrop/register` handler
+
+**Why:** First write endpoint. Validates body, enforces window, idempotent insert.
+
+**Files:**
+- Create: `internal/api/airdrop_register.go`
+- Create: `internal/api/airdrop_register_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/api/airdrop_register_test.go`. Use `httptest` to exercise the handler directly — minimal Echo setup, no full server bootstrap.
+
+```go
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/vultisig/agent-backend/internal/types"
+)
+
+// fakeRegistrationRepo lets us exercise the handler without Postgres.
+type fakeRegistrationRepo struct {
+	insert func(ctx interface{}, pk string, src types.RegistrationSource, addr string) (*types.AirdropRegistration, error)
+}
+
+// (Wire as a small interface in airdrop_register.go — see Step 3.)
+
+func TestRegisterHandler(t *testing.T) {
+	now := time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC)
+	openAt := time.Date(2026, 4, 25, 0, 0, 0, 0, time.UTC)
+	closeAt := time.Date(2026, 4, 30, 0, 0, 0, 0, time.UTC)
+
+	cases := []struct {
+		name       string
+		body       string
+		windowOpen time.Time
+		windowEnd  time.Time
+		now        time.Time
+		jwtPK      string
+		wantStatus int
+		wantErrKey string // "" if 200
+	}{
+		{
+			name:       "valid request → 200",
+			body:       `{"source":"seed","recipient_address":"0x0000000000000000000000000000000000000001"}`,
+			windowOpen: openAt, windowEnd: closeAt, now: now,
+			jwtPK:      "pk1",
+			wantStatus: 200,
+		},
+		{
+			name:       "missing source → 400 INVALID_SOURCE",
+			body:       `{"recipient_address":"0x0000000000000000000000000000000000000001"}`,
+			windowOpen: openAt, windowEnd: closeAt, now: now,
+			jwtPK:      "pk1", wantStatus: 400, wantErrKey: "INVALID_SOURCE",
+		},
+		{
+			name:       "wrong source enum → 400 INVALID_SOURCE",
+			body:       `{"source":"qrcode","recipient_address":"0x0000000000000000000000000000000000000001"}`,
+			windowOpen: openAt, windowEnd: closeAt, now: now,
+			jwtPK:      "pk1", wantStatus: 400, wantErrKey: "INVALID_SOURCE",
+		},
+		{
+			name:       "missing recipient → 400 INVALID_RECIPIENT_ADDRESS",
+			body:       `{"source":"seed"}`,
+			windowOpen: openAt, windowEnd: closeAt, now: now,
+			jwtPK:      "pk1", wantStatus: 400, wantErrKey: "INVALID_RECIPIENT_ADDRESS",
+		},
+		{
+			name:       "malformed recipient → 400",
+			body:       `{"source":"seed","recipient_address":"not-an-address"}`,
+			windowOpen: openAt, windowEnd: closeAt, now: now,
+			jwtPK:      "pk1", wantStatus: 400, wantErrKey: "INVALID_RECIPIENT_ADDRESS",
+		},
+		{
+			name:       "before window opens → 403 WINDOW_NOT_OPEN",
+			body:       `{"source":"seed","recipient_address":"0x0000000000000000000000000000000000000001"}`,
+			windowOpen: openAt, windowEnd: closeAt,
+			now:        time.Date(2026, 4, 24, 12, 0, 0, 0, time.UTC), // before openAt
+			jwtPK:      "pk1", wantStatus: 403, wantErrKey: "WINDOW_NOT_OPEN",
+		},
+		{
+			name:       "after window closes → 403 WINDOW_CLOSED",
+			body:       `{"source":"seed","recipient_address":"0x0000000000000000000000000000000000000001"}`,
+			windowOpen: openAt, windowEnd: closeAt,
+			now:        time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC), // after closeAt
+			jwtPK:      "pk1", wantStatus: 403, wantErrKey: "WINDOW_CLOSED",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := &fakeRegistrationRepo{
+				insert: func(_ interface{}, pk string, src types.RegistrationSource, addr string) (*types.AirdropRegistration, error) {
+					return &types.AirdropRegistration{
+						PublicKey: pk, Source: src, RecipientAddress: addr,
+						RegisteredAt: tc.now,
+					}, nil
+				},
+			}
+			h := &registerHandler{
+				repo:        repo,
+				windowOpen:  tc.windowOpen,
+				windowEnd:   tc.windowEnd,
+				now:         func() time.Time { return tc.now },
+			}
+
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodPost, "/airdrop/register", bytes.NewBufferString(tc.body))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+			c.Set("public_key", tc.jwtPK)
+
+			err := h.Handle(c)
+			if err != nil {
+				t.Fatalf("handler returned err: %v", err)
+			}
+			if rec.Code != tc.wantStatus {
+				t.Errorf("status = %d, want %d (body=%s)", rec.Code, tc.wantStatus, rec.Body.String())
+			}
+			if tc.wantErrKey != "" {
+				var body map[string]string
+				json.Unmarshal(rec.Body.Bytes(), &body)
+				if body["error"] != tc.wantErrKey {
+					t.Errorf("error = %q, want %q", body["error"], tc.wantErrKey)
+				}
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+go test ./internal/api/ -run TestRegisterHandler -v
+```
+
+Expected: compile error.
+
+- [ ] **Step 3: Implement the handler**
+
+Create `internal/api/airdrop_register.go`:
+
+```go
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"regexp"
+	"time"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/vultisig/agent-backend/internal/types"
+)
+
+// registrationRepo is the slice of RegistrationRepository this handler needs.
+// Defined as an interface so the test can pass a fake.
+type registrationRepo interface {
+	Insert(ctx context.Context, publicKey string, source types.RegistrationSource, recipientAddress string) (*types.AirdropRegistration, error)
+}
+
+type registerHandler struct {
+	repo       registrationRepo
+	windowOpen time.Time
+	windowEnd  time.Time
+	now        func() time.Time // injected for tests; production = time.Now
+}
+
+type registerRequest struct {
+	Source           string `json:"source"`
+	RecipientAddress string `json:"recipient_address"`
+}
+
+type registerResponse struct {
+	RegisteredAt     time.Time `json:"registered_at"`
+	Source           string    `json:"source"`
+	RecipientAddress string    `json:"recipient_address"`
+}
+
+var evmAddressRE = regexp.MustCompile(`^0x[a-fA-F0-9]{40}$`)
+
+// Handle implements POST /airdrop/register. JWT is required (registered via
+// AuthMiddleware on the route); public_key comes from the JWT context, not
+// the request body.
+func (h *registerHandler) Handle(c echo.Context) error {
+	publicKey := GetPublicKey(c)
+	if publicKey == "" {
+		return c.JSON(http.StatusUnauthorized, ErrorResponse{Error: "missing public key"})
+	}
+
+	var req registerRequest
+	if err := json.NewDecoder(c.Request().Body).Decode(&req); err != nil {
+		return c.JSON(http.StatusBadRequest, ErrorResponse{Error: "INVALID_BODY"})
+	}
+
+	source := types.RegistrationSource(req.Source)
+	if !source.Valid() {
+		return c.JSON(http.StatusBadRequest, ErrorResponse{Error: "INVALID_SOURCE"})
+	}
+	if !evmAddressRE.MatchString(req.RecipientAddress) {
+		return c.JSON(http.StatusBadRequest, ErrorResponse{Error: "INVALID_RECIPIENT_ADDRESS"})
+	}
+
+	now := h.now()
+	if now.Before(h.windowOpen) {
+		return c.JSON(http.StatusForbidden, ErrorResponse{Error: "WINDOW_NOT_OPEN"})
+	}
+	if !now.Before(h.windowEnd) { // closed at exactly windowEnd
+		return c.JSON(http.StatusForbidden, ErrorResponse{Error: "WINDOW_CLOSED"})
+	}
+
+	row, err := h.repo.Insert(c.Request().Context(), publicKey, source, req.RecipientAddress)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "INSERT_FAILED"})
+	}
+
+	return c.JSON(http.StatusOK, registerResponse{
+		RegisteredAt:     row.RegisteredAt,
+		Source:           string(row.Source),
+		RecipientAddress: row.RecipientAddress,
+	})
+}
+```
+
+In the same file or in `airdrop_register_test.go`, satisfy the fake:
+
+```go
+func (f *fakeRegistrationRepo) Insert(ctx context.Context, pk string, src types.RegistrationSource, addr string) (*types.AirdropRegistration, error) {
+	return f.insert(ctx, pk, src, addr)
+}
+```
+
+(Move this method to the test file since it's test-only. Adjust the field signature in the fake to use `context.Context` rather than `interface{}` to match the interface.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+go test ./internal/api/ -run TestRegisterHandler -v
+```
+
+Expected: PASS for all subtests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/api/airdrop_register.go internal/api/airdrop_register_test.go
+git commit -m "feat(airdrop): add POST /airdrop/register handler"
+```
+
+---
+
+## Task 5: `GET /airdrop/status` handler
+
+**Why:** Drives the in-app pending screen. Single source of truth for `claim_eligible`. Always returns the full shape.
+
+**Files:**
+- Create: `internal/api/airdrop_status.go`
+- Create: `internal/api/airdrop_status_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/api/airdrop_status_test.go`:
+
+```go
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/vultisig/agent-backend/internal/service/airdrop/quests"
+	"github.com/vultisig/agent-backend/internal/storage/postgres"
+	"github.com/vultisig/agent-backend/internal/types"
+)
+
+type fakeStatusRepo struct {
+	get             func(ctx context.Context, pk string) (*types.AirdropRegistration, error)
+	hasAnyWinners   func(ctx context.Context) (bool, error)
+	fullStatus      func(ctx context.Context, pk string, threshold int) (*quests.EligibilityResult, error)
+}
+
+func (f *fakeStatusRepo) Get(ctx context.Context, pk string) (*types.AirdropRegistration, error) {
+	return f.get(ctx, pk)
+}
+func (f *fakeStatusRepo) HasAnyWinners(ctx context.Context) (bool, error) {
+	return f.hasAnyWinners(ctx)
+}
+func (f *fakeStatusRepo) FullStatus(ctx context.Context, pk string, threshold int) (*quests.EligibilityResult, error) {
+	return f.fullStatus(ctx, pk, threshold)
+}
+
+func TestStatusHandler_NotRegistered(t *testing.T) {
+	repo := &fakeStatusRepo{
+		get: func(_ context.Context, _ string) (*types.AirdropRegistration, error) {
+			return nil, postgres.ErrNotFound
+		},
+	}
+	h := &statusHandler{repo: repo, threshold: 3, now: func() time.Time {
+		return time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC)
+	}}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/airdrop/status", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set("public_key", "pk1")
+
+	if err := h.Handle(c); err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	var body map[string]interface{}
+	json.Unmarshal(rec.Body.Bytes(), &body)
+	if body["registered"] != false {
+		t.Errorf("registered = %v, want false", body["registered"])
+	}
+	if len(body) != 1 {
+		t.Errorf("not-registered response should have 1 field, got %d: %+v", len(body), body)
+	}
+}
+
+func TestStatusHandler_StateMatrix(t *testing.T) {
+	regAt := time.Date(2026, 4, 26, 0, 0, 0, 0, time.UTC)
+	closeAt := time.Date(2026, 4, 30, 0, 0, 0, 0, time.UTC)
+
+	cases := []struct {
+		name           string
+		now            time.Time
+		hasAnyWinners  bool
+		eligibility    *quests.EligibilityResult
+		wantState      string
+		wantClaimable  bool
+		wantClaimed    bool
+		wantTxHash     string
+	}{
+		{
+			name: "during window → pending",
+			now:  closeAt.Add(-time.Hour), hasAnyWinners: false,
+			eligibility: &quests.EligibilityResult{},
+			wantState:   "pending",
+		},
+		{
+			name: "after window, no winners loaded → awaiting_draw",
+			now:  closeAt.Add(time.Hour), hasAnyWinners: false,
+			eligibility: &quests.EligibilityResult{},
+			wantState:   "awaiting_draw",
+		},
+		{
+			name: "after window, winners loaded, lost → lost",
+			now:  closeAt.Add(time.Hour), hasAnyWinners: true,
+			eligibility: &quests.EligibilityResult{WonRaffle: false},
+			wantState:   "lost",
+		},
+		{
+			name: "won, 2 quests → won, claim_eligible=false",
+			now:  closeAt.Add(time.Hour), hasAnyWinners: true,
+			eligibility: &quests.EligibilityResult{
+				WonRaffle: true, QuestsCompleted: 2, Eligible: false, Reason: "only_2_quests_complete",
+			},
+			wantState: "won", wantClaimable: false,
+		},
+		{
+			name: "won, 3 quests, not claimed → won, claim_eligible=true",
+			now:  closeAt.Add(time.Hour), hasAnyWinners: true,
+			eligibility: &quests.EligibilityResult{
+				WonRaffle: true, QuestsCompleted: 3, Eligible: true,
+			},
+			wantState: "won", wantClaimable: true,
+		},
+		{
+			name: "won, 3 quests, claimed → won, already_claimed=true with tx",
+			now:  closeAt.Add(time.Hour), hasAnyWinners: true,
+			eligibility: &quests.EligibilityResult{
+				WonRaffle: true, QuestsCompleted: 3, AlreadyClaimed: true, ClaimTxHash: "0xdeadbeef",
+				Eligible: false, Reason: "already_claimed",
+			},
+			wantState: "won", wantClaimed: true, wantTxHash: "0xdeadbeef",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := &fakeStatusRepo{
+				get: func(_ context.Context, _ string) (*types.AirdropRegistration, error) {
+					return &types.AirdropRegistration{
+						PublicKey: "pk1", Source: types.SourceSeed,
+						RecipientAddress: "0xaaa", RegisteredAt: regAt,
+					}, nil
+				},
+				hasAnyWinners: func(_ context.Context) (bool, error) { return tc.hasAnyWinners, nil },
+				fullStatus: func(_ context.Context, _ string, _ int) (*quests.EligibilityResult, error) {
+					return tc.eligibility, nil
+				},
+			}
+			h := &statusHandler{
+				repo: repo, threshold: 3, windowEnd: closeAt,
+				now: func() time.Time { return tc.now },
+			}
+
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodGet, "/airdrop/status", nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+			c.Set("public_key", "pk1")
+
+			if err := h.Handle(c); err != nil {
+				t.Fatalf("handler: %v", err)
+			}
+			var body map[string]interface{}
+			if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if body["raffle_state"] != tc.wantState {
+				t.Errorf("raffle_state = %v, want %s", body["raffle_state"], tc.wantState)
+			}
+			if body["claim_eligible"] != tc.wantClaimable {
+				t.Errorf("claim_eligible = %v, want %v", body["claim_eligible"], tc.wantClaimable)
+			}
+			if body["already_claimed"] != tc.wantClaimed {
+				t.Errorf("already_claimed = %v, want %v", body["already_claimed"], tc.wantClaimed)
+			}
+			if tc.wantTxHash != "" && body["claim_tx_hash"] != tc.wantTxHash {
+				t.Errorf("claim_tx_hash = %v, want %s", body["claim_tx_hash"], tc.wantTxHash)
+			}
+			// All quest keys always present
+			questsMap, ok := body["quests"].(map[string]interface{})
+			if !ok {
+				t.Fatalf("quests should be a map; got %T", body["quests"])
+			}
+			for _, q := range []string{"swap", "bridge", "defi_action", "alert", "dca"} {
+				if _, present := questsMap[q]; !present {
+					t.Errorf("quests map missing key %q", q)
+				}
+			}
+		})
+	}
+
+	// Defensive: avoid unused-import errors in some builds
+	_ = errors.New
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+go test ./internal/api/ -run TestStatusHandler -v
+```
+
+Expected: compile error.
+
+- [ ] **Step 3: Implement the handler**
+
+Create `internal/api/airdrop_status.go`:
+
+```go
+package api
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/vultisig/agent-backend/internal/service/airdrop/quests"
+	"github.com/vultisig/agent-backend/internal/storage/postgres"
+	"github.com/vultisig/agent-backend/internal/types"
+)
+
+type statusRepo interface {
+	Get(ctx context.Context, publicKey string) (*types.AirdropRegistration, error)
+	HasAnyWinners(ctx context.Context) (bool, error)
+	FullStatus(ctx context.Context, publicKey string, threshold int) (*quests.EligibilityResult, error)
+}
+
+type statusHandler struct {
+	repo      statusRepo
+	threshold int
+	windowEnd time.Time
+	now       func() time.Time
+}
+
+type statusResponseRegistered struct {
+	Registered       bool              `json:"registered"`
+	RegisteredAt     time.Time         `json:"registered_at"`
+	Source           string            `json:"source"`
+	RecipientAddress string            `json:"recipient_address"`
+	RaffleState      string            `json:"raffle_state"`
+	Quests           map[string]string `json:"quests"`
+	QuestsCompleted  int               `json:"quests_completed"`
+	ClaimEligible    bool              `json:"claim_eligible"`
+	AlreadyClaimed   bool              `json:"already_claimed"`
+	ClaimTxHash      *string           `json:"claim_tx_hash"` // null if no claim yet
+}
+
+type statusResponseNotRegistered struct {
+	Registered bool `json:"registered"`
+}
+
+func (h *statusHandler) Handle(c echo.Context) error {
+	publicKey := GetPublicKey(c)
+	if publicKey == "" {
+		return c.JSON(http.StatusUnauthorized, ErrorResponse{Error: "missing public key"})
+	}
+	ctx := c.Request().Context()
+
+	reg, err := h.repo.Get(ctx, publicKey)
+	if err != nil {
+		if errors.Is(err, postgres.ErrNotFound) {
+			return c.JSON(http.StatusOK, statusResponseNotRegistered{Registered: false})
+		}
+		return c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "STATUS_LOOKUP_FAILED"})
+	}
+
+	hasWinners, err := h.repo.HasAnyWinners(ctx)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "STATUS_LOOKUP_FAILED"})
+	}
+
+	full, err := h.repo.FullStatus(ctx, publicKey, h.threshold)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "STATUS_LOOKUP_FAILED"})
+	}
+
+	// State machine
+	state := computeRaffleState(h.now(), h.windowEnd, hasWinners, full.WonRaffle)
+
+	// Build the always-full quests map
+	questsMap := make(map[string]string, len(quests.AllQuestIDs))
+	for _, qs := range full.QuestStates {
+		if qs.Completed {
+			questsMap[qs.QuestID] = "completed"
+		} else {
+			questsMap[qs.QuestID] = "pending"
+		}
+	}
+	// Defensive: ensure every quest key is present (in case AllQuestIDs grows later
+	// and FullStatus hasn't been re-run)
+	for _, q := range quests.AllQuestIDs {
+		if _, ok := questsMap[q]; !ok {
+			questsMap[q] = "pending"
+		}
+	}
+
+	var txHashPtr *string
+	if full.ClaimTxHash != "" {
+		v := full.ClaimTxHash
+		txHashPtr = &v
+	}
+
+	return c.JSON(http.StatusOK, statusResponseRegistered{
+		Registered:       true,
+		RegisteredAt:     reg.RegisteredAt,
+		Source:           string(reg.Source),
+		RecipientAddress: reg.RecipientAddress,
+		RaffleState:      state,
+		Quests:           questsMap,
+		QuestsCompleted:  full.QuestsCompleted,
+		ClaimEligible:    full.Eligible,
+		AlreadyClaimed:   full.AlreadyClaimed,
+		ClaimTxHash:      txHashPtr,
+	})
+}
+
+// computeRaffleState implements the spec's state machine.
+//   - pending       — now < windowEnd
+//   - awaiting_draw — now >= windowEnd AND no winners loaded yet
+//   - won           — winners loaded AND this user is among them
+//   - lost          — winners loaded AND this user is not among them
+func computeRaffleState(now, windowEnd time.Time, hasAnyWinners, won bool) string {
+	if now.Before(windowEnd) {
+		return "pending"
+	}
+	if !hasAnyWinners {
+		return "awaiting_draw"
+	}
+	if won {
+		return "won"
+	}
+	return "lost"
+}
+```
+
+The repo struct needs a `HasAnyWinners` method and a `FullStatus` method. The `FullStatus` is a thin wrapper around `quests.FullStatus`. Add to `internal/storage/postgres/airdrop_registration.go`:
+
+```go
+func (r *RegistrationRepository) HasAnyWinners(ctx context.Context) (bool, error) {
+	exists, err := r.q.AirdropRaffleHasAnyWinners(ctx)
+	if err != nil {
+		return false, fmt.Errorf("has any winners: %w", err)
+	}
+	return exists, nil
+}
+
+func (r *RegistrationRepository) FullStatus(
+	ctx context.Context,
+	publicKey string,
+	threshold int,
+) (*quests.EligibilityResult, error) {
+	return quests.FullStatus(ctx, r.pool, publicKey, threshold)
+}
+```
+
+Add the new import:
+
+```go
+import "github.com/vultisig/agent-backend/internal/service/airdrop/quests"
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+go test ./internal/api/ -run TestStatusHandler -v
+```
+
+Expected: PASS for both `TestStatusHandler_NotRegistered` and all subtests of `TestStatusHandler_StateMatrix`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/api/airdrop_status.go internal/api/airdrop_status_test.go internal/storage/postgres/airdrop_registration.go
+git commit -m "feat(airdrop): add GET /airdrop/status handler"
+```
+
+---
+
+## Task 6: `GET /airdrop/stats` handler
+
+**Why:** Marketing's live counter. No auth, no Redis, just a Postgres `GROUP BY`.
+
+**Files:**
+- Create: `internal/api/airdrop_stats.go`
+- Create: `internal/api/airdrop_stats_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/api/airdrop_stats_test.go`:
+
+```go
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/vultisig/agent-backend/internal/types"
+)
+
+type fakeStatsRepo struct {
+	countBySource func(ctx context.Context) ([]types.SourceCount, int64, error)
+}
+
+func (f *fakeStatsRepo) CountBySource(ctx context.Context) ([]types.SourceCount, int64, error) {
+	return f.countBySource(ctx)
+}
+
+func TestStatsHandler(t *testing.T) {
+	openAt := time.Date(2026, 4, 25, 0, 0, 0, 0, time.UTC)
+	closeAt := time.Date(2026, 4, 30, 0, 0, 0, 0, time.UTC)
+
+	cases := []struct {
+		name        string
+		now         time.Time
+		wantState   string
+		wantTotal   int64
+	}{
+		{
+			name: "before window → upcoming",
+			now:  openAt.Add(-time.Hour), wantState: "upcoming", wantTotal: 0,
+		},
+		{
+			name: "during window → open",
+			now:  openAt.Add(time.Hour), wantState: "open", wantTotal: 0,
+		},
+		{
+			name: "after window → closed",
+			now:  closeAt.Add(time.Hour), wantState: "closed", wantTotal: 0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := &fakeStatsRepo{
+				countBySource: func(_ context.Context) ([]types.SourceCount, int64, error) {
+					return []types.SourceCount{
+						{Source: types.SourceSeed, Count: 800},
+						{Source: types.SourceVaultShare, Count: 434},
+					}, 1234, nil
+				},
+			}
+			h := &statsHandler{
+				repo: repo, windowOpen: openAt, windowEnd: closeAt,
+				now: func() time.Time { return tc.now },
+			}
+
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodGet, "/airdrop/stats", nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			if err := h.Handle(c); err != nil {
+				t.Fatalf("handler: %v", err)
+			}
+			var body map[string]interface{}
+			json.Unmarshal(rec.Body.Bytes(), &body)
+			if body["window_state"] != tc.wantState {
+				t.Errorf("window_state = %v, want %s", body["window_state"], tc.wantState)
+			}
+			if body["total_registrations"].(float64) != 1234 {
+				t.Errorf("total = %v, want 1234", body["total_registrations"])
+			}
+			bySource, _ := body["by_source"].(map[string]interface{})
+			if bySource["seed"].(float64) != 800 || bySource["vault_share"].(float64) != 434 {
+				t.Errorf("by_source = %+v", bySource)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+go test ./internal/api/ -run TestStatsHandler -v
+```
+
+Expected: compile error.
+
+- [ ] **Step 3: Implement the handler**
+
+Create `internal/api/airdrop_stats.go`:
+
+```go
+package api
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/vultisig/agent-backend/internal/types"
+)
+
+type statsRepo interface {
+	CountBySource(ctx context.Context) ([]types.SourceCount, int64, error)
+}
+
+type statsHandler struct {
+	repo       statsRepo
+	windowOpen time.Time
+	windowEnd  time.Time
+	now        func() time.Time
+}
+
+type statsResponse struct {
+	TotalRegistrations int64            `json:"total_registrations"`
+	BySource           map[string]int64 `json:"by_source"`
+	WindowState        string           `json:"window_state"`
+	WindowOpensAt      time.Time        `json:"window_opens_at"`
+	WindowClosesAt     time.Time        `json:"window_closes_at"`
+}
+
+func (h *statsHandler) Handle(c echo.Context) error {
+	counts, total, err := h.repo.CountBySource(c.Request().Context())
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "STATS_LOOKUP_FAILED"})
+	}
+
+	bySource := map[string]int64{
+		string(types.SourceSeed):       0, // ensure both keys always present
+		string(types.SourceVaultShare): 0,
+	}
+	for _, sc := range counts {
+		bySource[string(sc.Source)] = sc.Count
+	}
+
+	now := h.now()
+	state := "open"
+	switch {
+	case now.Before(h.windowOpen):
+		state = "upcoming"
+	case !now.Before(h.windowEnd):
+		state = "closed"
+	}
+
+	return c.JSON(http.StatusOK, statsResponse{
+		TotalRegistrations: total,
+		BySource:           bySource,
+		WindowState:        state,
+		WindowOpensAt:      h.windowOpen,
+		WindowClosesAt:     h.windowEnd,
+	})
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+go test ./internal/api/ -run TestStatsHandler -v
+```
+
+Expected: PASS for all subtests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/api/airdrop_stats.go internal/api/airdrop_stats_test.go
+git commit -m "feat(airdrop): add GET /airdrop/stats handler (no auth, direct DB)"
+```
+
+---
+
+## Task 7: Wire routes in `cmd/server/main.go` and `internal/api/server.go`
+
+**Why:** Until this task the handlers exist but aren't reachable. This task plugs them into the running service.
+
+**Files:**
+- Modify: `internal/api/server.go` — add `RegistrationRepository` field, plus three handler instances.
+- Modify: `cmd/server/main.go` — instantiate the repo + handlers + register routes.
+
+- [ ] **Step 1: Add the repo + handler instances to the Server struct**
+
+Find the `Server` struct in `internal/api/server.go` (search: `grep -n "type Server struct" internal/api/*.go`). Add fields:
+
+```go
+type Server struct {
+	// ... existing fields ...
+	regRepo         *postgres.RegistrationRepository
+	registerHandler *registerHandler
+	statusHandler   *statusHandler
+	statsHandler    *statsHandler
+}
+```
+
+In whichever constructor takes `cfg *config.Config` (likely `NewServer`), add a `repo *postgres.RegistrationRepository` parameter and wire the three handlers from it:
+
+```go
+func NewServer(cfg *config.Config, /* existing args */, regRepo *postgres.RegistrationRepository) *Server {
+	s := &Server{
+		// ... existing field initialisers ...
+		regRepo: regRepo,
+	}
+
+	now := time.Now
+	s.registerHandler = &registerHandler{
+		repo:       regRepo,
+		windowOpen: cfg.Airdrop.TransitionWindowStart,
+		windowEnd:  cfg.Airdrop.TransitionWindowEnd,
+		now:        now,
+	}
+	s.statusHandler = &statusHandler{
+		repo:      regRepo,
+		threshold: cfg.Airdrop.QuestThreshold,
+		windowEnd: cfg.Airdrop.TransitionWindowEnd,
+		now:       now,
+	}
+	s.statsHandler = &statsHandler{
+		repo:       regRepo,
+		windowOpen: cfg.Airdrop.TransitionWindowStart,
+		windowEnd:  cfg.Airdrop.TransitionWindowEnd,
+		now:        now,
+	}
+
+	return s
+}
+```
+
+- [ ] **Step 2: Register the routes**
+
+Find where existing routes are registered. Per the survey, this looks like:
+
+```go
+agentGroup := e.Group("/agent", server.AuthMiddleware)
+agentGroup.POST("/conversations/:id/messages", server.SendMessage, ...)
+```
+
+Add after that block:
+
+```go
+// Airdrop endpoints — JWT-scoped + public stats
+airdropGroup := e.Group("/airdrop", server.AuthMiddleware)
+airdropGroup.POST("/register", server.registerHandler.Handle)
+airdropGroup.GET("/status", server.statusHandler.Handle)
+
+// Stats is intentionally public — marketing polls it for the live counter
+e.GET("/airdrop/stats", server.statsHandler.Handle)
+```
+
+- [ ] **Step 3: Wire the repository in `cmd/server/main.go`**
+
+Find where the existing repos are instantiated (search: `grep -n "postgres.New" cmd/server/main.go`). Add:
+
+```go
+regRepo := postgres.NewRegistrationRepository(db.Pool())
+```
+
+Then update the `api.NewServer(...)` call to pass it:
+
+```go
+server := api.NewServer(cfg, /* existing args */, regRepo)
+```
+
+- [ ] **Step 4: Build and run locally**
+
+```bash
+make build
+DATABASE_DSN="postgres://..." \
+  TRANSITION_WINDOW_START="2026-04-25T00:00:00Z" \
+  TRANSITION_WINDOW_END="2026-04-30T00:00:00Z" \
+  INTERNAL_API_KEY="local" \
+  QUEST_ACTIVATION_TIMESTAMP="2026-05-01T00:00:00Z" \
+  KMS_RELAYER_KEY_ARN="arn" \
+  EVM_RPC_URL="https://ethereum-rpc.publicnode.com" \
+  AIRDROP_CLAIM_CONTRACT_ADDRESS="0x0000000000000000000000000000000000000000" \
+  CLAIM_WINDOW_OPEN_AT="2026-05-15T00:00:00Z" \
+  OPS_USERNAME="ops" \
+  OPS_PASSWORD="ops" \
+  ./bin/server
+```
+
+(All other env vars use envconfig defaults.)
+
+In a second terminal, smoke test the public endpoint:
+
+```bash
+curl -s http://localhost:8084/airdrop/stats | jq .
+```
+
+Expected response shape:
+
+```json
+{
+  "total_registrations": 0,
+  "by_source": {"seed": 0, "vault_share": 0},
+  "window_state": "open",
+  "window_opens_at": "2026-04-25T00:00:00Z",
+  "window_closes_at": "2026-04-30T00:00:00Z"
+}
+```
+
+(Adjust the host/port to match where the local server binds.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/api/server.go cmd/server/main.go
+git commit -m "feat(airdrop): wire register/status/stats routes into server"
+```
+
+---
+
+## Task 8: End-to-end test + push PR
+
+- [ ] **Step 1: Run the full unit test suite**
+
+```bash
+go test ./...
+```
+
+Expected: PASS. Investigate any failures before continuing.
+
+- [ ] **Step 2: Run integration tests against a real DB**
+
+```bash
+DATABASE_DSN="postgres://..." go test -tags=integration ./internal/storage/postgres/ ./internal/service/airdrop/quests/
+```
+
+(If the repo doesn't use `-tags=integration`, just run `go test ./...` with `DATABASE_DSN` set.)
+
+Expected: PASS for the registration repo tests and the eligibility helper tests.
+
+- [ ] **Step 3: Manual smoke against running server**
+
+Start the server (Step 4 of Task 7). In another terminal:
+
+```bash
+# Mint a JWT — the existing /auth/token flow needs a vault signature; in dev with
+# DEV_SKIP_AUTH=true any JWT-shaped token with a public_key claim works.
+# Adjust to whatever the agent-backend repo's local-dev pattern is — see CLAUDE.md.
+TOKEN="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."  # replace
+
+curl -s -X POST http://localhost:8084/airdrop/register \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"source":"seed","recipient_address":"0x0000000000000000000000000000000000000001"}' | jq .
+
+curl -s http://localhost:8084/airdrop/status \
+  -H "Authorization: Bearer $TOKEN" | jq .
+
+curl -s http://localhost:8084/airdrop/stats | jq .
+```
+
+Expected:
+- `register` returns 200 with `registered_at` and the recipient address you sent.
+- `status` returns 200 with `registered: true`, `raffle_state: "pending"`, `quests` map with all five keys = "pending", `claim_eligible: false`.
+- `stats` returns 200 with `total_registrations: 1` (one registration just inserted).
+
+Re-run `register` with a different source — should return 200 but with the original source unchanged (idempotency check).
+
+- [ ] **Step 4: Run lint**
+
+```bash
+make lint
+```
+
+Expected: no errors.
+
+- [ ] **Step 5: Push branch**
+
+```bash
+git push -u origin feat/airdrop-stage-1-boarding
+```
+
+- [ ] **Step 6: Open PR**
+
+```bash
+gh pr create --title "feat(airdrop): Stage 1 boarding endpoints (register, status, stats)" --body "$(cat <<'EOF'
+## Summary
+
+Adds the three Stage 1 endpoints from the Vultiverse Airdrop spec:
+- \`POST /airdrop/register\` — idempotent vault registration (JWT-scoped)
+- \`GET /airdrop/status\` — drives the in-app pending screen, always returns the full shape with safe defaults (JWT-scoped)
+- \`GET /airdrop/stats\` — public marketing counter (no auth, direct Postgres query)
+
+Plus the shared eligibility helper that Stage 4 will also consume.
+
+Spec source of truth: \`docs/airdrop-specs/stage-1-boarding.md\`.
+
+## Architecture
+- Pure handler logic in \`internal/api/airdrop_*.go\` — small interfaces in front of the repo for testability
+- Repository in \`internal/storage/postgres/airdrop_registration.go\` wrapping sqlc-generated queries
+- Eligibility helper in \`internal/service/airdrop/quests/eligibility.go\` — shared with Stage 4
+- No Redis (\`/airdrop/stats\` is a sub-ms Postgres query against a small table)
+- Status response always returns the full shape; \`quests\`, \`claim_eligible\`, \`already_claimed\`, \`claim_tx_hash\` all populated with safe defaults so the mobile app integrates against one stable shape forever
+
+## Spec coverage
+- ✅ \`POST /airdrop/register\` with all error cases (\`INVALID_SOURCE\`, \`INVALID_RECIPIENT_ADDRESS\`, \`WINDOW_NOT_OPEN\`, \`WINDOW_CLOSED\`)
+- ✅ Idempotency: re-registering returns existing row, source/recipient immutable
+- ✅ \`GET /airdrop/status\` state machine: pending / awaiting_draw / won / lost
+- ✅ \`claim_eligible\` composite computed server-side
+- ✅ \`claim_tx_hash\` returned when already_claimed
+- ✅ \`GET /airdrop/stats\` with by_source breakdown + window_state
+- ✅ Eligibility helper covers all five (won/lost × quests/no quests × claimed/not) combinations
+
+## Test plan
+- [ ] \`go test ./...\` passes (unit + integration with DATABASE_DSN set)
+- [ ] Manual smoke test against running server (register → status → stats with curl)
+- [ ] Confirm response shape matches \`stage-1-boarding.md\` for each of the four \`raffle_state\` values
+- [ ] Idempotent register: same public_key + different source returns the original source
+
+## Hard deadline
+All three endpoints live in staging by Day 8 (boarding window opens). See Stage 0 decisions table for the wall-clock date.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Capture and report the PR URL.
+
+---
+
+## Self-review notes
+
+This plan was reviewed against `stage-1-boarding.md` after writing. Items confirmed:
+- Three endpoints, all with documented request/response shapes and status codes.
+- Status response always returns the full shape (per the cleanup-pass change committed in PR #67).
+- `claim_tx_hash` included (per the cleanup-pass change).
+- Stats endpoint uses direct Postgres, no Redis (per the cleanup-pass change).
+- Eligibility helper ships here (Stage 1 is the first consumer; Stage 4 reuses it).
+
+Items intentionally NOT in this plan:
+- **Quest event ingester** (`POST /internal/quests/event`) — Stage 3.
+- **Tool-result hook wiring** — Stage 3.
+- **Quest validators** — Stage 3.
+
+Stage 2 (the raffle CLI) can begin as soon as this PR merges; Stage 3 needs Stage 1's eligibility helper to be in `main` before its tests pass.

--- a/plans/airdrop/2026-04-23-stage-2-raffle-cli.md
+++ b/plans/airdrop/2026-04-23-stage-2-raffle-cli.md
@@ -1,0 +1,2226 @@
+# Vultiverse Airdrop — Stage 2 (Raffle Draw CLI) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A new `airdrop-raffle` CLI binary with three subcommands (`draw`, `load-winners`, `verify-onchain`) that the operator runs by hand on Day 12. `draw` reads `agent_airdrop_registrations`, picks winners with a seeded Fisher–Yates shuffle, and writes `winners.csv` + `manifest.json`. The multisig signer (a human, not this CLI) takes `winners.csv` and submits batched `setWinners(...)` calls. `load-winners` then mirrors the CSV into `agent_raffle_winners`. `verify-onchain` reads each row of `winners.csv` and asserts `allowance(recipient)` on the contract matches.
+
+**Architecture:** One Go binary at `cmd/airdrop-raffle/` with stdlib `flag`-based subcommand routing — same dependency-free pattern as `cmd/admin/main.go` and `cmd/scheduler/main.go`. Pure selection + serialization logic in `internal/service/airdrop/raffle/` so unit tests run without Postgres or RPC. New sqlc query file `internal/storage/postgres/sqlc/airdrop_raffle.sql` for the CLI's reads/writes against the tables shipped in shared-infra. The `verify-onchain` subcommand needs `allowance(address) -> uint256` on `AirdropClaim`, which differs from the ERC-20 `balanceOf` already in the wrapper — so we extend `internal/service/airdrop/ethclient/client.go` with one more method (`AirdropAllowance`) rather than calling `CallContract` directly from `cmd/`. That keeps all ABI-encoding concerns inside the wrapper, matching the existing `BalanceOf` pattern.
+
+**Tech Stack:**
+- Go 1.25 stdlib (`flag`, `crypto/rand`, `math/rand/v2`, `encoding/csv`, `encoding/json`)
+- pgx/v5 + sqlc (existing)
+- `internal/service/airdrop/ethclient` from shared-infra (extended with one method)
+- Logrus for structured stdout JSON logs
+- No new external dependencies
+
+**Spec source of truth:** `docs/airdrop-specs/stage-2-raffle-draw.md`
+
+**Working directory for all tasks:** `/Users/apotheosis/git/vultisig/agent-backend/`
+
+**Branch:** `feat/airdrop-stage-2-raffle-cli`. Branch off `main` once `feat/airdrop-shared-infra` has merged. Commit after every task.
+
+**Hard deadline:** Operator runs `airdrop-raffle draw` on Day 12 (boarding window closes at `TRANSITION_WINDOW_END`). The binary must be built and the runbook drafted by Day 11.
+
+---
+
+## Pre-flight (do once before Task 1)
+
+Confirm the shared-infra PR has merged to `main`, the airdrop migrations applied locally, and the `ethclient` + Stage 1 sqlc files exist:
+
+```bash
+cd /Users/apotheosis/git/vultisig/agent-backend
+git checkout main && git pull
+psql "$DATABASE_DSN" -c "\d agent_airdrop_registrations"
+psql "$DATABASE_DSN" -c "\d agent_raffle_winners"
+ls internal/service/airdrop/ethclient/client.go
+ls internal/storage/postgres/sqlc/airdrop_registrations.sql
+```
+
+All four checks must succeed. If `agent_raffle_winners` is missing, run `make migrate-up`. If `airdrop_registrations.sql` is missing, the Stage 1 PR has not merged yet — wait for it before continuing (this plan reuses its `AirdropRegistrationSource` enum binding and its `AgentAirdropRegistration` row type).
+
+```bash
+git checkout -b feat/airdrop-stage-2-raffle-cli
+```
+
+---
+
+## Task 1: sqlc queries for raffle reads + winner inserts
+
+**Why:** The CLI needs four queries: read every registration (for `draw`), check if winners exist (idempotency guard for `load-winners`), batched winner insert (`load-winners` body), and read every winner (for `verify-onchain`). All four belong in one file.
+
+**Files:**
+- Create: `internal/storage/postgres/sqlc/airdrop_raffle.sql`
+- Generated: `internal/storage/postgres/queries/airdrop_raffle.sql.go` (do not hand-edit)
+
+- [ ] **Step 1: Write the queries**
+
+Create `internal/storage/postgres/sqlc/airdrop_raffle.sql`:
+
+```sql
+-- name: ListAirdropRegistrationsForDraw :many
+-- Returns every registration in deterministic order (registered_at, public_key)
+-- so the same seed yields byte-identical winners.csv across runs.
+SELECT * FROM agent_airdrop_registrations
+ORDER BY registered_at ASC, public_key ASC;
+
+-- name: AirdropRaffleWinnerCount :one
+-- Used by load-winners to refuse if any winners are already loaded.
+SELECT COUNT(*)::bigint FROM agent_raffle_winners;
+
+-- name: InsertRaffleWinner :exec
+-- Single-row insert; load-winners issues many of these inside one tx.
+INSERT INTO agent_raffle_winners (public_key, recipient, amount)
+VALUES ($1, $2, $3);
+
+-- name: ListRaffleWinners :many
+-- Used by verify-onchain when re-reading from DB (not used by the CSV path,
+-- but useful for ad-hoc operator checks).
+SELECT * FROM agent_raffle_winners
+ORDER BY public_key ASC;
+```
+
+Note: `amount` is `NUMERIC(78,0)` in the schema. sqlc will bind it to `pgtype.Numeric`; the repository wrapper (Task 3) converts `*big.Int` ↔ `pgtype.Numeric`.
+
+- [ ] **Step 2: Run sqlc generation**
+
+```bash
+grep -n sqlc Makefile
+```
+
+If `make sqlc` exists, use it. Otherwise:
+
+```bash
+sqlc generate
+```
+
+Expected: `internal/storage/postgres/queries/airdrop_raffle.sql.go` appears.
+
+If sqlc is not installed locally:
+
+```bash
+go install github.com/sqlc-dev/sqlc/cmd/sqlc@latest
+```
+
+- [ ] **Step 3: Verify generated code compiles**
+
+```bash
+go build ./internal/storage/postgres/...
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/storage/postgres/sqlc/airdrop_raffle.sql \
+         internal/storage/postgres/queries/airdrop_raffle.sql.go
+git commit -m "feat(airdrop): add sqlc queries for raffle draw + load-winners"
+```
+
+---
+
+## Task 2: Selection logic (Fisher–Yates with seeded PRNG)
+
+**Why:** The randomness is the heart of the raffle. Splitting it into a pure function on a `[]Registration` slice makes it trivially unit-testable for determinism, undersubscription, oversubscription, and the zero-entries hard-fail. No DB, no I/O, no logger.
+
+**Files:**
+- Create: `internal/service/airdrop/raffle/selection.go`
+- Create: `internal/service/airdrop/raffle/selection_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/service/airdrop/raffle/selection_test.go`:
+
+```go
+package raffle
+
+import (
+	"testing"
+	"time"
+)
+
+func mkRegs(n int) []Registration {
+	out := make([]Registration, n)
+	base := time.Date(2026, 4, 25, 0, 0, 0, 0, time.UTC)
+	for i := 0; i < n; i++ {
+		out[i] = Registration{
+			PublicKey:        fmtPK(i),
+			Source:           "seed",
+			RecipientAddress: fmtAddr(i),
+			RegisteredAt:     base.Add(time.Duration(i) * time.Second),
+		}
+	}
+	return out
+}
+
+func fmtPK(i int) string   { return "pk-" + itoa(i) }
+func fmtAddr(i int) string { return "0xaddr" + itoa(i) }
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	out := []byte{}
+	for i > 0 {
+		out = append([]byte{byte('0' + i%10)}, out...)
+		i /= 10
+	}
+	return string(out)
+}
+
+func TestDraw_ZeroEntries(t *testing.T) {
+	_, err := Draw(nil, 700, 12345)
+	if err != ErrNoRegistrations {
+		t.Errorf("err = %v, want ErrNoRegistrations", err)
+	}
+}
+
+func TestDraw_Undersubscribed(t *testing.T) {
+	regs := mkRegs(50)
+	res, err := Draw(regs, 700, 12345)
+	if err != nil {
+		t.Fatalf("Draw: %v", err)
+	}
+	if !res.Undersubscribed {
+		t.Errorf("expected Undersubscribed = true")
+	}
+	if len(res.Winners) != 50 {
+		t.Errorf("winner count = %d, want 50 (all entries win)", len(res.Winners))
+	}
+}
+
+func TestDraw_Oversubscribed(t *testing.T) {
+	regs := mkRegs(1000)
+	res, err := Draw(regs, 700, 12345)
+	if err != nil {
+		t.Fatalf("Draw: %v", err)
+	}
+	if res.Undersubscribed {
+		t.Errorf("Undersubscribed should be false")
+	}
+	if len(res.Winners) != 700 {
+		t.Errorf("winner count = %d, want 700", len(res.Winners))
+	}
+	seen := map[string]bool{}
+	for _, w := range res.Winners {
+		if seen[w.PublicKey] {
+			t.Errorf("duplicate winner %s", w.PublicKey)
+		}
+		seen[w.PublicKey] = true
+	}
+}
+
+func TestDraw_DeterministicForSameSeed(t *testing.T) {
+	regs := mkRegs(1000)
+	a, _ := Draw(regs, 700, 0xDEADBEEF)
+	b, _ := Draw(regs, 700, 0xDEADBEEF)
+	if len(a.Winners) != len(b.Winners) {
+		t.Fatalf("len mismatch: %d vs %d", len(a.Winners), len(b.Winners))
+	}
+	for i := range a.Winners {
+		if a.Winners[i].PublicKey != b.Winners[i].PublicKey {
+			t.Errorf("idx %d: %s vs %s", i, a.Winners[i].PublicKey, b.Winners[i].PublicKey)
+		}
+	}
+}
+
+func TestDraw_DifferentSeedDifferentOrder(t *testing.T) {
+	regs := mkRegs(1000)
+	a, _ := Draw(regs, 700, 1)
+	b, _ := Draw(regs, 700, 2)
+	// At least one of the first 10 winners should differ — collision probability
+	// across 1000 entries is astronomically low for distinct seeds.
+	differ := false
+	for i := 0; i < 10; i++ {
+		if a.Winners[i].PublicKey != b.Winners[i].PublicKey {
+			differ = true
+			break
+		}
+	}
+	if !differ {
+		t.Errorf("two seeds produced identical first-10 ordering; PRNG suspect")
+	}
+}
+
+func TestDraw_RecipientPassthrough(t *testing.T) {
+	regs := mkRegs(100)
+	res, _ := Draw(regs, 50, 42)
+	for _, w := range res.Winners {
+		// Winner's RecipientAddress must match the source registration's exactly.
+		var src *Registration
+		for i := range regs {
+			if regs[i].PublicKey == w.PublicKey {
+				src = &regs[i]
+				break
+			}
+		}
+		if src == nil {
+			t.Fatalf("winner %s not in source", w.PublicKey)
+		}
+		if w.RecipientAddress != src.RecipientAddress {
+			t.Errorf("recipient mutated: winner=%s src=%s", w.RecipientAddress, src.RecipientAddress)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+go test ./internal/service/airdrop/raffle/ -v
+```
+
+Expected: compile error — `Draw`, `Registration`, `ErrNoRegistrations` undefined.
+
+- [ ] **Step 3: Implement selection.go**
+
+Create `internal/service/airdrop/raffle/selection.go`:
+
+```go
+package raffle
+
+import (
+	"errors"
+	"math/rand/v2"
+	"time"
+)
+
+// Registration is a row from agent_airdrop_registrations as the CLI reads it.
+// Owned by this package so selection has no Postgres-types coupling.
+type Registration struct {
+	PublicKey        string
+	Source           string // "seed" | "vault_share"
+	RecipientAddress string
+	RegisteredAt     time.Time
+}
+
+// DrawResult is what Draw returns: the winners (a subset of input, in pick order),
+// plus a flag indicating whether every entry won by virtue of undersubscription.
+type DrawResult struct {
+	Winners         []Registration
+	Undersubscribed bool
+}
+
+// ErrNoRegistrations is returned by Draw when the input slice is empty.
+// CLI maps this to exit code 2 per the spec.
+var ErrNoRegistrations = errors.New("no registrations to draw from")
+
+// Draw seeds a deterministic PRNG with `seed`, runs Fisher–Yates against a copy
+// of `regs`, and returns the first `slotCount` entries (or all of them when
+// undersubscribed). Pure function — no I/O, no clock, no logger. The same
+// `regs` (in any order) and the same `seed` yield the same winners; callers
+// that want byte-identical output should sort `regs` first (the sqlc query
+// ListAirdropRegistrationsForDraw already does this).
+func Draw(regs []Registration, slotCount int, seed uint64) (DrawResult, error) {
+	if len(regs) == 0 {
+		return DrawResult{}, ErrNoRegistrations
+	}
+
+	// Copy so we don't mutate the caller's slice.
+	pool := make([]Registration, len(regs))
+	copy(pool, regs)
+
+	if len(pool) <= slotCount {
+		// Undersubscribed: every entry wins. Order is the pre-shuffle order
+		// (i.e. registered_at ASC) to make the artifact human-scannable.
+		return DrawResult{Winners: pool, Undersubscribed: true}, nil
+	}
+
+	// math/rand/v2's PCG seeded with (seed, 0) is deterministic and well-
+	// distributed. We use shuffle (which is itself a Fisher–Yates) and then
+	// take the prefix.
+	r := rand.New(rand.NewPCG(seed, 0))
+	r.Shuffle(len(pool), func(i, j int) { pool[i], pool[j] = pool[j], pool[i] })
+
+	return DrawResult{
+		Winners:         pool[:slotCount],
+		Undersubscribed: false,
+	}, nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+go test ./internal/service/airdrop/raffle/ -v
+```
+
+Expected: PASS for all six subtests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/service/airdrop/raffle/selection.go \
+         internal/service/airdrop/raffle/selection_test.go
+git commit -m "feat(airdrop): add seeded Fisher-Yates draw selection"
+```
+
+---
+
+## Task 3: Output serialization (`winners.csv` + `manifest.json`)
+
+**Why:** Two artifact formats, both spec-defined. Single function each, file-system side-effect goes through an `io.Writer` so tests assert on bytes without temp files. CSV writer uses stdlib `encoding/csv`; manifest uses stdlib `encoding/json` with indentation for human review.
+
+**Files:**
+- Create: `internal/service/airdrop/raffle/output.go`
+- Create: `internal/service/airdrop/raffle/output_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/service/airdrop/raffle/output_test.go`:
+
+```go
+package raffle
+
+import (
+	"bytes"
+	"encoding/json"
+	"math/big"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestWriteWinnersCSV_HeaderAndRows(t *testing.T) {
+	winners := []Registration{
+		{PublicKey: "pk-a", Source: "seed", RecipientAddress: "0xaaa",
+			RegisteredAt: time.Date(2026, 4, 25, 12, 0, 0, 0, time.UTC)},
+		{PublicKey: "pk-b", Source: "vault_share", RecipientAddress: "0xbbb",
+			RegisteredAt: time.Date(2026, 4, 25, 13, 0, 0, 0, time.UTC)},
+	}
+	amount := new(big.Int).SetUint64(1500)
+
+	var buf bytes.Buffer
+	if err := WriteWinnersCSV(&buf, winners, amount); err != nil {
+		t.Fatalf("WriteWinnersCSV: %v", err)
+	}
+
+	got := buf.String()
+	wantHeader := "public_key,recipient,amount,registered_at,source"
+	if !strings.HasPrefix(got, wantHeader) {
+		t.Errorf("header mismatch:\ngot:  %q\nwant: %q...", got[:len(wantHeader)+1], wantHeader)
+	}
+	if !strings.Contains(got, "pk-a,0xaaa,1500,2026-04-25T12:00:00Z,seed") {
+		t.Errorf("missing pk-a row; got:\n%s", got)
+	}
+	if !strings.Contains(got, "pk-b,0xbbb,1500,2026-04-25T13:00:00Z,vault_share") {
+		t.Errorf("missing pk-b row; got:\n%s", got)
+	}
+}
+
+func TestWriteWinnersCSV_IsByteIdenticalForSameInput(t *testing.T) {
+	winners := []Registration{
+		{PublicKey: "pk-a", Source: "seed", RecipientAddress: "0xaaa",
+			RegisteredAt: time.Date(2026, 4, 25, 12, 0, 0, 0, time.UTC)},
+	}
+	amount := new(big.Int).SetUint64(1500)
+	var a, b bytes.Buffer
+	_ = WriteWinnersCSV(&a, winners, amount)
+	_ = WriteWinnersCSV(&b, winners, amount)
+	if !bytes.Equal(a.Bytes(), b.Bytes()) {
+		t.Errorf("non-deterministic output:\nA: %q\nB: %q", a.String(), b.String())
+	}
+}
+
+func TestWriteManifest_Shape(t *testing.T) {
+	m := Manifest{
+		Seed:              0xDEADBEEF,
+		SlotCount:         700,
+		VultAmount:        "1500000000000000000000",
+		RegistrationCount: 1500,
+		WinnerCount:       700,
+		DrawTimestamp:     time.Date(2026, 5, 5, 0, 0, 0, 0, time.UTC),
+		Undersubscribed:   false,
+	}
+	var buf bytes.Buffer
+	if err := WriteManifest(&buf, m); err != nil {
+		t.Fatalf("WriteManifest: %v", err)
+	}
+	var round Manifest
+	if err := json.Unmarshal(buf.Bytes(), &round); err != nil {
+		t.Fatalf("re-parse: %v", err)
+	}
+	if round.Seed != m.Seed || round.SlotCount != m.SlotCount ||
+		round.VultAmount != m.VultAmount || round.RegistrationCount != m.RegistrationCount ||
+		round.WinnerCount != m.WinnerCount || !round.DrawTimestamp.Equal(m.DrawTimestamp) ||
+		round.Undersubscribed != m.Undersubscribed {
+		t.Errorf("round-trip mismatch: got %+v want %+v", round, m)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+go test ./internal/service/airdrop/raffle/ -run TestWrite -v
+```
+
+Expected: compile error — `WriteWinnersCSV`, `WriteManifest`, `Manifest` undefined.
+
+- [ ] **Step 3: Implement output.go**
+
+Create `internal/service/airdrop/raffle/output.go`:
+
+```go
+package raffle
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/big"
+	"time"
+)
+
+// Manifest is the JSON shape written to manifest.json alongside winners.csv.
+// Field names match the spec (stage-2-raffle-draw.md, "Subcommands → draw").
+// VultAmount is a string so a uint256 fits without precision loss.
+type Manifest struct {
+	Seed              uint64    `json:"seed"`
+	SlotCount         int       `json:"slot_count"`
+	VultAmount        string    `json:"vult_amount"`
+	RegistrationCount int       `json:"registration_count"`
+	WinnerCount       int       `json:"winner_count"`
+	DrawTimestamp     time.Time `json:"draw_timestamp"`
+	Undersubscribed   bool      `json:"undersubscribed"`
+}
+
+// WinnersCSVHeader is the canonical header row. Exported so tests + the
+// load-winners reader can refer to the same string.
+var WinnersCSVHeader = []string{"public_key", "recipient", "amount", "registered_at", "source"}
+
+// WriteWinnersCSV writes the spec-defined CSV: one header row, one row per
+// winner with `amount` formatted as the decimal string representation of the
+// per-winner VULT amount and `registered_at` formatted as RFC3339 UTC.
+func WriteWinnersCSV(w io.Writer, winners []Registration, amount *big.Int) error {
+	cw := csv.NewWriter(w)
+	if err := cw.Write(WinnersCSVHeader); err != nil {
+		return fmt.Errorf("write header: %w", err)
+	}
+	amountStr := amount.String()
+	for _, win := range winners {
+		row := []string{
+			win.PublicKey,
+			win.RecipientAddress,
+			amountStr,
+			win.RegisteredAt.UTC().Format(time.RFC3339),
+			win.Source,
+		}
+		if err := cw.Write(row); err != nil {
+			return fmt.Errorf("write row %s: %w", win.PublicKey, err)
+		}
+	}
+	cw.Flush()
+	return cw.Error()
+}
+
+// WriteManifest serializes the manifest as indented JSON for human review.
+func WriteManifest(w io.Writer, m Manifest) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(m)
+}
+
+// CSVRow mirrors a single parsed row of winners.csv, used by load-winners
+// and verify-onchain when reading the artifact back.
+type CSVRow struct {
+	PublicKey        string
+	Recipient        string
+	Amount           *big.Int
+	RegisteredAt     time.Time
+	Source           string
+}
+
+// ReadWinnersCSV parses an entire winners.csv into rows. Returns an error
+// if the header is missing or malformed, or if any row's `amount` is not
+// a valid decimal integer.
+func ReadWinnersCSV(r io.Reader) ([]CSVRow, error) {
+	cr := csv.NewReader(r)
+	header, err := cr.Read()
+	if err != nil {
+		return nil, fmt.Errorf("read header: %w", err)
+	}
+	if len(header) != len(WinnersCSVHeader) {
+		return nil, fmt.Errorf("header has %d cols, want %d", len(header), len(WinnersCSVHeader))
+	}
+	for i, want := range WinnersCSVHeader {
+		if header[i] != want {
+			return nil, fmt.Errorf("header[%d] = %q, want %q", i, header[i], want)
+		}
+	}
+	var out []CSVRow
+	for lineNum := 2; ; lineNum++ {
+		rec, err := cr.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("read line %d: %w", lineNum, err)
+		}
+		amount, ok := new(big.Int).SetString(rec[2], 10)
+		if !ok {
+			return nil, fmt.Errorf("line %d: invalid amount %q", lineNum, rec[2])
+		}
+		ts, err := time.Parse(time.RFC3339, rec[3])
+		if err != nil {
+			return nil, fmt.Errorf("line %d: invalid registered_at %q: %w", lineNum, rec[3], err)
+		}
+		out = append(out, CSVRow{
+			PublicKey:    rec[0],
+			Recipient:    rec[1],
+			Amount:       amount,
+			RegisteredAt: ts,
+			Source:       rec[4],
+		})
+	}
+	return out, nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+go test ./internal/service/airdrop/raffle/ -v
+```
+
+Expected: PASS for all selection + output tests.
+
+- [ ] **Step 5: Add a CSV round-trip test**
+
+Append to `internal/service/airdrop/raffle/output_test.go`:
+
+```go
+func TestReadWinnersCSV_RoundTrip(t *testing.T) {
+	winners := []Registration{
+		{PublicKey: "pk-a", Source: "seed", RecipientAddress: "0xaaa",
+			RegisteredAt: time.Date(2026, 4, 25, 12, 0, 0, 0, time.UTC)},
+		{PublicKey: "pk-b", Source: "vault_share", RecipientAddress: "0xbbb",
+			RegisteredAt: time.Date(2026, 4, 25, 13, 0, 0, 0, time.UTC)},
+	}
+	amount, _ := new(big.Int).SetString("1500000000000000000000", 10)
+
+	var buf bytes.Buffer
+	if err := WriteWinnersCSV(&buf, winners, amount); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	rows, err := ReadWinnersCSV(&buf)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("rows = %d, want 2", len(rows))
+	}
+	if rows[0].PublicKey != "pk-a" || rows[0].Recipient != "0xaaa" ||
+		rows[0].Amount.Cmp(amount) != 0 || rows[0].Source != "seed" ||
+		!rows[0].RegisteredAt.Equal(winners[0].RegisteredAt) {
+		t.Errorf("row 0 mismatch: %+v", rows[0])
+	}
+}
+
+func TestReadWinnersCSV_RejectsBadHeader(t *testing.T) {
+	bad := "wrong,header,row\n"
+	_, err := ReadWinnersCSV(bytes.NewBufferString(bad))
+	if err == nil {
+		t.Errorf("expected error for bad header, got nil")
+	}
+}
+```
+
+- [ ] **Step 6: Run all raffle tests**
+
+```bash
+go test ./internal/service/airdrop/raffle/ -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/service/airdrop/raffle/output.go \
+         internal/service/airdrop/raffle/output_test.go
+git commit -m "feat(airdrop): add winners.csv + manifest.json serialization"
+```
+
+---
+
+## Task 4: `draw` subcommand
+
+**Why:** Wires Task 1 (DB read), Task 2 (selection), and Task 3 (CSV + manifest) together behind a `flag.FlagSet` matching the spec's flag table. Logger emits one structured JSON line per major step. Process exits non-zero with the spec's exit codes on documented failure modes.
+
+**Files:**
+- Create: `cmd/airdrop-raffle/draw.go`
+- Create: `cmd/airdrop-raffle/draw_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `cmd/airdrop-raffle/draw_test.go`:
+
+```go
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/vultisig/agent-backend/internal/service/airdrop/raffle"
+)
+
+// fakeRegLister implements registrationLister for tests without a DB.
+type fakeRegLister struct {
+	regs []raffle.Registration
+	err  error
+}
+
+func (f *fakeRegLister) ListForDraw(ctx context.Context) ([]raffle.Registration, error) {
+	return f.regs, f.err
+}
+
+func nopLogger() *logrus.Logger {
+	l := logrus.New()
+	l.SetOutput(&bytes.Buffer{})
+	l.SetLevel(logrus.PanicLevel)
+	return l
+}
+
+func TestRunDraw_WritesArtifacts(t *testing.T) {
+	dir := t.TempDir()
+	regs := []raffle.Registration{
+		{PublicKey: "pk1", Source: "seed", RecipientAddress: "0xaaa",
+			RegisteredAt: time.Date(2026, 4, 25, 12, 0, 0, 0, time.UTC)},
+		{PublicKey: "pk2", Source: "seed", RecipientAddress: "0xbbb",
+			RegisteredAt: time.Date(2026, 4, 25, 13, 0, 0, 0, time.UTC)},
+	}
+	amount, _ := new(big.Int).SetString("1500000000000000000000", 10)
+
+	code := runDraw(context.Background(), drawOpts{
+		seed:       42,
+		slotCount:  1,
+		vultAmount: amount,
+		outputDir:  dir,
+		lister:     &fakeRegLister{regs: regs},
+		logger:     nopLogger(),
+		now:        func() time.Time { return time.Date(2026, 5, 5, 0, 0, 0, 0, time.UTC) },
+	})
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+
+	csvBytes, err := os.ReadFile(filepath.Join(dir, "winners.csv"))
+	if err != nil {
+		t.Fatalf("winners.csv missing: %v", err)
+	}
+	if !bytes.Contains(csvBytes, []byte("public_key,recipient,amount,registered_at,source")) {
+		t.Errorf("winners.csv missing header; got:\n%s", csvBytes)
+	}
+
+	manBytes, err := os.ReadFile(filepath.Join(dir, "manifest.json"))
+	if err != nil {
+		t.Fatalf("manifest.json missing: %v", err)
+	}
+	if !bytes.Contains(manBytes, []byte(`"seed": 42`)) {
+		t.Errorf("manifest missing seed; got:\n%s", manBytes)
+	}
+	if !bytes.Contains(manBytes, []byte(`"winner_count": 1`)) {
+		t.Errorf("manifest missing winner_count; got:\n%s", manBytes)
+	}
+}
+
+func TestRunDraw_ZeroEntriesExitCode2(t *testing.T) {
+	dir := t.TempDir()
+	code := runDraw(context.Background(), drawOpts{
+		seed: 1, slotCount: 700, vultAmount: big.NewInt(1500),
+		outputDir: dir,
+		lister:    &fakeRegLister{regs: nil},
+		logger:    nopLogger(),
+		now:       time.Now,
+	})
+	if code != 2 {
+		t.Errorf("exit code = %d, want 2 (zero registrations)", code)
+	}
+}
+
+func TestRunDraw_DBErrorExitCode1(t *testing.T) {
+	dir := t.TempDir()
+	code := runDraw(context.Background(), drawOpts{
+		seed: 1, slotCount: 700, vultAmount: big.NewInt(1500),
+		outputDir: dir,
+		lister:    &fakeRegLister{err: errors.New("boom")},
+		logger:    nopLogger(),
+		now:       time.Now,
+	})
+	if code != 1 {
+		t.Errorf("exit code = %d, want 1 (input/db error)", code)
+	}
+}
+
+func TestRunDraw_OutputDirCreatedIfMissing(t *testing.T) {
+	parent := t.TempDir()
+	missing := filepath.Join(parent, "new-subdir")
+	regs := []raffle.Registration{
+		{PublicKey: "pk1", Source: "seed", RecipientAddress: "0xaaa",
+			RegisteredAt: time.Date(2026, 4, 25, 12, 0, 0, 0, time.UTC)},
+	}
+	code := runDraw(context.Background(), drawOpts{
+		seed: 1, slotCount: 1, vultAmount: big.NewInt(1),
+		outputDir: missing,
+		lister:    &fakeRegLister{regs: regs},
+		logger:    nopLogger(),
+		now:       time.Now,
+	})
+	if code != 0 {
+		t.Errorf("exit code = %d, want 0", code)
+	}
+	if _, err := os.Stat(filepath.Join(missing, "winners.csv")); err != nil {
+		t.Errorf("winners.csv not created: %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+go test ./cmd/airdrop-raffle/ -run TestRunDraw -v
+```
+
+Expected: compile error — `runDraw`, `drawOpts`, `registrationLister` undefined.
+
+- [ ] **Step 3: Implement draw.go**
+
+Create `cmd/airdrop-raffle/draw.go`:
+
+```go
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math/big"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/vultisig/agent-backend/internal/service/airdrop/raffle"
+)
+
+// registrationLister is the slice of the registrations repo this subcommand
+// needs. Defined as an interface so unit tests can pass a fake.
+type registrationLister interface {
+	ListForDraw(ctx context.Context) ([]raffle.Registration, error)
+}
+
+// drawOpts is the resolved set of inputs runDraw operates on. Constructed by
+// drawMain (the flag-parsing entrypoint) or directly by tests.
+type drawOpts struct {
+	seed       uint64
+	slotCount  int
+	vultAmount *big.Int
+	outputDir  string
+	lister     registrationLister
+	logger     *logrus.Logger
+	now        func() time.Time
+}
+
+// runDraw executes the draw subcommand with the given opts. Returns the spec's
+// exit code: 0 success, 1 input/db error, 2 zero registrations, 4 output write error.
+func runDraw(ctx context.Context, opts drawOpts) int {
+	log := opts.logger.WithFields(logrus.Fields{
+		"subcommand": "draw",
+		"seed":       opts.seed,
+		"slot_count": opts.slotCount,
+	})
+
+	regs, err := opts.lister.ListForDraw(ctx)
+	if err != nil {
+		log.WithError(err).Error("list registrations failed")
+		return 1
+	}
+	log.WithField("registration_count", len(regs)).Info("loaded registrations")
+
+	res, err := raffle.Draw(regs, opts.slotCount, opts.seed)
+	if err != nil {
+		if errors.Is(err, raffle.ErrNoRegistrations) {
+			log.Error("zero registrations: refusing to draw")
+			fmt.Fprintln(os.Stderr, "ERROR: no registrations in agent_airdrop_registrations; nothing to draw.")
+			return 2
+		}
+		log.WithError(err).Error("draw failed")
+		return 1
+	}
+
+	if res.Undersubscribed {
+		shortfall := opts.slotCount - len(res.Winners)
+		fmt.Fprintln(os.Stderr, "============================================================")
+		fmt.Fprintf(os.Stderr, "WARNING: undersubscribed (%d entries vs %d slots).\n", len(res.Winners), opts.slotCount)
+		fmt.Fprintln(os.Stderr, "All entries will win.")
+		fmt.Fprintf(os.Stderr, "Prize pool will be undersubscribed by %d × amount VULT.\n", shortfall)
+		fmt.Fprintln(os.Stderr, "============================================================")
+	}
+
+	if err := os.MkdirAll(opts.outputDir, 0o755); err != nil {
+		log.WithError(err).Error("mkdir output dir failed")
+		return 4
+	}
+
+	csvPath := filepath.Join(opts.outputDir, "winners.csv")
+	csvFile, err := os.Create(csvPath)
+	if err != nil {
+		log.WithError(err).Error("create winners.csv failed")
+		return 4
+	}
+	if err := raffle.WriteWinnersCSV(csvFile, res.Winners, opts.vultAmount); err != nil {
+		csvFile.Close()
+		log.WithError(err).Error("write winners.csv failed")
+		return 4
+	}
+	if err := csvFile.Close(); err != nil {
+		log.WithError(err).Error("close winners.csv failed")
+		return 4
+	}
+
+	manifestPath := filepath.Join(opts.outputDir, "manifest.json")
+	manFile, err := os.Create(manifestPath)
+	if err != nil {
+		log.WithError(err).Error("create manifest.json failed")
+		return 4
+	}
+	manifest := raffle.Manifest{
+		Seed:              opts.seed,
+		SlotCount:         opts.slotCount,
+		VultAmount:        opts.vultAmount.String(),
+		RegistrationCount: len(regs),
+		WinnerCount:       len(res.Winners),
+		DrawTimestamp:     opts.now().UTC(),
+		Undersubscribed:   res.Undersubscribed,
+	}
+	if err := raffle.WriteManifest(manFile, manifest); err != nil {
+		manFile.Close()
+		log.WithError(err).Error("write manifest.json failed")
+		return 4
+	}
+	if err := manFile.Close(); err != nil {
+		log.WithError(err).Error("close manifest.json failed")
+		return 4
+	}
+
+	log.WithFields(logrus.Fields{
+		"winner_count":     len(res.Winners),
+		"undersubscribed":  res.Undersubscribed,
+		"output_dir":       opts.outputDir,
+		"winners_csv":      csvPath,
+		"manifest_json":    manifestPath,
+	}).Info("draw complete")
+
+	fmt.Printf("Draw complete:\n")
+	fmt.Printf("  seed:            %d\n", opts.seed)
+	fmt.Printf("  registrations:   %d\n", len(regs))
+	fmt.Printf("  winners:         %d\n", len(res.Winners))
+	fmt.Printf("  undersubscribed: %v\n", res.Undersubscribed)
+	fmt.Printf("  artifacts:       %s\n", opts.outputDir)
+	return 0
+}
+
+// freshSeed mints a 64-bit seed from crypto/rand. Used when the operator did
+// not pass --seed explicitly. Logged + printed so the operator can record it
+// for later reproduction.
+func freshSeed() (uint64, error) {
+	var b [8]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return 0, fmt.Errorf("crypto/rand: %w", err)
+	}
+	return binary.BigEndian.Uint64(b[:]), nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+go test ./cmd/airdrop-raffle/ -run TestRunDraw -v
+```
+
+Expected: PASS for all four subtests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/airdrop-raffle/draw.go cmd/airdrop-raffle/draw_test.go
+git commit -m "feat(airdrop): add draw subcommand with CSV + manifest output"
+```
+
+---
+
+## Task 5: `load-winners` subcommand
+
+**Why:** Reads `winners.csv` from a draw artifact directory and inserts every row into `agent_raffle_winners` in a single transaction. Refuses if the table already has any rows (operator must explicitly `TRUNCATE` to re-load).
+
+**Files:**
+- Create: `cmd/airdrop-raffle/load_winners.go`
+- Create: `cmd/airdrop-raffle/load_winners_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `cmd/airdrop-raffle/load_winners_test.go`:
+
+```go
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/vultisig/agent-backend/internal/service/airdrop/raffle"
+)
+
+// fakeWinnersStore implements winnersStore for tests.
+type fakeWinnersStore struct {
+	existing  int64
+	inserted  []raffle.CSVRow
+	insertErr error
+	countErr  error
+}
+
+func (f *fakeWinnersStore) Count(ctx context.Context) (int64, error) {
+	return f.existing, f.countErr
+}
+
+func (f *fakeWinnersStore) InsertAll(ctx context.Context, rows []raffle.CSVRow) error {
+	if f.insertErr != nil {
+		return f.insertErr
+	}
+	f.inserted = append(f.inserted, rows...)
+	return nil
+}
+
+func writeFixtureCSV(t *testing.T, dir string) {
+	t.Helper()
+	winners := []raffle.Registration{
+		{PublicKey: "pk-a", Source: "seed", RecipientAddress: "0xaaa",
+			RegisteredAt: time.Date(2026, 4, 25, 12, 0, 0, 0, time.UTC)},
+		{PublicKey: "pk-b", Source: "vault_share", RecipientAddress: "0xbbb",
+			RegisteredAt: time.Date(2026, 4, 25, 13, 0, 0, 0, time.UTC)},
+	}
+	amount, _ := new(big.Int).SetString("1500", 10)
+	var buf bytes.Buffer
+	if err := raffle.WriteWinnersCSV(&buf, winners, amount); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "winners.csv"), buf.Bytes(), 0o644); err != nil {
+		t.Fatalf("write fixture file: %v", err)
+	}
+}
+
+func TestRunLoadWinners_Success(t *testing.T) {
+	dir := t.TempDir()
+	writeFixtureCSV(t, dir)
+	store := &fakeWinnersStore{}
+	code := runLoadWinners(context.Background(), loadWinnersOpts{
+		outputDir: dir,
+		store:     store,
+		logger:    nopLogger(),
+	})
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0", code)
+	}
+	if len(store.inserted) != 2 {
+		t.Errorf("inserted = %d rows, want 2", len(store.inserted))
+	}
+}
+
+func TestRunLoadWinners_RefusesIfAlreadyLoaded(t *testing.T) {
+	dir := t.TempDir()
+	writeFixtureCSV(t, dir)
+	store := &fakeWinnersStore{existing: 700}
+	code := runLoadWinners(context.Background(), loadWinnersOpts{
+		outputDir: dir,
+		store:     store,
+		logger:    nopLogger(),
+	})
+	if code == 0 {
+		t.Errorf("expected non-zero exit when table already loaded")
+	}
+	if len(store.inserted) != 0 {
+		t.Errorf("inserted should be empty; got %d rows", len(store.inserted))
+	}
+}
+
+func TestRunLoadWinners_MissingCSV(t *testing.T) {
+	dir := t.TempDir()
+	store := &fakeWinnersStore{}
+	code := runLoadWinners(context.Background(), loadWinnersOpts{
+		outputDir: dir,
+		store:     store,
+		logger:    nopLogger(),
+	})
+	if code == 0 {
+		t.Errorf("expected non-zero exit when winners.csv missing")
+	}
+}
+
+func TestRunLoadWinners_InsertErrorPropagates(t *testing.T) {
+	dir := t.TempDir()
+	writeFixtureCSV(t, dir)
+	store := &fakeWinnersStore{insertErr: errors.New("constraint violation")}
+	code := runLoadWinners(context.Background(), loadWinnersOpts{
+		outputDir: dir,
+		store:     store,
+		logger:    nopLogger(),
+	})
+	if code == 0 {
+		t.Errorf("expected non-zero exit when insert fails")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+go test ./cmd/airdrop-raffle/ -run TestRunLoadWinners -v
+```
+
+Expected: compile error — `runLoadWinners`, `loadWinnersOpts`, `winnersStore` undefined.
+
+- [ ] **Step 3: Implement load_winners.go**
+
+Create `cmd/airdrop-raffle/load_winners.go`:
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/vultisig/agent-backend/internal/service/airdrop/raffle"
+)
+
+// winnersStore is the slice of the raffle winners repo load-winners needs.
+// Implemented for production by RaffleWinnersRepository (Task 7).
+type winnersStore interface {
+	Count(ctx context.Context) (int64, error)
+	InsertAll(ctx context.Context, rows []raffle.CSVRow) error
+}
+
+type loadWinnersOpts struct {
+	outputDir string
+	store     winnersStore
+	logger    *logrus.Logger
+}
+
+// runLoadWinners reads winners.csv from outputDir, refuses if the table is
+// non-empty, and inserts every row inside a single transaction (the store's
+// InsertAll is responsible for the BEGIN/COMMIT). Returns 0 on success;
+// non-zero on any error so the caller's shell sees a failure.
+func runLoadWinners(ctx context.Context, opts loadWinnersOpts) int {
+	log := opts.logger.WithField("subcommand", "load-winners")
+
+	csvPath := filepath.Join(opts.outputDir, "winners.csv")
+	f, err := os.Open(csvPath)
+	if err != nil {
+		log.WithError(err).Error("open winners.csv failed")
+		fmt.Fprintf(os.Stderr, "ERROR: cannot open %s: %v\n", csvPath, err)
+		return 1
+	}
+	defer f.Close()
+
+	rows, err := raffle.ReadWinnersCSV(f)
+	if err != nil {
+		log.WithError(err).Error("parse winners.csv failed")
+		fmt.Fprintf(os.Stderr, "ERROR: parse %s: %v\n", csvPath, err)
+		return 1
+	}
+	log.WithField("row_count", len(rows)).Info("parsed winners.csv")
+
+	existing, err := opts.store.Count(ctx)
+	if err != nil {
+		log.WithError(err).Error("count agent_raffle_winners failed")
+		return 1
+	}
+	if existing > 0 {
+		msg := fmt.Sprintf("agent_raffle_winners already has %d rows; refusing to load. "+
+			"Run `psql ... -c 'TRUNCATE agent_raffle_winners'` to re-load.", existing)
+		log.Error(msg)
+		fmt.Fprintln(os.Stderr, "ERROR: "+msg)
+		return 1
+	}
+
+	if err := opts.store.InsertAll(ctx, rows); err != nil {
+		log.WithError(err).Error("insert winners failed")
+		fmt.Fprintf(os.Stderr, "ERROR: insert: %v\n", err)
+		return 1
+	}
+
+	log.WithField("inserted", len(rows)).Info("load-winners complete")
+	fmt.Printf("Loaded %d winners into agent_raffle_winners.\n", len(rows))
+	return 0
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+go test ./cmd/airdrop-raffle/ -run TestRunLoadWinners -v
+```
+
+Expected: PASS for all four subtests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/airdrop-raffle/load_winners.go cmd/airdrop-raffle/load_winners_test.go
+git commit -m "feat(airdrop): add load-winners subcommand"
+```
+
+---
+
+## Task 6: `verify-onchain` subcommand (and `AirdropAllowance` on the ETH client)
+
+**Why:** Reads each row of `winners.csv`, calls `allowance(recipient)` on the deployed `AirdropClaim` contract, asserts the value matches the CSV's `amount`. Catches multisig batch errors before users start claiming. The ethclient wrapper from shared-infra has `BalanceOf` (ERC-20 `balanceOf(address)`) but `AirdropClaim.allowance(address)` is a different selector — extending the wrapper with one airdrop-specific method keeps all ABI encoding inside the wrapper rather than scattering raw `CallContract` invocations through `cmd/`.
+
+**Files:**
+- Modify: `internal/service/airdrop/ethclient/client.go` (add `AirdropAllowance` method to interface + impl)
+- Modify: `internal/service/airdrop/ethclient/client_test.go` (cover the new method's API surface)
+- Create: `cmd/airdrop-raffle/verify_onchain.go`
+- Create: `cmd/airdrop-raffle/verify_onchain_test.go`
+
+- [ ] **Step 1: Extend the ethclient wrapper**
+
+Open `internal/service/airdrop/ethclient/client.go`. Add `AirdropAllowance` to the `Client` interface alongside the existing methods:
+
+```go
+type Client interface {
+	// ... existing methods ...
+
+	// AirdropAllowance reads `allowance(address)` on AirdropClaim — the per-recipient
+	// VULT amount the contract owes. Distinct from BalanceOf (ERC-20) because
+	// AirdropClaim's allowance is a single-arg storage getter, not the ERC-20
+	// two-arg allowance(owner, spender).
+	AirdropAllowance(ctx context.Context, contract, recipient common.Address) (*big.Int, error)
+}
+```
+
+Add the selector and implementation alongside the existing `erc20BalanceOfSelector` block:
+
+```go
+// airdropAllowanceSelector is keccak256("allowance(address)")[:4] — the AirdropClaim
+// public mapping getter. Distinct from ERC-20 allowance(address,address).
+var airdropAllowanceSelector = []byte{0xbb, 0xa0, 0xb9, 0x73}
+
+func (c *client) AirdropAllowance(ctx context.Context, contract, recipient common.Address) (*big.Int, error) {
+	calldata := make([]byte, 0, 36)
+	calldata = append(calldata, airdropAllowanceSelector...)
+	// pad address to 32 bytes
+	calldata = append(calldata, make([]byte, 12)...)
+	calldata = append(calldata, recipient.Bytes()...)
+
+	out, err := c.rpc.CallContract(ctx, ethereum.CallMsg{
+		To:   &contract,
+		Data: calldata,
+	}, nil)
+	if err != nil {
+		return nil, fmt.Errorf("eth_call allowance: %w", err)
+	}
+	if len(out) != 32 {
+		return nil, fmt.Errorf("expected 32-byte response, got %d", len(out))
+	}
+	return new(big.Int).SetBytes(out), nil
+}
+```
+
+The selector hex value `0xbba0b973` is `keccak256("allowance(address)")[:4]`. Confirm it after the implementation by running the test in Step 4 — if the bytes are wrong, `AirdropAllowance` will return zero against a deployed contract and the integration test in Task 8 will catch it.
+
+- [ ] **Step 2: Update the ethclient API-surface test**
+
+Open `internal/service/airdrop/ethclient/client_test.go` and add `AirdropAllowance` to the unreachable interface-pin block:
+
+```go
+// Inside the existing TestClientInterface, add to the `if false` block:
+_, _ = iface.AirdropAllowance(ctx, common.Address{}, common.Address{})
+```
+
+- [ ] **Step 3: Add a selector regression test**
+
+Append to `internal/service/airdrop/ethclient/client_test.go`:
+
+```go
+import "github.com/ethereum/go-ethereum/crypto"
+
+func TestAirdropAllowanceSelector(t *testing.T) {
+	got := crypto.Keccak256([]byte("allowance(address)"))[:4]
+	if !bytes.Equal(got, airdropAllowanceSelector) {
+		t.Errorf("airdropAllowanceSelector mismatch: got %x want %x", airdropAllowanceSelector, got)
+	}
+}
+```
+
+(Add `"bytes"` to imports if not already present.)
+
+- [ ] **Step 4: Run ethclient tests**
+
+```bash
+go test ./internal/service/airdrop/ethclient/ -v
+```
+
+Expected: PASS for `TestClientInterface`, `TestNewClientRejectsBadURL`, `TestAirdropAllowanceSelector`.
+
+- [ ] **Step 5: Write the failing verify-onchain test**
+
+Create `cmd/airdrop-raffle/verify_onchain_test.go`:
+
+```go
+package main
+
+import (
+	"context"
+	"errors"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// fakeAllowanceReader implements allowanceReader for tests without a real chain.
+type fakeAllowanceReader struct {
+	values map[common.Address]*big.Int
+	err    error
+}
+
+func (f *fakeAllowanceReader) AirdropAllowance(ctx context.Context, contract, recipient common.Address) (*big.Int, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	if v, ok := f.values[recipient]; ok {
+		return v, nil
+	}
+	return new(big.Int), nil
+}
+
+func writeVerifyFixture(t *testing.T, dir string) (recipientA, recipientB common.Address) {
+	t.Helper()
+	recipientA = common.HexToAddress("0x000000000000000000000000000000000000000a")
+	recipientB = common.HexToAddress("0x000000000000000000000000000000000000000b")
+	csv := "public_key,recipient,amount,registered_at,source\n" +
+		"pk-a," + recipientA.Hex() + ",1500,2026-04-25T12:00:00Z,seed\n" +
+		"pk-b," + recipientB.Hex() + ",1500,2026-04-25T13:00:00Z,vault_share\n"
+	if err := os.WriteFile(filepath.Join(dir, "winners.csv"), []byte(csv), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	return
+}
+
+func TestRunVerifyOnchain_AllMatch(t *testing.T) {
+	dir := t.TempDir()
+	a, b := writeVerifyFixture(t, dir)
+	reader := &fakeAllowanceReader{values: map[common.Address]*big.Int{
+		a: big.NewInt(1500),
+		b: big.NewInt(1500),
+	}}
+	code := runVerifyOnchain(context.Background(), verifyOpts{
+		outputDir: dir,
+		contract:  common.HexToAddress("0x1"),
+		reader:    reader,
+		logger:    nopLogger(),
+	})
+	if code != 0 {
+		t.Errorf("exit = %d, want 0 (all match)", code)
+	}
+}
+
+func TestRunVerifyOnchain_AmountMismatch(t *testing.T) {
+	dir := t.TempDir()
+	a, b := writeVerifyFixture(t, dir)
+	reader := &fakeAllowanceReader{values: map[common.Address]*big.Int{
+		a: big.NewInt(1500),
+		b: big.NewInt(999), // wrong
+	}}
+	code := runVerifyOnchain(context.Background(), verifyOpts{
+		outputDir: dir,
+		contract:  common.HexToAddress("0x1"),
+		reader:    reader,
+		logger:    nopLogger(),
+	})
+	if code == 0 {
+		t.Errorf("expected non-zero exit on mismatch, got 0")
+	}
+}
+
+func TestRunVerifyOnchain_MissingAllowance(t *testing.T) {
+	dir := t.TempDir()
+	a, _ := writeVerifyFixture(t, dir)
+	reader := &fakeAllowanceReader{values: map[common.Address]*big.Int{
+		a: big.NewInt(1500),
+		// recipient B intentionally absent → returns 0
+	}}
+	code := runVerifyOnchain(context.Background(), verifyOpts{
+		outputDir: dir,
+		contract:  common.HexToAddress("0x1"),
+		reader:    reader,
+		logger:    nopLogger(),
+	})
+	if code == 0 {
+		t.Errorf("expected non-zero exit on missing allowance, got 0")
+	}
+}
+
+func TestRunVerifyOnchain_RPCErrorPropagates(t *testing.T) {
+	dir := t.TempDir()
+	writeVerifyFixture(t, dir)
+	reader := &fakeAllowanceReader{err: errors.New("rpc down")}
+	code := runVerifyOnchain(context.Background(), verifyOpts{
+		outputDir: dir,
+		contract:  common.HexToAddress("0x1"),
+		reader:    reader,
+		logger:    nopLogger(),
+	})
+	if code == 0 {
+		t.Errorf("expected non-zero exit on RPC error, got 0")
+	}
+}
+```
+
+- [ ] **Step 6: Run test to verify it fails**
+
+```bash
+go test ./cmd/airdrop-raffle/ -run TestRunVerifyOnchain -v
+```
+
+Expected: compile error — `runVerifyOnchain`, `verifyOpts`, `allowanceReader` undefined.
+
+- [ ] **Step 7: Implement verify_onchain.go**
+
+Create `cmd/airdrop-raffle/verify_onchain.go`:
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/sirupsen/logrus"
+
+	"github.com/vultisig/agent-backend/internal/service/airdrop/raffle"
+)
+
+// allowanceReader is the slice of the ethclient.Client this subcommand needs.
+// Defined here so the test can pass a fake without a live RPC.
+type allowanceReader interface {
+	AirdropAllowance(ctx context.Context, contract, recipient common.Address) (*big.Int, error)
+}
+
+type verifyOpts struct {
+	outputDir string
+	contract  common.Address
+	reader    allowanceReader
+	logger    *logrus.Logger
+}
+
+// runVerifyOnchain reads winners.csv, queries allowance(recipient) for each row,
+// and asserts the on-chain value matches the CSV's amount. Returns 0 only when
+// every row matches; non-zero on any mismatch, missing allowance, or RPC error.
+func runVerifyOnchain(ctx context.Context, opts verifyOpts) int {
+	log := opts.logger.WithFields(logrus.Fields{
+		"subcommand": "verify-onchain",
+		"contract":   opts.contract.Hex(),
+	})
+
+	csvPath := filepath.Join(opts.outputDir, "winners.csv")
+	f, err := os.Open(csvPath)
+	if err != nil {
+		log.WithError(err).Error("open winners.csv failed")
+		fmt.Fprintf(os.Stderr, "ERROR: cannot open %s: %v\n", csvPath, err)
+		return 1
+	}
+	defer f.Close()
+
+	rows, err := raffle.ReadWinnersCSV(f)
+	if err != nil {
+		log.WithError(err).Error("parse winners.csv failed")
+		return 1
+	}
+
+	var matched, mismatched, errored int
+	for _, row := range rows {
+		recipient := common.HexToAddress(row.Recipient)
+		got, err := opts.reader.AirdropAllowance(ctx, opts.contract, recipient)
+		if err != nil {
+			errored++
+			fmt.Printf("ERROR  %s  rpc: %v\n", row.Recipient, err)
+			log.WithError(err).WithField("recipient", row.Recipient).Error("allowance call failed")
+			continue
+		}
+		if got.Cmp(row.Amount) == 0 {
+			matched++
+			fmt.Printf("OK     %s  %s\n", row.Recipient, got.String())
+		} else {
+			mismatched++
+			fmt.Printf("FAIL   %s  on-chain=%s csv=%s\n", row.Recipient, got.String(), row.Amount.String())
+			log.WithFields(logrus.Fields{
+				"recipient":   row.Recipient,
+				"on_chain":    got.String(),
+				"csv_amount":  row.Amount.String(),
+			}).Warn("allowance mismatch")
+		}
+	}
+
+	fmt.Printf("\nSummary: %d matched, %d mismatched, %d errored, %d total.\n",
+		matched, mismatched, errored, len(rows))
+	log.WithFields(logrus.Fields{
+		"matched":    matched,
+		"mismatched": mismatched,
+		"errored":    errored,
+		"total":      len(rows),
+	}).Info("verify-onchain complete")
+
+	if mismatched == 0 && errored == 0 {
+		return 0
+	}
+	return 1
+}
+```
+
+(Add `"math/big"` to the imports — go's import organizer should handle it.)
+
+- [ ] **Step 8: Run tests to verify they pass**
+
+```bash
+go test ./cmd/airdrop-raffle/ -run TestRunVerifyOnchain -v
+```
+
+Expected: PASS for all four subtests.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add internal/service/airdrop/ethclient/client.go \
+         internal/service/airdrop/ethclient/client_test.go \
+         cmd/airdrop-raffle/verify_onchain.go \
+         cmd/airdrop-raffle/verify_onchain_test.go
+git commit -m "feat(airdrop): add verify-onchain subcommand + AirdropAllowance method"
+```
+
+---
+
+## Task 7: `RaffleWinnersRepository` (Postgres adapter for the store interface)
+
+**Why:** The CLI's three subcommands talk to interfaces (`registrationLister`, `winnersStore`); production needs a real Postgres implementation that wraps the sqlc queries from Task 1 and converts between `*big.Int` and `pgtype.Numeric`. `ListForDraw` lives on a separate adapter that wraps the existing Stage 1 `RegistrationRepository` row type — we add one new method there since the `agent_airdrop_registrations` table is already owned by the Stage 1 repo.
+
+**Files:**
+- Create: `internal/storage/postgres/airdrop_raffle_winners.go`
+- Create: `internal/storage/postgres/airdrop_raffle_winners_test.go`
+- Modify: `internal/storage/postgres/airdrop_registration.go` (add `ListForDraw` method)
+
+- [ ] **Step 1: Add `ListForDraw` to the registration repository**
+
+Open `internal/storage/postgres/airdrop_registration.go`. Add a new method on `RegistrationRepository`:
+
+```go
+import "github.com/vultisig/agent-backend/internal/service/airdrop/raffle"
+
+// ListForDraw returns every registration in deterministic order
+// (registered_at ASC, public_key ASC) — input to the raffle draw CLI.
+func (r *RegistrationRepository) ListForDraw(ctx context.Context) ([]raffle.Registration, error) {
+	rows, err := r.q.ListAirdropRegistrationsForDraw(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list registrations for draw: %w", err)
+	}
+	out := make([]raffle.Registration, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, raffle.Registration{
+			PublicKey:        row.PublicKey,
+			Source:           string(row.Source),
+			RecipientAddress: row.RecipientAddress,
+			RegisteredAt:     pgtimestamptzToTime(row.RegisteredAt),
+		})
+	}
+	return out, nil
+}
+```
+
+(`pgtimestamptzToTime` is already used by the existing `Get`/`Insert` methods in the same file.)
+
+- [ ] **Step 2: Write the failing test for the winners repository**
+
+Create `internal/storage/postgres/airdrop_raffle_winners_test.go`:
+
+```go
+package postgres_test
+
+import (
+	"context"
+	"math/big"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/vultisig/agent-backend/internal/service/airdrop/raffle"
+	"github.com/vultisig/agent-backend/internal/storage/postgres"
+)
+
+func newRaffleTestPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	dsn := os.Getenv("TEST_DATABASE_DSN")
+	if dsn == "" {
+		dsn = os.Getenv("DATABASE_DSN")
+	}
+	if dsn == "" {
+		t.Skip("TEST_DATABASE_DSN or DATABASE_DSN not set; skipping integration test")
+	}
+	pool, err := pgxpool.New(context.Background(), dsn)
+	if err != nil {
+		t.Fatalf("pgxpool.New: %v", err)
+	}
+	t.Cleanup(func() { pool.Close() })
+	_, err = pool.Exec(context.Background(), `TRUNCATE agent_raffle_winners`)
+	if err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+	return pool
+}
+
+func TestRaffleWinnersRepo_CountAndInsertAll(t *testing.T) {
+	pool := newRaffleTestPool(t)
+	repo := postgres.NewRaffleWinnersRepository(pool)
+	ctx := context.Background()
+
+	count, err := repo.Count(ctx)
+	if err != nil {
+		t.Fatalf("Count: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("initial count = %d, want 0", count)
+	}
+
+	rows := []raffle.CSVRow{
+		{PublicKey: "pk-1", Recipient: "0x0000000000000000000000000000000000000001",
+			Amount: big.NewInt(1500), RegisteredAt: time.Now(), Source: "seed"},
+		{PublicKey: "pk-2", Recipient: "0x0000000000000000000000000000000000000002",
+			Amount: big.NewInt(1500), RegisteredAt: time.Now(), Source: "vault_share"},
+	}
+	if err := repo.InsertAll(ctx, rows); err != nil {
+		t.Fatalf("InsertAll: %v", err)
+	}
+
+	count, err = repo.Count(ctx)
+	if err != nil {
+		t.Fatalf("Count after insert: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("count after insert = %d, want 2", count)
+	}
+}
+
+func TestRaffleWinnersRepo_InsertAllIsAtomic(t *testing.T) {
+	pool := newRaffleTestPool(t)
+	repo := postgres.NewRaffleWinnersRepository(pool)
+	ctx := context.Background()
+
+	// Two rows with the same public_key — the second insert should fail and
+	// the entire batch should roll back.
+	rows := []raffle.CSVRow{
+		{PublicKey: "pk-dup", Recipient: "0x1", Amount: big.NewInt(1500), Source: "seed"},
+		{PublicKey: "pk-dup", Recipient: "0x2", Amount: big.NewInt(1500), Source: "seed"},
+	}
+	err := repo.InsertAll(ctx, rows)
+	if err == nil {
+		t.Errorf("expected error from duplicate insert")
+	}
+	count, _ := repo.Count(ctx)
+	if count != 0 {
+		t.Errorf("count after failed batch = %d, want 0 (transaction should have rolled back)", count)
+	}
+}
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+```bash
+go test ./internal/storage/postgres/ -run TestRaffleWinnersRepo -v
+```
+
+Expected: compile error — `NewRaffleWinnersRepository` undefined.
+
+- [ ] **Step 4: Implement the repository**
+
+Create `internal/storage/postgres/airdrop_raffle_winners.go`:
+
+```go
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/vultisig/agent-backend/internal/service/airdrop/raffle"
+	"github.com/vultisig/agent-backend/internal/storage/postgres/queries"
+)
+
+// RaffleWinnersRepository implements the load-winners subcommand's storage
+// needs against agent_raffle_winners.
+type RaffleWinnersRepository struct {
+	pool *pgxpool.Pool
+	q    *queries.Queries
+}
+
+func NewRaffleWinnersRepository(pool *pgxpool.Pool) *RaffleWinnersRepository {
+	return &RaffleWinnersRepository{pool: pool, q: queries.New(pool)}
+}
+
+// Count returns the total number of rows currently in agent_raffle_winners.
+// Used by load-winners as the idempotency guard.
+func (r *RaffleWinnersRepository) Count(ctx context.Context) (int64, error) {
+	n, err := r.q.AirdropRaffleWinnerCount(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("count winners: %w", err)
+	}
+	return n, nil
+}
+
+// InsertAll inserts every row inside a single transaction. On any failure,
+// the entire batch rolls back. Used by load-winners.
+func (r *RaffleWinnersRepository) InsertAll(ctx context.Context, rows []raffle.CSVRow) error {
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }() // no-op if Commit succeeded
+
+	qtx := r.q.WithTx(tx)
+	for _, row := range rows {
+		amount, err := bigIntToNumeric(row.Amount)
+		if err != nil {
+			return fmt.Errorf("convert amount for %s: %w", row.PublicKey, err)
+		}
+		err = qtx.InsertRaffleWinner(ctx, &queries.InsertRaffleWinnerParams{
+			PublicKey: row.PublicKey,
+			Recipient: row.Recipient,
+			Amount:    amount,
+		})
+		if err != nil {
+			return fmt.Errorf("insert %s: %w", row.PublicKey, err)
+		}
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("commit: %w", err)
+	}
+	return nil
+}
+
+// bigIntToNumeric converts a *big.Int into the pgtype.Numeric the sqlc
+// binding expects for NUMERIC(78,0). Tested implicitly by the round-trip
+// in TestRaffleWinnersRepo_CountAndInsertAll.
+func bigIntToNumeric(n *big.Int) (pgtype.Numeric, error) {
+	var num pgtype.Numeric
+	if n == nil {
+		return num, fmt.Errorf("nil amount")
+	}
+	if err := num.Scan(n.String()); err != nil {
+		return num, err
+	}
+	return num, nil
+}
+
+// silence unused import when the file lives alongside helpers
+var _ pgx.Tx = (pgx.Tx)(nil)
+```
+
+The exact name of `WithTx` and the param-struct (`InsertRaffleWinnerParams`) depend on what sqlc generated; open `internal/storage/postgres/queries/airdrop_raffle.sql.go` to confirm. Match whatever pattern `conversation.go` uses for transactional inserts if `WithTx` is named differently in this repo.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+DATABASE_DSN="$DATABASE_DSN" go test ./internal/storage/postgres/ -run TestRaffleWinnersRepo -v
+```
+
+Expected: PASS for both subtests, given a live test DB.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/storage/postgres/airdrop_raffle_winners.go \
+         internal/storage/postgres/airdrop_raffle_winners_test.go \
+         internal/storage/postgres/airdrop_registration.go
+git commit -m "feat(airdrop): add RaffleWinnersRepository + ListForDraw on registrations"
+```
+
+---
+
+## Task 8: `main.go` subcommand router + integration build + push PR
+
+**Why:** Final wiring. The `flag.NewFlagSet` per-subcommand pattern (matching the rest of the agent-backend CLIs) lives in `main.go`. End-to-end: build the binary, run `--help` to confirm the surface, and push the branch.
+
+**Files:**
+- Create: `cmd/airdrop-raffle/main.go`
+- Create: `docs/runbooks/raffle-day-12.md`
+
+- [ ] **Step 1: Implement main.go**
+
+Create `cmd/airdrop-raffle/main.go`. Mirrors the config-loading + DB-pool-construction pattern from `cmd/admin/main.go`, but with stdlib `flag.FlagSet`-based subcommand routing instead of an HTTP server bootstrap:
+
+```go
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"math/big"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/vultisig/agent-backend/internal/service/airdrop/ethclient"
+	"github.com/vultisig/agent-backend/internal/storage/postgres"
+)
+
+const usage = `airdrop-raffle — Vultiverse Airdrop raffle CLI
+
+Usage:
+  airdrop-raffle <subcommand> [flags]
+
+Subcommands:
+  draw            Pick winners from agent_airdrop_registrations and write winners.csv + manifest.json
+  load-winners    Load winners.csv into agent_raffle_winners (refuses if non-empty)
+  verify-onchain  Read winners.csv and assert allowance(recipient) on the contract matches each row
+
+Run "airdrop-raffle <subcommand> -h" for subcommand-specific flags.
+`
+
+func main() {
+	logger := logrus.New()
+	logger.SetFormatter(&logrus.JSONFormatter{})
+	logger.SetOutput(os.Stdout)
+
+	if len(os.Args) < 2 {
+		fmt.Fprint(os.Stderr, usage)
+		os.Exit(2)
+	}
+
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	switch os.Args[1] {
+	case "draw":
+		os.Exit(drawMain(ctx, logger, os.Args[2:]))
+	case "load-winners":
+		os.Exit(loadWinnersMain(ctx, logger, os.Args[2:]))
+	case "verify-onchain":
+		os.Exit(verifyOnchainMain(ctx, logger, os.Args[2:]))
+	case "-h", "--help", "help":
+		fmt.Print(usage)
+		os.Exit(0)
+	default:
+		fmt.Fprintf(os.Stderr, "unknown subcommand: %s\n\n%s", os.Args[1], usage)
+		os.Exit(2)
+	}
+}
+
+func drawMain(ctx context.Context, logger *logrus.Logger, args []string) int {
+	fs := flag.NewFlagSet("draw", flag.ExitOnError)
+	seed := fs.Uint64("seed", 0, "PRNG seed (uint64). Default: a fresh crypto/rand value, printed at start.")
+	slotCount := fs.Int("slot-count", 0, "Number of winners to draw. Required.")
+	vultAmountStr := fs.String("vult-amount", "", "VULT per winner, decimal string (uint256). Required.")
+	outputDir := fs.String("output-dir", "", "Directory to write winners.csv + manifest.json. Created if missing. Required.")
+	dbURL := fs.String("db-url", "", "Postgres connection string. Required.")
+	if err := fs.Parse(args); err != nil {
+		return 1
+	}
+
+	if *slotCount <= 0 || *vultAmountStr == "" || *outputDir == "" || *dbURL == "" {
+		fmt.Fprintln(os.Stderr, "ERROR: --slot-count, --vult-amount, --output-dir, --db-url are required")
+		fs.Usage()
+		return 1
+	}
+	amount, ok := new(big.Int).SetString(*vultAmountStr, 10)
+	if !ok || amount.Sign() <= 0 {
+		fmt.Fprintf(os.Stderr, "ERROR: invalid --vult-amount: %q\n", *vultAmountStr)
+		return 1
+	}
+
+	resolvedSeed := *seed
+	if resolvedSeed == 0 {
+		var err error
+		resolvedSeed, err = freshSeed()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "ERROR: generate fresh seed: %v\n", err)
+			return 1
+		}
+		fmt.Printf("No --seed passed; using fresh crypto/rand seed: %d\n", resolvedSeed)
+	}
+
+	db, err := postgres.New(ctx, *dbURL)
+	if err != nil {
+		logger.WithError(err).Error("connect to db")
+		return 1
+	}
+	defer db.Close()
+	regRepo := postgres.NewRegistrationRepository(db.Pool())
+
+	return runDraw(ctx, drawOpts{
+		seed:       resolvedSeed,
+		slotCount:  *slotCount,
+		vultAmount: amount,
+		outputDir:  *outputDir,
+		lister:     regRepo,
+		logger:     logger,
+		now:        time.Now,
+	})
+}
+
+func loadWinnersMain(ctx context.Context, logger *logrus.Logger, args []string) int {
+	fs := flag.NewFlagSet("load-winners", flag.ExitOnError)
+	outputDir := fs.String("output-dir", "", "Directory containing winners.csv from a prior draw. Required.")
+	dbURL := fs.String("db-url", "", "Postgres connection string. Required.")
+	if err := fs.Parse(args); err != nil {
+		return 1
+	}
+	if *outputDir == "" || *dbURL == "" {
+		fmt.Fprintln(os.Stderr, "ERROR: --output-dir and --db-url are required")
+		fs.Usage()
+		return 1
+	}
+
+	db, err := postgres.New(ctx, *dbURL)
+	if err != nil {
+		logger.WithError(err).Error("connect to db")
+		return 1
+	}
+	defer db.Close()
+	store := postgres.NewRaffleWinnersRepository(db.Pool())
+
+	return runLoadWinners(ctx, loadWinnersOpts{
+		outputDir: *outputDir,
+		store:     store,
+		logger:    logger,
+	})
+}
+
+func verifyOnchainMain(ctx context.Context, logger *logrus.Logger, args []string) int {
+	fs := flag.NewFlagSet("verify-onchain", flag.ExitOnError)
+	outputDir := fs.String("output-dir", "", "Directory containing winners.csv. Required.")
+	rpcURL := fs.String("rpc-url", "", "Ethereum RPC URL (read-only, no signing). Required.")
+	contractStr := fs.String("contract", "", "Deployed AirdropClaim address (0x...). Required.")
+	if err := fs.Parse(args); err != nil {
+		return 1
+	}
+	if *outputDir == "" || *rpcURL == "" || *contractStr == "" {
+		fmt.Fprintln(os.Stderr, "ERROR: --output-dir, --rpc-url, --contract are required")
+		fs.Usage()
+		return 1
+	}
+	contract, err := parseAddress(*contractStr)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: invalid --contract: %v\n", err)
+		return 1
+	}
+
+	rpc, err := ethclient.NewClient(*rpcURL)
+	if err != nil {
+		logger.WithError(err).Error("dial rpc")
+		return 1
+	}
+
+	return runVerifyOnchain(ctx, verifyOpts{
+		outputDir: *outputDir,
+		contract:  contract,
+		reader:    rpc,
+		logger:    logger,
+	})
+}
+
+// parseAddress validates and parses a 0x-prefixed hex address. Defined here
+// (small one-liner) to avoid pulling go-ethereum/common into main.go's import
+// surface for one call site — both subcommand mains use it.
+func parseAddress(s string) (common.Address, error) {
+	s = strings.TrimSpace(s)
+	if !strings.HasPrefix(s, "0x") || len(s) != 42 {
+		return common.Address{}, fmt.Errorf("expected 0x-prefixed 20-byte hex, got %q", s)
+	}
+	return common.HexToAddress(s), nil
+}
+```
+
+(Add `"github.com/ethereum/go-ethereum/common"` to imports — `parseAddress` returns `common.Address`. The import is also already pulled in by `verify_onchain.go`.)
+
+- [ ] **Step 2: Build the binary**
+
+```bash
+go build -o bin/airdrop-raffle ./cmd/airdrop-raffle
+./bin/airdrop-raffle help
+./bin/airdrop-raffle draw -h
+./bin/airdrop-raffle load-winners -h
+./bin/airdrop-raffle verify-onchain -h
+```
+
+Expected: top-level usage prints; each subcommand prints its `flag.FlagSet` usage with the documented flags.
+
+- [ ] **Step 3: Run the full test suite**
+
+```bash
+go test ./...
+```
+
+Expected: PASS. Investigate any failures.
+
+- [ ] **Step 4: Manual smoke test against local Postgres**
+
+Seed three fake registrations and run `draw` then `load-winners`:
+
+```bash
+psql "$DATABASE_DSN" <<'SQL'
+TRUNCATE agent_airdrop_registrations;
+TRUNCATE agent_raffle_winners;
+INSERT INTO agent_airdrop_registrations (public_key, source, recipient_address)
+VALUES ('pk-1', 'seed', '0x0000000000000000000000000000000000000001'),
+       ('pk-2', 'seed', '0x0000000000000000000000000000000000000002'),
+       ('pk-3', 'vault_share', '0x0000000000000000000000000000000000000003');
+SQL
+
+mkdir -p /tmp/raffle-test
+./bin/airdrop-raffle draw \
+  --seed 12345 \
+  --slot-count 2 \
+  --vult-amount 1500 \
+  --output-dir /tmp/raffle-test \
+  --db-url "$DATABASE_DSN"
+
+cat /tmp/raffle-test/winners.csv
+cat /tmp/raffle-test/manifest.json
+
+./bin/airdrop-raffle load-winners \
+  --output-dir /tmp/raffle-test \
+  --db-url "$DATABASE_DSN"
+
+psql "$DATABASE_DSN" -c "SELECT * FROM agent_raffle_winners"
+
+# Re-running load-winners should now refuse:
+./bin/airdrop-raffle load-winners \
+  --output-dir /tmp/raffle-test \
+  --db-url "$DATABASE_DSN"
+```
+
+Expected: `draw` writes a CSV with two rows + a manifest. `load-winners` inserts both, prints "Loaded 2 winners". The second `load-winners` exits non-zero with the "agent_raffle_winners already has 2 rows; refusing" message.
+
+- [ ] **Step 5: Draft the operator runbook**
+
+Create `docs/runbooks/raffle-day-12.md`:
+
+```markdown
+# Day 12 Runbook — Raffle Draw
+
+> **Operator audience.** This runbook is the step-by-step for the human running the Day 12 raffle. Companion to `docs/airdrop-specs/stage-2-raffle-draw.md` (the spec) and `docs/airdrop-specs/sibling-on-chain-contract.md` (the contract behaviour).
+
+## Pre-flight
+
+- Boarding window has closed (`TRANSITION_WINDOW_END` has passed).
+- `AirdropClaim.sol` is deployed; address + ABI captured.
+- VULT prize pool has been transferred to the contract (`slot_count × amount × 1.05`).
+- The `airdrop-raffle` binary is built and on the operator's PATH.
+- A private ops repo (or `vultisig/vultisig-contract`) is cloned locally for committing the artifact directory.
+
+## Step 1 — Draw
+
+```bash
+mkdir -p ./raffle-2026-day-12
+airdrop-raffle draw \
+  --slot-count <STAGE_0_SLOT_COUNT> \
+  --vult-amount <STAGE_0_VULT_AMOUNT_BASE_UNITS> \
+  --output-dir ./raffle-2026-day-12 \
+  --db-url "$AIRDROP_PROD_DSN"
+```
+
+Captures:
+- `winners.csv` — the artifact handed to the multisig signer.
+- `manifest.json` — includes the seed for later verifiability.
+
+The CLI prints the seed to stdout. Record it (operator log + post-draw note on X).
+
+## Step 2 — Commit the artifact directory
+
+```bash
+cp -r ./raffle-2026-day-12 path/to/ops-repo/
+cd path/to/ops-repo
+git add raffle-2026-day-12
+git commit -m "raffle: 2026 day-12 draw artifacts (seed=<SEED>)"
+git push
+```
+
+## Step 3 — Hand winners.csv to the multisig signer
+
+The multisig signer's checklist:
+1. Open `winners.csv`. Eyeball: row count matches `slot_count`, no malformed addresses.
+2. Split into batches of ~100 rows.
+3. For each batch, construct `setWinners(addresses, amounts)` calldata and sign through the multisig UI.
+4. Check on Etherscan that each batch was mined; capture each tx hash.
+5. **Footgun guard:** before submitting, diff against any prior `setWinners` calls + any confirmed `Claimed` events. Re-arming a previously-claimed address re-grants their allowance (see `sibling-on-chain-contract.md`).
+
+## Step 4 — Verify on-chain
+
+After every batch is mined:
+
+```bash
+airdrop-raffle verify-onchain \
+  --output-dir ./raffle-2026-day-12 \
+  --rpc-url "$EVM_RPC_URL" \
+  --contract "$AIRDROP_CLAIM_CONTRACT_ADDRESS"
+```
+
+Expected: every row prints `OK`. Summary: `N matched, 0 mismatched, 0 errored`.
+
+If anything is `FAIL` or `ERROR`, **do not load-winners**. Investigate which batch missed the recipient and re-run the multisig batch for the missed entries before re-running `verify-onchain`.
+
+## Step 5 — Load winners into Postgres
+
+```bash
+airdrop-raffle load-winners \
+  --output-dir ./raffle-2026-day-12 \
+  --db-url "$AIRDROP_PROD_DSN"
+```
+
+Single transaction. After this commits, `/airdrop/status` returns `won` / `lost` to all users.
+
+If `agent_raffle_winners` is already populated (e.g. you ran this earlier and need to re-load), explicitly:
+
+```bash
+psql "$AIRDROP_PROD_DSN" -c "TRUNCATE agent_raffle_winners"
+```
+
+then re-run `load-winners`.
+
+## Done
+
+- Artifact directory committed to ops repo.
+- Multisig has set every winner's allowance.
+- `verify-onchain` is green.
+- `agent_raffle_winners` is populated.
+- Stage 1's `/airdrop/status` is now returning `won`/`lost` instead of `awaiting_draw`.
+
+The system is ready for Stage 4's claim relayer to come up on Day 28.
+```
+
+- [ ] **Step 6: Run lint**
+
+```bash
+make lint
+```
+
+Expected: no errors.
+
+- [ ] **Step 7: Push branch**
+
+```bash
+git add cmd/airdrop-raffle/main.go docs/runbooks/raffle-day-12.md
+git commit -m "feat(airdrop): wire main.go subcommand router + Day 12 runbook"
+git push -u origin feat/airdrop-stage-2-raffle-cli
+```
+
+- [ ] **Step 8: Open PR**
+
+```bash
+gh pr create --title "feat(airdrop): Stage 2 raffle draw CLI (draw, load-winners, verify-onchain)" --body "$(cat <<'EOF'
+## Summary
+
+Adds the Stage 2 raffle CLI from the Vultiverse Airdrop spec — a single `airdrop-raffle` binary with three subcommands the operator runs by hand on Day 12:
+
+- `draw` — picks winners with a seeded Fisher–Yates shuffle and writes `winners.csv` + `manifest.json`
+- `load-winners` — mirrors winners.csv into `agent_raffle_winners` in a single transaction (refuses if non-empty)
+- `verify-onchain` — reads winners.csv and asserts `allowance(recipient)` on the deployed AirdropClaim matches each row
+
+Plus the Day 12 operator runbook.
+
+Spec source of truth: `docs/airdrop-specs/stage-2-raffle-draw.md`.
+
+## Architecture
+- One Go binary at `cmd/airdrop-raffle/` with stdlib `flag.FlagSet` per-subcommand routing — same dependency-free pattern as `cmd/admin` and `cmd/scheduler`
+- Pure selection + serialization logic in `internal/service/airdrop/raffle/` so unit tests run without Postgres or RPC
+- New sqlc query file `internal/storage/postgres/sqlc/airdrop_raffle.sql` for the CLI's reads/writes
+- New `RaffleWinnersRepository` for batched inserts inside one transaction
+- `internal/service/airdrop/ethclient/client.go` extended with `AirdropAllowance(contract, recipient)` — distinct selector from the existing `BalanceOf` (ERC-20 vs AirdropClaim's single-arg storage getter)
+- No Merkle code (dropped from the spec 2026-04-23)
+
+## Spec coverage
+- `draw` — all flags, exit codes (0/1/2/4), idempotent for the same seed, undersubscription banner, output to `--output-dir`
+- `load-winners` — single-transaction insert, refuses if already populated
+- `verify-onchain` — per-row pass/fail print, summary line, non-zero exit on any mismatch
+- Selection unit tests cover the spec's "Tests → Unit" list (zero entries hard-fail, undersubscription, oversubscription with no duplicates, idempotency, recipient passthrough)
+- Repository integration tests cover atomic batch insert + idempotency guard
+- Operator runbook drafted at `docs/runbooks/raffle-day-12.md`
+
+## Test plan
+- [ ] `go test ./...` passes
+- [ ] Manual smoke (Step 4 of Task 8) inserts test registrations, runs all three subcommands, verifies idempotency guard
+- [ ] `make lint` clean
+- [ ] (Deferred to E2E test) `verify-onchain` against an Anvil-deployed `AirdropClaim` after multisig has set allowances
+
+## Hard deadline
+Operator runs `airdrop-raffle draw` on Day 12 (boarding window closes at `TRANSITION_WINDOW_END`). Binary must be built + runbook drafted by Day 11.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Capture and report the PR URL.
+
+---
+
+## Self-review notes
+
+This plan was reviewed against `stage-2-raffle-draw.md` after writing. Items confirmed against the spec's "Done when" list:
+
+- ✅ All three subcommands implemented and unit-tested (`runDraw`, `runLoadWinners`, `runVerifyOnchain` each have a test file).
+- ✅ Integration test against real Postgres covered by `TestRaffleWinnersRepo_*` (Task 7).
+- ✅ Operator runbook drafted at `docs/runbooks/raffle-day-12.md` (Task 8 Step 5).
+- ⏭ E2E test against an Anvil-deployed `AirdropClaim` — left as the test plan checkbox in the PR body. The unit tests prove the CSV round-trip, the selector regression test proves the calldata, the integration tests prove the DB path. The end-to-end "draw → multisig sets allowances → verify-onchain → load-winners → claim succeeds" flow is the Stage 4 PR's responsibility (it owns the relayer and will be the only place an Anvil fixture is wired in).
+
+Items intentionally NOT in this plan (in line with the scope-of-this-plan section of the brief):
+- **No Merkle / proof / leaf code** — the spec explicitly dropped this on 2026-04-23. Confirmed nothing in `internal/service/airdrop/raffle/` references trees or proofs.
+- **No `setWinners` signing** — multisig owns this; the CLI just produces `winners.csv`.
+- **No HTTP service / goroutines / middleware** — every subcommand exits when its work is done.
+- **No new env vars** — every input is a CLI flag, per the spec's "Configuration" section.
+
+Decisions that needed to be made and why:
+
+- **stdlib `flag` over cobra.** No other agent-backend CLI uses cobra; matching the existing pattern keeps the binary's import surface tiny.
+- **Extended the ethclient wrapper rather than calling `CallContract` from `cmd/`.** ABI encoding (selector + 32-byte padding) belongs alongside the existing `BalanceOf` implementation. Adds one method + one regression test to the wrapper; saves repeating the same encoding pattern in `cmd/airdrop-raffle/`.
+- **`InsertAll` does its own `tx.Begin/Commit` rather than accepting a `pgx.Tx` from the caller.** load-winners is the sole caller; nothing else needs the transactional surface; keeps the CLI side dead-simple.
+- **`ListForDraw` lives on the existing `RegistrationRepository`** rather than a new repo — the table is owned by Stage 1's repo, and bolting on a single read method is cheaper than introducing a parallel adapter.

--- a/plans/airdrop/2026-04-23-stage-3-quest-tracking.md
+++ b/plans/airdrop/2026-04-23-stage-3-quest-tracking.md
@@ -1,0 +1,2492 @@
+# Vultiverse Airdrop — Stage 3 (Quest Tracking) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A single new internal endpoint (`POST /internal/quests/event`) plus a hook in the existing `SignTxProposal` handler that fires quest events whenever the mobile app reports a tx as signed-and-broadcast. Five hard-coded validators (three real, two stubs). Idempotent on `tool_call_id`. Activation-gated by `QUEST_ACTIVATION_TIMESTAMP`.
+
+**Architecture:** New `/internal/quests/event` route on the existing `Server`, protected by `InternalTokenMiddleware` from shared infra. Validators are pure functions in `internal/service/airdrop/quests/validators/` — one file per quest type, each reading the normalised `quest_metadata` map (already populated by the agent-backend at proposal-creation time) plus relevant config, returning `(qualifies bool, reason string)`. A small lookup table in `internal/service/airdrop/quests/dispatch.go` maps `tool_name` → `quest_type` (with swap-vs-bridge resolved by comparing `source_chain_id` and `dest_chain_id` from `quest_metadata`). Repo layer wraps two sqlc files (`airdrop_quest_events.sql`, `airdrop_user_quests.sql`). The hook is a small additive change at `internal/api/tx_proposals.go` (after `MarkSigned` succeeds) that reads `tool_name` + `quest_metadata` off the signed proposal and fires an in-process HTTP POST to `http://127.0.0.1:<SERVER_PORT>/internal/quests/event` with the `X-Internal-Token` header — errors logged, never propagated to the user.
+
+**Cross-team prerequisite (HARD BLOCKER):** This plan depends on two new columns (`tool_name`, `quest_metadata`) on `agent_tx_proposals`, populated by the agent-backend's scheduler.go at proposal-creation time, with values supplied by the MCP server's `build_*` tools. See **Task 0** below. None of the airdrop-side code paths in this plan can be E2E-tested until that prerequisite ships.
+
+**Tech Stack:**
+- Go 1.25, Echo v4
+- pgx/v5 + sqlc (existing pattern — see `internal/storage/postgres/sqlc/conversations.sql`)
+- `InternalTokenMiddleware` from shared-infra (`internal/api/internal_token_middleware.go`)
+- `cfg.Airdrop.*` substruct from shared-infra (`internal/config/config.go:41`)
+- `net/http` stdlib for the in-process POST (no new deps)
+
+**Spec source of truth:** `docs/airdrop-specs/stage-3-quest-tracking.md`
+
+**Working directory for all tasks:** `/Users/apotheosis/git/vultisig/agent-backend/`
+
+**Branch:** `feat/airdrop-stage-3-quest-tracking`. Branch off `main` after the shared-infra PR has merged. Stage 1's `eligibility.go` does not block this stage — Stage 3 only writes to `agent_quest_events` + `agent_user_quests`; Stage 1 is the consumer.
+
+**Hard deadline:** Live in staging by Day 13 (the quest-earning window opens). This plan is roughly 1.5 days of focused work.
+
+---
+
+## Pre-flight (do once before Task 1)
+
+Confirm the shared-infra PR has merged AND the cross-team prerequisite (Task 0) has landed:
+
+```bash
+cd /Users/apotheosis/git/vultisig/agent-backend
+git checkout main && git pull
+psql "$DATABASE_DSN" -c "\d agent_quest_events"
+psql "$DATABASE_DSN" -c "\d agent_user_quests"
+psql "$DATABASE_DSN" -c "\d agent_tx_proposals" | grep -E "tool_name|quest_metadata"
+grep -n "InternalTokenMiddleware" internal/api/internal_token_middleware.go
+grep -n "QuestActivationTimestamp" internal/config/config.go
+```
+
+All five checks should succeed. The third one (column existence on `agent_tx_proposals`) is the cross-team prerequisite gate — if it fails, **stop**: the agent-backend migration from Task 0 hasn't merged yet and Stage 3 cannot proceed.
+
+```bash
+git checkout -b feat/airdrop-stage-3-quest-tracking
+```
+
+---
+
+## Task 0: Cross-team prerequisite — `tool_name` + `quest_metadata` on `agent_tx_proposals`
+
+**Why:** The airdrop's quest dispatch needs a reliable, structured signal of "what tool built this tx and how much was it worth in USD." That data exists at the MCP layer (the build_* tool that built the tx). Reverse-engineering it from raw `action_params`/`quote_data` JSONB at quest-event time is brittle and couples the airdrop module to every tool's bespoke shape. The fix is to have the MCP tools emit a normalised `quest_metadata` block in their result, have the agent-backend persist it on the proposal, and have the airdrop module read it at quest-event time.
+
+**This task is OWNED BY OTHER TEAMS.** This plan documents the contract, the file paths, and the acceptance criteria; the work itself is done by the MCP team and the agent-backend team. Stage 3 cannot ship until both PRs land.
+
+### Schema contract
+
+Two new columns on `agent_tx_proposals`:
+
+```sql
+ALTER TABLE agent_tx_proposals ADD COLUMN tool_name TEXT;        -- e.g. "build_swap_tx"
+ALTER TABLE agent_tx_proposals ADD COLUMN quest_metadata JSONB;  -- normalised, see below
+```
+
+`quest_metadata` is a flat JSON object. All fields are optional — the airdrop validators only read what they need. Field semantics:
+
+```json
+{
+  "amount_usd":         25.50,
+  "token_in_symbol":    "USDC",
+  "token_out_symbol":   "ETH",
+  "source_chain_id":    1,
+  "dest_chain_id":      1,
+  "target_contract":    "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+  "router_address":     "0x6131b5fae19ea4f9d964eac0408e4408b66337b5"
+}
+```
+
+- `amount_usd` is a JSON number (decimal), not an integer in cents. Computed by the build tool using its existing quote pipeline. Omit if not available — validators treat absence as "below threshold."
+- Chain IDs are **integers** (1, 42161, 8453, …), not strings. Deliberate divergence from `tx_proposals.chain` (strings). Universal EVM convention; lets validators do `source_chain_id != dest_chain_id` cleanly.
+- Addresses lowercase hex with `0x` prefix. The DeFi-action validator does a lowercase compare against the configured allowlist.
+
+### Sub-task A — MCP team
+
+In `vultisig/mcp`, update each `build_*` tool to emit `quest_metadata` in its result. Sizing is **bigger than the original spec implied** because `build_swap_tx` needs a CoinGecko price lookup to compute `amount_usd` from the user's input amount.
+
+Concretely for the three tools the airdrop directly uses:
+
+| Tool | File | Required fields | Effort |
+|---|---|---|---|
+| `build_evm_tx` | `internal/tools/build_evm_tx.go:142-153` (the result map) | `target_contract` (= the existing `to` field), `source_chain_id` (= the existing `chain_id` parsed to integer) | ~5 lines |
+| `build_swap_tx` | `internal/tools/build_swap_tx.go:39-60` (the `swapResult` struct) | `amount_usd`, `token_in_symbol`, `token_out_symbol`, `source_chain_id`, `dest_chain_id`, `router_address` | ~25 lines |
+| Any future bridge tool | n/a yet | `amount_usd`, `source_chain_id`, `dest_chain_id` | n/a |
+
+For `build_swap_tx`, three things to add:
+1. **`AmountUsd float64`** — call the existing `coingecko.Client.GetSimplePrice(ctx, ...)` (already wired into MCP) to fetch the USD price of the input token; multiply by `params.Amount / 10^FromDecimals`.
+2. **`RouterAddress string`** — `bundle.Quote.Router` exists internally (post `svc.GetSwapTxBundle()`) but isn't currently exposed in the result struct. Just add the field and pass through.
+3. **`SourceChainID, DestChainID int64`** — convert the existing `FromChain`/`ToChain` strings to integer chain IDs. The MCP repo has chain-ID lookup utilities (`evmclient.ChainIDByName` or similar — check `internal/evm/`). Emit as JSON numbers (not strings).
+
+For `build_evm_tx`, just two map keys to add to the existing result map. `chain_id` already exists as a string — emit a parallel `source_chain_id` as integer for the airdrop, leave the existing string for backward compat.
+
+Other build tools (Solana, Sui, Ton, Trx, etc.) can omit `quest_metadata` for now — none of them map to airdrop quests.
+
+**Chain ID encoding gotcha:** the airdrop validators expect chain IDs as JSON numbers (e.g. `1`, `42161`), not strings (`"1"`, `"42161"`). Make sure the new fields marshal as numbers — easy to get wrong if the engineer reuses MCP's existing chain_id-as-string pattern.
+
+**Acceptance:** PR open in `vultisig/mcp` with `quest_metadata` populated by `build_swap_tx` and `build_evm_tx`, plus a fixture or unit test asserting the shape (including chain IDs being JSON numbers).
+
+### Sub-task B — agent-backend team
+
+In `vultisig/agent-backend`:
+
+1. **Migration.** Add a new migration file `internal/storage/postgres/migrations/<TIMESTAMP>_add_tool_name_quest_metadata_to_tx_proposals.sql`:
+
+```sql
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE agent_tx_proposals ADD COLUMN tool_name TEXT;
+ALTER TABLE agent_tx_proposals ADD COLUMN quest_metadata JSONB;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE agent_tx_proposals DROP COLUMN tool_name;
+ALTER TABLE agent_tx_proposals DROP COLUMN quest_metadata;
+-- +goose StatementEnd
+```
+
+2. **Type update.** Add `ToolName *string` and `QuestMetadata json.RawMessage` to the `TxProposal` struct at `internal/types/tx_proposal.go`.
+
+3. **Repo update.** Update `internal/storage/postgres/tx_proposal.go`'s `Create` method to write the new columns, and `GetByID` / `MarkSigned` to read them. (sqlc regeneration after updating the corresponding `.sql` file in the sqlc directory.)
+
+4. **Scheduler change.** In `internal/service/scheduler/scheduler.go`, around line 320 (call site of `txProposalRepo.Create`; line numbers may have drifted — `grep -n "txProposalRepo.Create" internal/service/scheduler/scheduler.go` to find current location). The surrounding loop reads `result.ToolLogs` (defined at `internal/service/agent/headless.go:21-34` as `[]ToolCallLog{Name, Input, Result}`). Before building the `TxProposal` struct:
+   - Capture the active `tool.Name` from the `result.ToolLogs` entry — this becomes `proposal.ToolName`.
+   - Extract `quest_metadata` from the tool's result JSON if present — this becomes `proposal.QuestMetadata`.
+   - Pass both into `txProposalRepo.Create(...)`.
+
+   Implementation sketch (~10 lines insert):
+
+```go
+// (around scheduler.go:306, before building the TxProposal struct)
+var toolName string
+var questMetadata json.RawMessage
+if log := activeBuildToolLog(result.ToolLogs); log != nil {
+    toolName = log.Name
+    if raw, ok := log.Result.(map[string]any)["quest_metadata"]; ok {
+        if b, err := json.Marshal(raw); err == nil {
+            questMetadata = b
+        }
+    }
+}
+
+proposal := &types.TxProposal{
+    // ... existing fields ...
+    ToolName:      &toolName,
+    QuestMetadata: questMetadata,
+}
+```
+
+(Adjust `activeBuildToolLog` to whatever helper or inline loop the existing scheduler uses to pick the relevant tool from the result logs — see line 277–287 today.)
+
+**Acceptance:** PR open in `vultisig/agent-backend` with the migration applied, the type updated, the scheduler populating both fields. Unit test in scheduler covering: (a) tool emits `quest_metadata` → both columns populated, (b) tool omits → both columns NULL, (c) older proposals (without the new columns) still work.
+
+### Verification
+
+When both sub-task PRs are merged to `main`, this command should succeed against your local DB:
+
+```bash
+psql "$DATABASE_DSN" -c "\d agent_tx_proposals" | grep -E "tool_name|quest_metadata"
+```
+
+Expected: two lines (tool_name as TEXT, quest_metadata as JSONB).
+
+To confirm end-to-end, trigger a real swap through the agent (in dev) and inspect:
+
+```bash
+psql "$DATABASE_DSN" -c "SELECT id, action_type, tool_name, quest_metadata FROM agent_tx_proposals ORDER BY created_at DESC LIMIT 1;"
+```
+
+Expected: the most recent row has `tool_name = 'build_swap_tx'` and a populated `quest_metadata` blob with at least `amount_usd` and chain IDs.
+
+### Once Task 0 acceptance is met
+
+Proceed to Task 1. Until it's met, do not write any Stage 3 code — every E2E test will be untestable.
+
+---
+
+## Task 1: sqlc queries for quest events + user quests
+
+> **Schema update (2026-04-23):** apply this column rename across all SQL + sqlc-generated Go in this task:
+>
+> | Old column | New column |
+> |---|---|
+> | `status airdrop_quest_event_status` (enum) | `counted BOOLEAN NOT NULL` |
+> | `payload JSONB NOT NULL` | `tx_proposal_id UUID` (nullable, soft reference to agent_tx_proposals — no FK) |
+>
+> The `airdrop_quest_event_status` enum was dropped entirely; both shared-infra plan and stage-3 spec now reflect this. Status values "counted" / "rejected" become `counted = true / false`. Insert SQL parameters become `(tool_call_id, public_key, quest_id, tx_hash, counted, reject_reason, tx_proposal_id)`. The `payload` JSONB column was redundant with `agent_tx_proposals.quest_metadata`; audit consumers should join by `tx_proposal_id` if they need the metadata.
+
+**Why:** Idempotent insert keyed on `tool_call_id`, plus the user-quest mark-complete with `xmax = 0 AS was_inserted` for first-completion detection (per spec response field `quest_completed`), plus a count for the response's `quests_completed` field.
+
+**Files:**
+- Create: `internal/storage/postgres/sqlc/airdrop_quest_events.sql`
+- Create: `internal/storage/postgres/sqlc/airdrop_user_quests.sql`
+- Generated: `internal/storage/postgres/queries/airdrop_quest_events.sql.go` (do not hand-edit)
+- Generated: `internal/storage/postgres/queries/airdrop_user_quests.sql.go` (do not hand-edit)
+
+- [ ] **Step 1: Write the quest-events queries**
+
+Create `internal/storage/postgres/sqlc/airdrop_quest_events.sql`:
+
+```sql
+-- name: InsertQuestEvent :one
+-- Idempotent insert keyed on tool_call_id (the events PK). On conflict, returns
+-- the existing row so the handler can decide what to do (likely nothing — same
+-- tool_call_id means the same broadcast was reported twice, which is a no-op).
+WITH ins AS (
+    INSERT INTO agent_quest_events (tool_call_id, public_key, quest_id, tx_hash, status, reject_reason, payload)
+    VALUES ($1, $2, $3, $4, $5, $6, $7)
+    ON CONFLICT (tool_call_id) DO NOTHING
+    RETURNING *, true AS was_inserted
+)
+SELECT tool_call_id, public_key, quest_id, tx_hash, status, reject_reason, payload, created_at, was_inserted
+FROM ins
+UNION ALL
+SELECT tool_call_id, public_key, quest_id, tx_hash, status, reject_reason, payload, created_at, false AS was_inserted
+FROM agent_quest_events
+WHERE tool_call_id = $1
+  AND NOT EXISTS (SELECT 1 FROM ins)
+LIMIT 1;
+```
+
+- [ ] **Step 2: Write the user-quests queries**
+
+Create `internal/storage/postgres/sqlc/airdrop_user_quests.sql`:
+
+```sql
+-- name: MarkUserQuestComplete :one
+-- Marks a quest complete for a user. Returns was_inserted=true on the first
+-- qualifying event for that quest (drives the spec's `quest_completed: true`
+-- response field). xmax = 0 is the canonical Postgres trick for "this row
+-- was just inserted, not pre-existing" inside an INSERT ... ON CONFLICT.
+INSERT INTO agent_user_quests (public_key, quest_id)
+VALUES ($1, $2)
+ON CONFLICT (public_key, quest_id) DO UPDATE SET completed_at = agent_user_quests.completed_at
+RETURNING (xmax = 0) AS was_inserted;
+
+-- name: CountUserQuests :one
+-- Running count of completed quests for the user. Drives the `quests_completed`
+-- response field. Fast PK lookup (covered by the (public_key, quest_id) PK).
+SELECT COUNT(*)::bigint AS count
+FROM agent_user_quests
+WHERE public_key = $1;
+```
+
+`ON CONFLICT DO UPDATE SET completed_at = agent_user_quests.completed_at` is a no-op write that lets `xmax = 0` work as the "fresh insert" detector. `DO NOTHING` would skip the RETURNING clause entirely, leaving us with no rows on the retry path — we'd need a second SELECT to disambiguate. The no-op UPDATE is cheaper.
+
+- [ ] **Step 3: Run sqlc generation**
+
+```bash
+grep -n sqlc Makefile
+```
+
+Use the existing `make sqlc` target if one exists, otherwise:
+
+```bash
+sqlc generate
+```
+
+Expected: two new files appear in `internal/storage/postgres/queries/`:
+- `airdrop_quest_events.sql.go`
+- `airdrop_user_quests.sql.go`
+
+- [ ] **Step 4: Verify generated code compiles**
+
+```bash
+go build ./internal/storage/postgres/...
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/storage/postgres/sqlc/airdrop_quest_events.sql \
+         internal/storage/postgres/sqlc/airdrop_user_quests.sql \
+         internal/storage/postgres/queries/airdrop_quest_events.sql.go \
+         internal/storage/postgres/queries/airdrop_user_quests.sql.go
+git commit -m "feat(airdrop): add sqlc queries for quest events + user quests"
+```
+
+---
+
+## Task 2: `QuestEventRepository` wrapping the queries
+
+**Why:** Map sqlc-generated types to plain Go domain types, same pattern as `internal/storage/postgres/conversation.go`. Two methods (`InsertEvent`, `MarkComplete`) plus a count helper.
+
+**Files:**
+- Create: `internal/storage/postgres/airdrop_quest_event.go`
+- Create: `internal/storage/postgres/airdrop_quest_event_test.go`
+- Modify: `internal/types/airdrop.go` (add quest types — file already exists from Stage 1)
+
+- [ ] **Step 1: Add domain types**
+
+Append to `internal/types/airdrop.go` (Stage 1 created this file with `RegistrationSource` etc.; if Stage 1 hasn't merged yet, create the file with just these types):
+
+```go
+// QuestID is the canonical identifier for one of the five Vultiverse quests.
+// Mirrors the airdrop_quest_id Postgres enum.
+type QuestID string
+
+const (
+	QuestSwap       QuestID = "swap"
+	QuestBridge     QuestID = "bridge"
+	QuestDefiAction QuestID = "defi_action"
+	QuestAlert      QuestID = "alert"
+	QuestDCA        QuestID = "dca"
+)
+
+// AllQuestIDs is the canonical list, in display order. Match the Stage 1
+// helper if both files end up defining a list — these should be identical.
+var AllQuestIDs = []QuestID{QuestSwap, QuestBridge, QuestDefiAction, QuestAlert, QuestDCA}
+
+func (q QuestID) Valid() bool {
+	switch q {
+	case QuestSwap, QuestBridge, QuestDefiAction, QuestAlert, QuestDCA:
+		return true
+	}
+	return false
+}
+
+// QuestEventStatus mirrors the airdrop_quest_event_status Postgres enum.
+type QuestEventStatus string
+
+const (
+	QuestEventCounted  QuestEventStatus = "counted"
+	QuestEventRejected QuestEventStatus = "rejected"
+)
+
+// QuestEvent is the domain representation of one row in agent_quest_events.
+type QuestEvent struct {
+	ToolCallID   string
+	PublicKey    string
+	QuestID      QuestID
+	TxHash       string
+	Status       QuestEventStatus
+	RejectReason string // empty unless Status == QuestEventRejected
+	Payload      []byte // raw JSONB
+	CreatedAt    time.Time
+	WasInserted  bool   // true if this call inserted; false if existing row returned
+}
+```
+
+- [ ] **Step 2: Write the repo test**
+
+Create `internal/storage/postgres/airdrop_quest_event_test.go`. Use the same `newTestPool` helper Stage 1 added in `airdrop_registration_test.go` — copy that helper inline if Stage 1 hasn't merged yet:
+
+```go
+package postgres_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/vultisig/agent-backend/internal/storage/postgres"
+	"github.com/vultisig/agent-backend/internal/types"
+)
+
+func newQuestTestPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	dsn := os.Getenv("TEST_DATABASE_DSN")
+	if dsn == "" {
+		dsn = os.Getenv("DATABASE_DSN")
+	}
+	if dsn == "" {
+		t.Skip("TEST_DATABASE_DSN or DATABASE_DSN not set")
+	}
+	pool, err := pgxpool.New(context.Background(), dsn)
+	if err != nil {
+		t.Fatalf("pgxpool.New: %v", err)
+	}
+	t.Cleanup(func() { pool.Close() })
+	_, err = pool.Exec(context.Background(), `
+		TRUNCATE agent_quest_events;
+		TRUNCATE agent_user_quests;
+	`)
+	if err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+	return pool
+}
+
+func TestQuestEventRepo_InsertEventIsIdempotent(t *testing.T) {
+	pool := newQuestTestPool(t)
+	repo := postgres.NewQuestEventRepository(pool)
+	ctx := context.Background()
+
+	first, err := repo.InsertEvent(ctx, postgres.InsertQuestEventParams{
+		ToolCallID:   "call-abc",
+		PublicKey:    "pk1",
+		QuestID:      types.QuestSwap,
+		TxHash:       "0xdead",
+		Status:       types.QuestEventCounted,
+		RejectReason: "",
+		Payload:      []byte(`{"amount_usd":42}`),
+	})
+	if err != nil {
+		t.Fatalf("first insert: %v", err)
+	}
+	if !first.WasInserted {
+		t.Errorf("first call should be a fresh insert")
+	}
+
+	second, err := repo.InsertEvent(ctx, postgres.InsertQuestEventParams{
+		ToolCallID:   "call-abc",
+		PublicKey:    "pk1",
+		QuestID:      types.QuestSwap,
+		TxHash:       "0xdead",
+		Status:       types.QuestEventCounted,
+		RejectReason: "",
+		Payload:      []byte(`{"amount_usd":42}`),
+	})
+	if err != nil {
+		t.Fatalf("second insert: %v", err)
+	}
+	if second.WasInserted {
+		t.Errorf("second call should be a no-op (idempotent retry)")
+	}
+	if second.ToolCallID != first.ToolCallID {
+		t.Errorf("idempotent retry should return same row; got %q vs %q", second.ToolCallID, first.ToolCallID)
+	}
+}
+
+func TestQuestEventRepo_MarkCompleteFirstTimeOnly(t *testing.T) {
+	pool := newQuestTestPool(t)
+	repo := postgres.NewQuestEventRepository(pool)
+	ctx := context.Background()
+
+	first, err := repo.MarkComplete(ctx, "pk1", types.QuestSwap)
+	if err != nil {
+		t.Fatalf("MarkComplete first: %v", err)
+	}
+	if !first {
+		t.Errorf("first MarkComplete should report was_inserted=true")
+	}
+
+	second, err := repo.MarkComplete(ctx, "pk1", types.QuestSwap)
+	if err != nil {
+		t.Fatalf("MarkComplete second: %v", err)
+	}
+	if second {
+		t.Errorf("second MarkComplete (already-complete quest) should report was_inserted=false")
+	}
+}
+
+func TestQuestEventRepo_CountUserQuests(t *testing.T) {
+	pool := newQuestTestPool(t)
+	repo := postgres.NewQuestEventRepository(pool)
+	ctx := context.Background()
+
+	if got, err := repo.CountUserQuests(ctx, "pk1"); err != nil || got != 0 {
+		t.Errorf("empty count = %d, err = %v; want 0, nil", got, err)
+	}
+
+	_, _ = repo.MarkComplete(ctx, "pk1", types.QuestSwap)
+	_, _ = repo.MarkComplete(ctx, "pk1", types.QuestBridge)
+	_, _ = repo.MarkComplete(ctx, "pk1", types.QuestSwap) // duplicate, doesn't bump count
+
+	got, err := repo.CountUserQuests(ctx, "pk1")
+	if err != nil {
+		t.Fatalf("CountUserQuests: %v", err)
+	}
+	if got != 2 {
+		t.Errorf("count = %d, want 2", got)
+	}
+}
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+```bash
+go test ./internal/storage/postgres/ -run TestQuestEventRepo -v
+```
+
+Expected: compile error — `NewQuestEventRepository`, `InsertQuestEventParams` undefined.
+
+- [ ] **Step 4: Implement the repository**
+
+Create `internal/storage/postgres/airdrop_quest_event.go`. Match `conversation.go`'s pattern (struct holding `pool` + `q`, `New...Repository(pool)` constructor):
+
+```go
+package postgres
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/vultisig/agent-backend/internal/storage/postgres/queries"
+	"github.com/vultisig/agent-backend/internal/types"
+)
+
+// QuestEventRepository wraps the sqlc-generated quest event + user quest queries
+// with domain-typed methods.
+type QuestEventRepository struct {
+	pool *pgxpool.Pool
+	q    *queries.Queries
+}
+
+func NewQuestEventRepository(pool *pgxpool.Pool) *QuestEventRepository {
+	return &QuestEventRepository{
+		pool: pool,
+		q:    queries.New(pool),
+	}
+}
+
+// InsertQuestEventParams is the input shape for InsertEvent. Mirrors the spec's
+// `agent_quest_events` row 1:1 except for created_at (DB default).
+type InsertQuestEventParams struct {
+	ToolCallID   string
+	PublicKey    string
+	QuestID      types.QuestID
+	TxHash       string
+	Status       types.QuestEventStatus
+	RejectReason string // empty for counted events
+	Payload      []byte // raw JSONB
+}
+
+// InsertEvent inserts an event, idempotent on tool_call_id. On conflict returns
+// the existing row with WasInserted = false.
+func (r *QuestEventRepository) InsertEvent(ctx context.Context, p InsertQuestEventParams) (*types.QuestEvent, error) {
+	var rejectReason *string
+	if p.RejectReason != "" {
+		rejectReason = &p.RejectReason
+	}
+	row, err := r.q.InsertQuestEvent(ctx, &queries.InsertQuestEventParams{
+		ToolCallID:   p.ToolCallID,
+		PublicKey:    p.PublicKey,
+		QuestID:      queries.AirdropQuestID(p.QuestID),
+		TxHash:       p.TxHash,
+		Status:       queries.AirdropQuestEventStatus(p.Status),
+		RejectReason: rejectReason,
+		Payload:      p.Payload,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("insert quest event: %w", err)
+	}
+	out := &types.QuestEvent{
+		ToolCallID:  row.ToolCallID,
+		PublicKey:   row.PublicKey,
+		QuestID:     types.QuestID(row.QuestID),
+		TxHash:      row.TxHash,
+		Status:      types.QuestEventStatus(row.Status),
+		Payload:     row.Payload,
+		CreatedAt:   pgtimestamptzToTime(row.CreatedAt),
+		WasInserted: row.WasInserted,
+	}
+	if row.RejectReason != nil {
+		out.RejectReason = *row.RejectReason
+	}
+	return out, nil
+}
+
+// MarkComplete records that publicKey has completed questID. Returns true on the
+// first qualifying call (so the caller can populate the spec's `quest_completed`
+// response flag) and false for already-complete quests (subsequent qualifying events).
+func (r *QuestEventRepository) MarkComplete(ctx context.Context, publicKey string, questID types.QuestID) (bool, error) {
+	wasInserted, err := r.q.MarkUserQuestComplete(ctx, &queries.MarkUserQuestCompleteParams{
+		PublicKey: publicKey,
+		QuestID:   queries.AirdropQuestID(questID),
+	})
+	if err != nil {
+		return false, fmt.Errorf("mark user quest complete: %w", err)
+	}
+	return wasInserted, nil
+}
+
+// CountUserQuests returns the running count of completed quests for the user.
+func (r *QuestEventRepository) CountUserQuests(ctx context.Context, publicKey string) (int64, error) {
+	n, err := r.q.CountUserQuests(ctx, publicKey)
+	if err != nil {
+		return 0, fmt.Errorf("count user quests: %w", err)
+	}
+	return n, nil
+}
+```
+
+The exact name of the sqlc-generated enum types (e.g. `queries.AirdropQuestID`, `queries.AirdropQuestEventStatus`) and the `pgtimestamptzToTime` helper depend on what sqlc generated and what `conversation.go` uses today. Open `internal/storage/postgres/queries/airdrop_quest_events.sql.go` to confirm the type names; copy the timestamp helper from `conversation.go`.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+DATABASE_DSN="$DATABASE_DSN" go test ./internal/storage/postgres/ -run TestQuestEventRepo -v
+```
+
+Expected: PASS for all three subtests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/storage/postgres/airdrop_quest_event.go \
+         internal/storage/postgres/airdrop_quest_event_test.go \
+         internal/types/airdrop.go
+git commit -m "feat(airdrop): add QuestEventRepository wrapping sqlc queries"
+```
+
+---
+
+## Task 3: Per-quest validators (3 real, 2 stubs)
+
+> **Field-name update (2026-04-23):** the validator inputs now match the `quest_metadata` JSONB shape locked in Task 0, not the original spec's free-form `data` field. Apply this rename across all test fixtures and the implementations in this task:
+>
+> | Old field | New field (from `quest_metadata`) |
+> |---|---|
+> | `token_in` | `token_in_symbol` |
+> | `token_out` | `token_out_symbol` |
+> | `chain_id` | `source_chain_id` (and `dest_chain_id` for bridge) |
+> | `contract_address` | `target_contract` |
+> | `amount_usd`, `router_address` | unchanged |
+>
+> **Swap validator** additionally must assert `source_chain_id == dest_chain_id` (same-chain swap; otherwise it's a bridge — dispatched there instead). **Bridge validator** asserts `source_chain_id != dest_chain_id`. **DeFi-action validator** does a lowercase compare of `target_contract` against the `DEFI_ACTION_CONTRACT_ALLOWLIST` (config is lowercased at parse time per Stage 3 spec).
+>
+> All other validator structure (Result type, Pass/Reject helpers, file layout, test patterns) is unchanged. Apply the renames as you copy the test fixtures and the implementations from the steps below.
+
+**Why:** One file per quest type keeps each validator's rules in one place. Pure functions (`quest_metadata` map + relevant config slice → `(qualifies, reason)`) are trivial to unit-test for boundary cases and have no dependency on Postgres or HTTP.
+
+**Files:**
+- Create: `internal/service/airdrop/quests/validators/types.go` (shared types)
+- Create: `internal/service/airdrop/quests/validators/swap.go` + `swap_test.go`
+- Create: `internal/service/airdrop/quests/validators/bridge.go` + `bridge_test.go`
+- Create: `internal/service/airdrop/quests/validators/defi_action.go` + `defi_action_test.go`
+- Create: `internal/service/airdrop/quests/validators/alert.go` (stub — no test needed; trivial)
+- Create: `internal/service/airdrop/quests/validators/dca.go` (stub — no test needed)
+
+- [ ] **Step 1: Define shared types**
+
+Create `internal/service/airdrop/quests/validators/types.go`:
+
+```go
+// Package validators holds per-quest validators for the Vultiverse Airdrop.
+// Each validator is a pure function: given a JSONB payload (the request body's
+// `data` field) and the relevant slice of config, return whether the action
+// qualifies for the quest plus a structured rejection reason for logging.
+//
+// New quests slot in via two changes: a file in this package (the validator)
+// and an entry in `quests/dispatch.go` (the dispatch-table mapping).
+package validators
+
+// Result is the validator's verdict on a single payload.
+type Result struct {
+	// Qualifies is true if the payload meets the quest's rules.
+	Qualifies bool
+	// Reason is a short snake_case identifier for why the payload was rejected.
+	// Empty when Qualifies == true. Examples: "amount_below_min",
+	// "router_not_allowlisted", "same_chain_bridge", "not_yet_implemented".
+	Reason string
+}
+
+// Pass is the canonical "qualified" result.
+var Pass = Result{Qualifies: true, Reason: ""}
+
+// Reject builds a rejected result with the given reason.
+func Reject(reason string) Result {
+	return Result{Qualifies: false, Reason: reason}
+}
+```
+
+- [ ] **Step 2: Write the swap validator test**
+
+Create `internal/service/airdrop/quests/validators/swap_test.go`:
+
+```go
+package validators
+
+import "testing"
+
+func TestSwap(t *testing.T) {
+	cases := []struct {
+		name      string
+		payload   []byte
+		minUSD    int
+		want      bool
+		reason    string
+	}{
+		{
+			name:    "exact min usd → qualifies",
+			payload: []byte(`{"amount_usd":10,"token_in":"USDC","token_out":"ETH","chain_id":1,"router_address":"0xabc"}`),
+			minUSD:  10,
+			want:    true,
+		},
+		{
+			name:    "above min → qualifies",
+			payload: []byte(`{"amount_usd":12.5,"token_in":"USDC","token_out":"ETH","chain_id":1,"router_address":"0xabc"}`),
+			minUSD:  10,
+			want:    true,
+		},
+		{
+			name:    "below min → rejected with amount_below_min",
+			payload: []byte(`{"amount_usd":9.99,"token_in":"USDC","token_out":"ETH","chain_id":1,"router_address":"0xabc"}`),
+			minUSD:  10,
+			want:    false, reason: "amount_below_min",
+		},
+		{
+			name:    "missing amount_usd → rejected",
+			payload: []byte(`{"token_in":"USDC","token_out":"ETH","chain_id":1,"router_address":"0xabc"}`),
+			minUSD:  10,
+			want:    false, reason: "missing_amount_usd",
+		},
+		{
+			name:    "missing router_address → rejected",
+			payload: []byte(`{"amount_usd":15,"token_in":"USDC","token_out":"ETH","chain_id":1}`),
+			minUSD:  10,
+			want:    false, reason: "missing_router_address",
+		},
+		{
+			name:    "malformed JSON → rejected",
+			payload: []byte(`{not-json`),
+			minUSD:  10,
+			want:    false, reason: "invalid_payload",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Swap(tc.payload, tc.minUSD)
+			if got.Qualifies != tc.want {
+				t.Errorf("Qualifies = %v, want %v (reason=%q)", got.Qualifies, tc.want, got.Reason)
+			}
+			if !tc.want && got.Reason != tc.reason {
+				t.Errorf("Reason = %q, want %q", got.Reason, tc.reason)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 3: Run swap test to verify it fails**
+
+```bash
+go test ./internal/service/airdrop/quests/validators/ -run TestSwap -v
+```
+
+Expected: compile error — `Swap` undefined.
+
+- [ ] **Step 4: Implement swap validator**
+
+Create `internal/service/airdrop/quests/validators/swap.go`:
+
+```go
+package validators
+
+import "encoding/json"
+
+// swapPayload is the documented `data` shape for swap quest events.
+// Spec: docs/airdrop-specs/stage-3-quest-tracking.md, "Per-quest data payloads".
+type swapPayload struct {
+	AmountUSD     *float64 `json:"amount_usd"`
+	TokenIn       string   `json:"token_in"`
+	TokenOut      string   `json:"token_out"`
+	ChainID       int      `json:"chain_id"`
+	RouterAddress string   `json:"router_address"`
+}
+
+// Swap qualifies if the payload's amount_usd >= minUSD AND the router address
+// is non-empty. Router-allowlist enforcement is intentionally out of scope for
+// the swap quest (see spec): the swap MCP tool's whitelist of integrated
+// providers IS the allowlist; if `build_swap_tx` produced the tx then the
+// router is by construction one we trust. We capture the address for audit.
+func Swap(rawPayload []byte, minUSD int) Result {
+	var p swapPayload
+	if err := json.Unmarshal(rawPayload, &p); err != nil {
+		return Reject("invalid_payload")
+	}
+	if p.AmountUSD == nil {
+		return Reject("missing_amount_usd")
+	}
+	if p.RouterAddress == "" {
+		return Reject("missing_router_address")
+	}
+	if *p.AmountUSD < float64(minUSD) {
+		return Reject("amount_below_min")
+	}
+	return Pass
+}
+```
+
+- [ ] **Step 5: Run swap test to verify it passes**
+
+```bash
+go test ./internal/service/airdrop/quests/validators/ -run TestSwap -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Write the bridge validator test**
+
+Create `internal/service/airdrop/quests/validators/bridge_test.go`:
+
+```go
+package validators
+
+import "testing"
+
+func TestBridge(t *testing.T) {
+	cases := []struct {
+		name    string
+		payload []byte
+		minUSD  int
+		want    bool
+		reason  string
+	}{
+		{
+			name:    "valid cross-chain at min → qualifies",
+			payload: []byte(`{"amount_usd":10,"source_chain_id":1,"dest_chain_id":42161}`),
+			minUSD:  10, want: true,
+		},
+		{
+			name:    "same chain → rejected with same_chain_bridge",
+			payload: []byte(`{"amount_usd":50,"source_chain_id":1,"dest_chain_id":1}`),
+			minUSD:  10, want: false, reason: "same_chain_bridge",
+		},
+		{
+			name:    "below min → rejected",
+			payload: []byte(`{"amount_usd":5,"source_chain_id":1,"dest_chain_id":42161}`),
+			minUSD:  10, want: false, reason: "amount_below_min",
+		},
+		{
+			name:    "missing source_chain_id → rejected",
+			payload: []byte(`{"amount_usd":15,"dest_chain_id":42161}`),
+			minUSD:  10, want: false, reason: "missing_source_chain_id",
+		},
+		{
+			name:    "missing dest_chain_id → rejected",
+			payload: []byte(`{"amount_usd":15,"source_chain_id":1}`),
+			minUSD:  10, want: false, reason: "missing_dest_chain_id",
+		},
+		{
+			name:    "malformed JSON → rejected",
+			payload: []byte(`x`),
+			minUSD:  10, want: false, reason: "invalid_payload",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Bridge(tc.payload, tc.minUSD)
+			if got.Qualifies != tc.want {
+				t.Errorf("Qualifies = %v, want %v (reason=%q)", got.Qualifies, tc.want, got.Reason)
+			}
+			if !tc.want && got.Reason != tc.reason {
+				t.Errorf("Reason = %q, want %q", got.Reason, tc.reason)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 7: Implement bridge validator**
+
+Create `internal/service/airdrop/quests/validators/bridge.go`:
+
+```go
+package validators
+
+import "encoding/json"
+
+type bridgePayload struct {
+	AmountUSD     *float64 `json:"amount_usd"`
+	SourceChainID *int     `json:"source_chain_id"`
+	DestChainID   *int     `json:"dest_chain_id"`
+}
+
+// Bridge qualifies if amount_usd >= minUSD AND source_chain_id != dest_chain_id.
+func Bridge(rawPayload []byte, minUSD int) Result {
+	var p bridgePayload
+	if err := json.Unmarshal(rawPayload, &p); err != nil {
+		return Reject("invalid_payload")
+	}
+	if p.AmountUSD == nil {
+		return Reject("missing_amount_usd")
+	}
+	if p.SourceChainID == nil {
+		return Reject("missing_source_chain_id")
+	}
+	if p.DestChainID == nil {
+		return Reject("missing_dest_chain_id")
+	}
+	if *p.SourceChainID == *p.DestChainID {
+		return Reject("same_chain_bridge")
+	}
+	if *p.AmountUSD < float64(minUSD) {
+		return Reject("amount_below_min")
+	}
+	return Pass
+}
+```
+
+- [ ] **Step 8: Write the defi-action validator test**
+
+Create `internal/service/airdrop/quests/validators/defi_action_test.go`:
+
+```go
+package validators
+
+import "testing"
+
+func TestDefiAction(t *testing.T) {
+	allow := []string{
+		"0x1111111111111111111111111111111111111111",
+		"0x2222222222222222222222222222222222222222",
+	}
+
+	cases := []struct {
+		name      string
+		payload   []byte
+		allowlist []string
+		want      bool
+		reason    string
+	}{
+		{
+			name:      "contract on allowlist → qualifies",
+			payload:   []byte(`{"contract_address":"0x1111111111111111111111111111111111111111","chain_id":1,"method":"deposit"}`),
+			allowlist: allow, want: true,
+		},
+		{
+			name:      "case-insensitive match → qualifies",
+			payload:   []byte(`{"contract_address":"0X1111111111111111111111111111111111111111","chain_id":1,"method":"deposit"}`),
+			allowlist: allow, want: true,
+		},
+		{
+			name:      "contract not on allowlist → rejected",
+			payload:   []byte(`{"contract_address":"0x9999999999999999999999999999999999999999","chain_id":1,"method":"deposit"}`),
+			allowlist: allow, want: false, reason: "contract_not_allowlisted",
+		},
+		{
+			name:      "missing contract_address → rejected",
+			payload:   []byte(`{"chain_id":1,"method":"deposit"}`),
+			allowlist: allow, want: false, reason: "missing_contract_address",
+		},
+		{
+			name:      "empty allowlist → all rejected",
+			payload:   []byte(`{"contract_address":"0x1111111111111111111111111111111111111111","chain_id":1,"method":"deposit"}`),
+			allowlist: []string{}, want: false, reason: "contract_not_allowlisted",
+		},
+		{
+			name:      "malformed JSON → rejected",
+			payload:   []byte(`{`),
+			allowlist: allow, want: false, reason: "invalid_payload",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := DefiAction(tc.payload, tc.allowlist)
+			if got.Qualifies != tc.want {
+				t.Errorf("Qualifies = %v, want %v (reason=%q)", got.Qualifies, tc.want, got.Reason)
+			}
+			if !tc.want && got.Reason != tc.reason {
+				t.Errorf("Reason = %q, want %q", got.Reason, tc.reason)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 9: Implement defi-action validator**
+
+Create `internal/service/airdrop/quests/validators/defi_action.go`:
+
+```go
+package validators
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+type defiActionPayload struct {
+	ContractAddress string `json:"contract_address"`
+	ChainID         int    `json:"chain_id"`
+	Method          string `json:"method"`
+}
+
+// DefiAction qualifies if contract_address (case-insensitive) is in the allowlist.
+// Allowlist comes from cfg.Airdrop.DefiActionContractAllowlist (a comma-separated
+// string in env, normalized to []string at boot).
+func DefiAction(rawPayload []byte, allowlist []string) Result {
+	var p defiActionPayload
+	if err := json.Unmarshal(rawPayload, &p); err != nil {
+		return Reject("invalid_payload")
+	}
+	if p.ContractAddress == "" {
+		return Reject("missing_contract_address")
+	}
+	target := strings.ToLower(p.ContractAddress)
+	for _, addr := range allowlist {
+		if strings.ToLower(strings.TrimSpace(addr)) == target {
+			return Pass
+		}
+	}
+	return Reject("contract_not_allowlisted")
+}
+```
+
+- [ ] **Step 10: Implement alert + dca stubs**
+
+Create `internal/service/airdrop/quests/validators/alert.go`:
+
+```go
+package validators
+
+// Alert is a stub validator. The alert quest's rules are TBD with Product
+// (per stage-0-preflight decisions). Wiring exists end-to-end so the rules
+// are a one-file change here when Product locks them — the dispatch-table
+// entry doesn't need to change.
+//
+// Until then: every alert event is recorded with status='rejected' and
+// reason='not_yet_implemented' (audit-trail visible to Product so they can
+// see the volume of would-have-counted events).
+func Alert(_ []byte) Result {
+	return Reject("not_yet_implemented")
+}
+```
+
+Create `internal/service/airdrop/quests/validators/dca.go`:
+
+```go
+package validators
+
+// DCA is a stub validator. See Alert for the same rationale: rules TBD with
+// Product, wiring is in place, every event recorded as rejected with
+// reason='not_yet_implemented'.
+func DCA(_ []byte) Result {
+	return Reject("not_yet_implemented")
+}
+```
+
+- [ ] **Step 11: Run all validator tests**
+
+```bash
+go test ./internal/service/airdrop/quests/validators/ -v
+```
+
+Expected: PASS for `TestSwap`, `TestBridge`, `TestDefiAction`. Stubs have no tests (function body is one line).
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add internal/service/airdrop/quests/validators/
+git commit -m "feat(airdrop): add per-quest validators (swap/bridge/defi_action + alert/dca stubs)"
+```
+
+---
+
+## Task 4: Quest dispatch table
+
+> **2026-04-23 update:** the `tool_name → quest_type` map is the *primary* dispatch (per the Cross-team contract from Task 0). For `build_swap_tx` specifically, the resolution depends on whether the tx is same-chain (swap) or cross-chain (bridge) — so the dispatcher inspects `quest_metadata.source_chain_id` vs `quest_metadata.dest_chain_id`. Reference shape:
+>
+> ```go
+> // QuestForTool returns the quest_type this tool maps to, or "" if none.
+> // Reads quest_metadata for the swap-vs-bridge resolution.
+> func QuestForTool(toolName string, meta map[string]any) string {
+>     switch toolName {
+>     case "build_swap_tx":
+>         srcRaw, dstRaw := meta["source_chain_id"], meta["dest_chain_id"]
+>         if asInt(srcRaw) == asInt(dstRaw) {
+>             return "swap"
+>         }
+>         return "bridge"
+>     case "build_bridge_tx":
+>         return "bridge"
+>     case "build_evm_tx":
+>         return "defi_action"
+>     default:
+>         return ""
+>     }
+> }
+> ```
+>
+> Add `QuestForTool` (and a small `asInt` helper) to `dispatch.go` alongside the existing `quest_type → validator` map. The TestDispatch tests should cover: each mapped tool, the swap-vs-bridge resolution by chain ID, and an unmapped tool returning "".
+
+**Why:** One Go file mapping `quest_type → validator function` AND `tool_name → quest_type`. Adding a new quest is a one-file change here; the event handler and the tx-proposal hook both consume this mapping.
+
+**Files:**
+- Create: `internal/service/airdrop/quests/dispatch.go`
+- Create: `internal/service/airdrop/quests/dispatch_test.go`
+
+- [ ] **Step 1: Write the dispatch test**
+
+Create `internal/service/airdrop/quests/dispatch_test.go`:
+
+```go
+package quests
+
+import (
+	"testing"
+
+	"github.com/vultisig/agent-backend/internal/types"
+)
+
+func TestQuestTypeForTool(t *testing.T) {
+	cases := []struct {
+		toolName string
+		want     types.QuestID
+		wantOK   bool
+	}{
+		{"build_swap_tx", types.QuestSwap, true},
+		{"build_bridge_tx", types.QuestBridge, true},
+		{"build_evm_tx", types.QuestDefiAction, true},
+		{"build_send_tx", "", false},   // sends don't count toward any quest
+		{"get_balances", "", false},    // read-only tools never count
+		{"", "", false},
+	}
+	for _, tc := range cases {
+		got, ok := QuestTypeForTool(tc.toolName)
+		if ok != tc.wantOK {
+			t.Errorf("QuestTypeForTool(%q) ok = %v, want %v", tc.toolName, ok, tc.wantOK)
+		}
+		if got != tc.want {
+			t.Errorf("QuestTypeForTool(%q) = %q, want %q", tc.toolName, got, tc.want)
+		}
+	}
+}
+
+func TestValidate_DispatchesByQuestType(t *testing.T) {
+	cfg := DispatchConfig{
+		SwapQuestMinUSD:             10,
+		BridgeQuestMinUSD:           10,
+		DefiActionContractAllowlist: []string{"0xabc"},
+	}
+
+	swapPayload := []byte(`{"amount_usd":15,"token_in":"USDC","token_out":"ETH","chain_id":1,"router_address":"0xrouter"}`)
+	res, err := Validate(types.QuestSwap, swapPayload, cfg)
+	if err != nil {
+		t.Fatalf("validate swap: %v", err)
+	}
+	if !res.Qualifies {
+		t.Errorf("expected swap to qualify, got %+v", res)
+	}
+
+	bridgePayload := []byte(`{"amount_usd":15,"source_chain_id":1,"dest_chain_id":42161}`)
+	res, err = Validate(types.QuestBridge, bridgePayload, cfg)
+	if err != nil || !res.Qualifies {
+		t.Errorf("bridge: %+v, err=%v", res, err)
+	}
+
+	// Unknown quest type → error
+	if _, err := Validate(types.QuestID("invalid"), []byte(`{}`), cfg); err == nil {
+		t.Error("expected error for unknown quest type")
+	}
+
+	// Stub returns rejected
+	res, err = Validate(types.QuestAlert, []byte(`{}`), cfg)
+	if err != nil {
+		t.Fatalf("alert: %v", err)
+	}
+	if res.Qualifies || res.Reason != "not_yet_implemented" {
+		t.Errorf("alert stub: got %+v, want rejected/not_yet_implemented", res)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+go test ./internal/service/airdrop/quests/ -run "TestQuestTypeForTool|TestValidate_DispatchesByQuestType" -v
+```
+
+Expected: compile error.
+
+- [ ] **Step 3: Implement the dispatch table**
+
+Create `internal/service/airdrop/quests/dispatch.go`:
+
+```go
+package quests
+
+import (
+	"fmt"
+
+	"github.com/vultisig/agent-backend/internal/service/airdrop/quests/validators"
+	"github.com/vultisig/agent-backend/internal/types"
+)
+
+// toolToQuest maps the agent's tool names to the quest type they trigger.
+// This is the ONE place to update when a new triggering tool ships.
+//
+// Mapping rationale:
+//   - build_swap_tx       → swap (the canonical swap MCP tool; see
+//                           internal/service/agent/prompt.go for the prompt
+//                           guidance the LLM follows)
+//   - build_bridge_tx     → bridge (cross-chain via the bridge MCP tool)
+//   - build_evm_tx        → defi_action (any EVM tx that's not a send;
+//                           the validator filters by contract allowlist so
+//                           a vanilla ETH transfer to a friend doesn't count)
+//
+// build_send_tx, build_btc_send, build_solana_tx, build_sui_send, build_ton_send,
+// sign_typed_data, etc. are intentionally absent — sends and signatures don't
+// qualify for any quest in the launch v1 list.
+var toolToQuest = map[string]types.QuestID{
+	"build_swap_tx":   types.QuestSwap,
+	"build_bridge_tx": types.QuestBridge,
+	"build_evm_tx":    types.QuestDefiAction,
+}
+
+// QuestTypeForTool returns the quest type a given tool name triggers, or
+// (zero, false) if the tool isn't quest-relevant.
+func QuestTypeForTool(toolName string) (types.QuestID, bool) {
+	q, ok := toolToQuest[toolName]
+	return q, ok
+}
+
+// DispatchConfig is the slice of cfg.Airdrop the validators need. Passed
+// explicitly (rather than imported) so this package stays free of import
+// cycles with internal/config.
+type DispatchConfig struct {
+	SwapQuestMinUSD             int
+	BridgeQuestMinUSD           int
+	DefiActionContractAllowlist []string
+}
+
+// FromAirdropConfig converts the comma-separated allowlist string from the
+// config struct into a slice. Call this once at boot and pass the result
+// into the handler — splitting per-request would be wasteful.
+func FromAirdropConfig(swapMinUSD, bridgeMinUSD int, defiAllowlistCSV string) DispatchConfig {
+	var allow []string
+	if defiAllowlistCSV != "" {
+		// Manual split to keep imports tight; equivalent to strings.Split + trim.
+		var current []byte
+		for i := 0; i <= len(defiAllowlistCSV); i++ {
+			if i == len(defiAllowlistCSV) || defiAllowlistCSV[i] == ',' {
+				if len(current) > 0 {
+					allow = append(allow, string(current))
+					current = current[:0]
+				}
+				continue
+			}
+			c := defiAllowlistCSV[i]
+			if c == ' ' || c == '\t' {
+				continue
+			}
+			current = append(current, c)
+		}
+	}
+	return DispatchConfig{
+		SwapQuestMinUSD:             swapMinUSD,
+		BridgeQuestMinUSD:           bridgeMinUSD,
+		DefiActionContractAllowlist: allow,
+	}
+}
+
+// Validate dispatches to the per-quest validator. Returns the validator's
+// Result. Returns an error only for unknown quest types — that's a programmer
+// bug (the handler validated the enum already), not a per-event failure.
+func Validate(questID types.QuestID, payload []byte, cfg DispatchConfig) (validators.Result, error) {
+	switch questID {
+	case types.QuestSwap:
+		return validators.Swap(payload, cfg.SwapQuestMinUSD), nil
+	case types.QuestBridge:
+		return validators.Bridge(payload, cfg.BridgeQuestMinUSD), nil
+	case types.QuestDefiAction:
+		return validators.DefiAction(payload, cfg.DefiActionContractAllowlist), nil
+	case types.QuestAlert:
+		return validators.Alert(payload), nil
+	case types.QuestDCA:
+		return validators.DCA(payload), nil
+	default:
+		return validators.Result{}, fmt.Errorf("unknown quest type: %q", questID)
+	}
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+go test ./internal/service/airdrop/quests/ -run "TestQuestTypeForTool|TestValidate_DispatchesByQuestType" -v
+```
+
+Expected: PASS for both.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/service/airdrop/quests/dispatch.go \
+         internal/service/airdrop/quests/dispatch_test.go
+git commit -m "feat(airdrop): add quest dispatch table (tool→type, type→validator)"
+```
+
+---
+
+## Task 5: `POST /internal/quests/event` handler
+
+> **2026-04-23 update:** the request body now carries `tool_name` + `quest_metadata` (forwarded from the agent-backend's signed proposal). The handler resolves quest_type via `quests.QuestForTool(tool_name, quest_metadata)`. If unmapped, return 200 with `{"recorded": false}` — not an error. New request shape:
+>
+> ```json
+> {
+>   "public_key":     "...",
+>   "tool_call_id":   "<proposal_uuid>",
+>   "tx_hash":        "0x...",
+>   "tool_name":      "build_swap_tx",
+>   "quest_metadata": { "amount_usd": 25.5, "token_in_symbol": "USDC", ... }
+> }
+> ```
+>
+> The handler then passes `quest_metadata` (as `map[string]any`) to the resolved validator. Update the request struct, the dispatch call, and any test fixtures accordingly. The 400 error key changes from `INVALID_QUEST_TYPE` to `MISSING_FIELDS` (per the updated spec) — quest_type is no longer in the request envelope.
+
+**Why:** The single ingestion endpoint. Validates envelope, gates on activation timestamp, dispatches to the right validator, persists event + (if qualifying) marks the quest complete.
+
+**Files:**
+- Create: `internal/api/airdrop_quest_event.go`
+- Create: `internal/api/airdrop_quest_event_test.go`
+- Modify: `internal/api/server.go` (add `questEventRepo` field + setter)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/api/airdrop_quest_event_test.go`:
+
+```go
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/vultisig/agent-backend/internal/service/airdrop/quests"
+	"github.com/vultisig/agent-backend/internal/storage/postgres"
+	"github.com/vultisig/agent-backend/internal/types"
+)
+
+// fakeQuestRepo lets us exercise the handler without Postgres.
+type fakeQuestRepo struct {
+	insertEvent   func(ctx context.Context, p postgres.InsertQuestEventParams) (*types.QuestEvent, error)
+	markComplete  func(ctx context.Context, pk string, q types.QuestID) (bool, error)
+	countComplete func(ctx context.Context, pk string) (int64, error)
+}
+
+func (f *fakeQuestRepo) InsertEvent(ctx context.Context, p postgres.InsertQuestEventParams) (*types.QuestEvent, error) {
+	return f.insertEvent(ctx, p)
+}
+func (f *fakeQuestRepo) MarkComplete(ctx context.Context, pk string, q types.QuestID) (bool, error) {
+	return f.markComplete(ctx, pk, q)
+}
+func (f *fakeQuestRepo) CountUserQuests(ctx context.Context, pk string) (int64, error) {
+	return f.countComplete(ctx, pk)
+}
+
+func TestQuestEventHandler(t *testing.T) {
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	activation := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC) // before `now`
+
+	type recordedInsert struct {
+		params postgres.InsertQuestEventParams
+		called bool
+	}
+	type recordedMark struct {
+		pk     string
+		quest  types.QuestID
+		called bool
+	}
+
+	cases := []struct {
+		name           string
+		body           string
+		now            time.Time
+		activation     time.Time
+		fakeMarkResult bool
+		fakeCount      int64
+		wantStatus     int
+		wantErrKey     string
+		wantInsert     bool
+		wantInsertStat types.QuestEventStatus
+		wantMark       bool
+		wantBodyJSON   map[string]any
+	}{
+		{
+			name: "valid swap → 200, recorded, quest_completed=true",
+			body: `{"public_key":"pk1","quest_type":"swap","tool_call_id":"tc1","tx_hash":"0xabc","data":{"amount_usd":15,"token_in":"USDC","token_out":"ETH","chain_id":1,"router_address":"0xrouter"}}`,
+			now: now, activation: activation,
+			fakeMarkResult: true, fakeCount: 1,
+			wantStatus: 200, wantInsert: true, wantInsertStat: types.QuestEventCounted, wantMark: true,
+			wantBodyJSON: map[string]any{"recorded": true, "quest_completed": true, "quests_completed": float64(1)},
+		},
+		{
+			name: "valid swap, already-complete quest → 200, quest_completed=false",
+			body: `{"public_key":"pk1","quest_type":"swap","tool_call_id":"tc2","tx_hash":"0xabc","data":{"amount_usd":15,"token_in":"USDC","token_out":"ETH","chain_id":1,"router_address":"0xrouter"}}`,
+			now: now, activation: activation,
+			fakeMarkResult: false, fakeCount: 2,
+			wantStatus: 200, wantInsert: true, wantInsertStat: types.QuestEventCounted, wantMark: true,
+			wantBodyJSON: map[string]any{"recorded": true, "quest_completed": false, "quests_completed": float64(2)},
+		},
+		{
+			name: "swap below min → 200, recorded as rejected, no MarkComplete",
+			body: `{"public_key":"pk1","quest_type":"swap","tool_call_id":"tc3","tx_hash":"0xabc","data":{"amount_usd":5,"token_in":"USDC","token_out":"ETH","chain_id":1,"router_address":"0xrouter"}}`,
+			now: now, activation: activation,
+			fakeCount: 0,
+			wantStatus: 200, wantInsert: true, wantInsertStat: types.QuestEventRejected, wantMark: false,
+			wantBodyJSON: map[string]any{"recorded": true, "quest_completed": false, "quests_completed": float64(0)},
+		},
+		{
+			name: "alert (stub) → 200, rejected with not_yet_implemented",
+			body: `{"public_key":"pk1","quest_type":"alert","tool_call_id":"tc4","tx_hash":"0xabc","data":{}}`,
+			now: now, activation: activation,
+			fakeCount: 0,
+			wantStatus: 200, wantInsert: true, wantInsertStat: types.QuestEventRejected, wantMark: false,
+		},
+		{
+			name: "before activation → 403 QUEST_NOT_ACTIVE",
+			body: `{"public_key":"pk1","quest_type":"swap","tool_call_id":"tc5","tx_hash":"0xabc","data":{"amount_usd":15,"router_address":"0xr"}}`,
+			now:  time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC), // before activation
+			activation: activation,
+			wantStatus: 403, wantErrKey: "QUEST_NOT_ACTIVE",
+		},
+		{
+			name: "unknown quest_type → 400 INVALID_QUEST_TYPE",
+			body: `{"public_key":"pk1","quest_type":"hodl","tool_call_id":"tc6","tx_hash":"0xabc","data":{}}`,
+			now: now, activation: activation,
+			wantStatus: 400, wantErrKey: "INVALID_QUEST_TYPE",
+		},
+		{
+			name: "missing tool_call_id → 400 INVALID_PAYLOAD",
+			body: `{"public_key":"pk1","quest_type":"swap","tx_hash":"0xabc","data":{}}`,
+			now: now, activation: activation,
+			wantStatus: 400, wantErrKey: "INVALID_PAYLOAD",
+		},
+		{
+			name: "missing tx_hash → 400 INVALID_PAYLOAD",
+			body: `{"public_key":"pk1","quest_type":"swap","tool_call_id":"tc","data":{}}`,
+			now: now, activation: activation,
+			wantStatus: 400, wantErrKey: "INVALID_PAYLOAD",
+		},
+		{
+			name: "missing public_key → 400 INVALID_PAYLOAD",
+			body: `{"quest_type":"swap","tool_call_id":"tc","tx_hash":"0xabc","data":{}}`,
+			now: now, activation: activation,
+			wantStatus: 400, wantErrKey: "INVALID_PAYLOAD",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ins := &recordedInsert{}
+			mark := &recordedMark{}
+
+			repo := &fakeQuestRepo{
+				insertEvent: func(_ context.Context, p postgres.InsertQuestEventParams) (*types.QuestEvent, error) {
+					ins.params = p
+					ins.called = true
+					return &types.QuestEvent{
+						ToolCallID: p.ToolCallID, PublicKey: p.PublicKey, QuestID: p.QuestID,
+						TxHash: p.TxHash, Status: p.Status, RejectReason: p.RejectReason,
+						Payload: p.Payload, WasInserted: true,
+					}, nil
+				},
+				markComplete: func(_ context.Context, pk string, q types.QuestID) (bool, error) {
+					mark.pk = pk
+					mark.quest = q
+					mark.called = true
+					return tc.fakeMarkResult, nil
+				},
+				countComplete: func(_ context.Context, _ string) (int64, error) {
+					return tc.fakeCount, nil
+				},
+			}
+			h := &questEventHandler{
+				repo:       repo,
+				now:        func() time.Time { return tc.now },
+				activation: tc.activation,
+				dispatch: quests.DispatchConfig{
+					SwapQuestMinUSD:             10,
+					BridgeQuestMinUSD:           10,
+					DefiActionContractAllowlist: []string{"0xabc"},
+				},
+				logger: testLogger(t),
+			}
+
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodPost, "/internal/quests/event", bytes.NewBufferString(tc.body))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			err := h.Handle(c)
+			if err != nil {
+				t.Fatalf("handler returned err: %v", err)
+			}
+			if rec.Code != tc.wantStatus {
+				t.Fatalf("status = %d, want %d (body=%s)", rec.Code, tc.wantStatus, rec.Body.String())
+			}
+			if tc.wantErrKey != "" {
+				var body map[string]string
+				if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+					t.Fatalf("unmarshal err body: %v", err)
+				}
+				if body["error"] != tc.wantErrKey {
+					t.Errorf("error = %q, want %q", body["error"], tc.wantErrKey)
+				}
+				return
+			}
+			if tc.wantInsert != ins.called {
+				t.Errorf("insert called = %v, want %v", ins.called, tc.wantInsert)
+			}
+			if tc.wantInsert && ins.params.Status != tc.wantInsertStat {
+				t.Errorf("insert status = %q, want %q (reject_reason=%q)", ins.params.Status, tc.wantInsertStat, ins.params.RejectReason)
+			}
+			if tc.wantMark != mark.called {
+				t.Errorf("mark called = %v, want %v", mark.called, tc.wantMark)
+			}
+			if tc.wantBodyJSON != nil {
+				var body map[string]any
+				if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+					t.Fatalf("unmarshal: %v", err)
+				}
+				for k, v := range tc.wantBodyJSON {
+					if body[k] != v {
+						t.Errorf("body[%q] = %v (%T), want %v (%T)", k, body[k], body[k], v, v)
+					}
+				}
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+go test ./internal/api/ -run TestQuestEventHandler -v
+```
+
+Expected: compile error — `questEventHandler` undefined.
+
+- [ ] **Step 3: Implement the handler**
+
+Create `internal/api/airdrop_quest_event.go`:
+
+```go
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/sirupsen/logrus"
+
+	"github.com/vultisig/agent-backend/internal/service/airdrop/quests"
+	"github.com/vultisig/agent-backend/internal/storage/postgres"
+	"github.com/vultisig/agent-backend/internal/types"
+)
+
+// questEventRepo is the slice of QuestEventRepository the handler needs.
+// Defined as an interface so the test can pass a fake.
+type questEventRepo interface {
+	InsertEvent(ctx context.Context, p postgres.InsertQuestEventParams) (*types.QuestEvent, error)
+	MarkComplete(ctx context.Context, publicKey string, questID types.QuestID) (bool, error)
+	CountUserQuests(ctx context.Context, publicKey string) (int64, error)
+}
+
+// questEventRequest is the documented request body for POST /internal/quests/event.
+type questEventRequest struct {
+	PublicKey  string          `json:"public_key"`
+	QuestType  string          `json:"quest_type"`
+	ToolCallID string          `json:"tool_call_id"`
+	TxHash     string          `json:"tx_hash"`
+	Data       json.RawMessage `json:"data"`
+}
+
+type questEventResponse struct {
+	Recorded         bool  `json:"recorded"`
+	QuestCompleted   bool  `json:"quest_completed"`
+	QuestsCompleted  int64 `json:"quests_completed"`
+}
+
+// questEventHandler handles POST /internal/quests/event.
+//
+// Behavior (per spec):
+//  1. Validate envelope (public_key, quest_type, tool_call_id, tx_hash present;
+//     quest_type in enum). 400 on failure.
+//  2. Reject if now() < activation. 403.
+//  3. Dispatch to the per-quest validator.
+//  4. On reject: insert quest_events row with status='rejected' + reason. 200.
+//  5. On qualify: insert quest_events row with status='counted', mark the quest
+//     complete (idempotent), read the running count. 200 with quest_completed
+//     populated from the MarkComplete return.
+//
+// The insert is idempotent on tool_call_id, so duplicate POSTs of the same
+// tool result are no-ops at the DB layer; both responses return 200.
+type questEventHandler struct {
+	repo       questEventRepo
+	now        func() time.Time
+	activation time.Time
+	dispatch   quests.DispatchConfig
+	logger     *logrus.Logger
+}
+
+func (h *questEventHandler) Handle(c echo.Context) error {
+	var req questEventRequest
+	if err := c.Bind(&req); err != nil {
+		return c.JSON(http.StatusBadRequest, ErrorResponse{Error: "INVALID_PAYLOAD"})
+	}
+	if req.PublicKey == "" || req.ToolCallID == "" || req.TxHash == "" {
+		return c.JSON(http.StatusBadRequest, ErrorResponse{Error: "INVALID_PAYLOAD"})
+	}
+	questID := types.QuestID(req.QuestType)
+	if !questID.Valid() {
+		return c.JSON(http.StatusBadRequest, ErrorResponse{Error: "INVALID_QUEST_TYPE"})
+	}
+	if h.now().Before(h.activation) {
+		return c.JSON(http.StatusForbidden, ErrorResponse{Error: "QUEST_NOT_ACTIVE"})
+	}
+
+	payload := []byte(req.Data)
+	if len(payload) == 0 {
+		payload = []byte("{}")
+	}
+
+	result, err := quests.Validate(questID, payload, h.dispatch)
+	if err != nil {
+		// Programmer bug — the enum check above should make this impossible.
+		h.logger.WithError(err).WithField("quest_type", req.QuestType).Error("dispatch failed")
+		return c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "INTERNAL_ERROR"})
+	}
+
+	status := types.QuestEventCounted
+	rejectReason := ""
+	if !result.Qualifies {
+		status = types.QuestEventRejected
+		rejectReason = result.Reason
+	}
+
+	event, err := h.repo.InsertEvent(c.Request().Context(), postgres.InsertQuestEventParams{
+		ToolCallID:   req.ToolCallID,
+		PublicKey:    req.PublicKey,
+		QuestID:      questID,
+		TxHash:       req.TxHash,
+		Status:       status,
+		RejectReason: rejectReason,
+		Payload:      payload,
+	})
+	if err != nil {
+		h.logger.WithError(err).WithFields(logrus.Fields{
+			"tool_call_id": req.ToolCallID,
+			"quest_type":   req.QuestType,
+		}).Error("insert quest event failed")
+		return c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "INTERNAL_ERROR"})
+	}
+
+	resp := questEventResponse{Recorded: true}
+
+	if !result.Qualifies {
+		// Recorded but doesn't progress the user. Read the count for the response.
+		count, err := h.repo.CountUserQuests(c.Request().Context(), req.PublicKey)
+		if err != nil {
+			h.logger.WithError(err).Warn("count user quests failed (rejected path)")
+		}
+		resp.QuestsCompleted = count
+		h.logQuestEvent(req, "rejected", rejectReason)
+		return c.JSON(http.StatusOK, resp)
+	}
+
+	// Qualifying path. Mark complete (idempotent) + count.
+	wasInserted, err := h.repo.MarkComplete(c.Request().Context(), req.PublicKey, questID)
+	if err != nil {
+		h.logger.WithError(err).WithFields(logrus.Fields{
+			"public_key": shortPublicKey(req.PublicKey),
+			"quest_type": req.QuestType,
+		}).Error("mark quest complete failed")
+		// We've already inserted the event row; the count won't move. Return
+		// 200 so the caller doesn't retry — the event is on disk.
+		return c.JSON(http.StatusOK, resp)
+	}
+	resp.QuestCompleted = wasInserted && event.WasInserted
+
+	count, err := h.repo.CountUserQuests(c.Request().Context(), req.PublicKey)
+	if err != nil {
+		h.logger.WithError(err).Warn("count user quests failed (qualifying path)")
+	}
+	resp.QuestsCompleted = count
+
+	outcome := "counted"
+	if !event.WasInserted {
+		outcome = "idempotent_retry"
+	}
+	h.logQuestEvent(req, outcome, "")
+	return c.JSON(http.StatusOK, resp)
+}
+
+func (h *questEventHandler) logQuestEvent(req questEventRequest, outcome, reason string) {
+	fields := logrus.Fields{
+		"action":       "quest_event",
+		"public_key":   shortPublicKey(req.PublicKey),
+		"quest_type":   req.QuestType,
+		"tool_call_id": req.ToolCallID,
+		"tx_hash":      req.TxHash,
+		"result":       outcome,
+	}
+	if reason != "" {
+		fields["reject_reason"] = reason
+	}
+	h.logger.WithFields(fields).Info("quest event processed")
+}
+
+// shortPublicKey returns the first 8 characters of the key for logging
+// (privacy convention from shared-concerns.md).
+func shortPublicKey(pk string) string {
+	if len(pk) <= 8 {
+		return pk
+	}
+	return pk[:8]
+}
+```
+
+- [ ] **Step 4: Add the handler-wiring fields to `Server`**
+
+In `internal/api/server.go`, append to the `Server` struct:
+
+```go
+	questEventRepo *postgres.QuestEventRepository
+	questHandler   *questEventHandler
+```
+
+Add a setter at the bottom of the file (matches the existing setter pattern around `SetInternalToken` at line 124):
+
+```go
+// SetQuestEventRepo sets the quest event repository for the
+// /internal/quests/event handler.
+func (s *Server) SetQuestEventRepo(r *postgres.QuestEventRepository) {
+	s.questEventRepo = r
+}
+
+// InitQuestEventHandler constructs the quest event handler. Call after
+// SetQuestEventRepo + SetInternalToken at boot. Activation is the wall-clock
+// time after which quest events are accepted; before that, the handler returns
+// 403 QUEST_NOT_ACTIVE.
+func (s *Server) InitQuestEventHandler(activation time.Time, dispatch quests.DispatchConfig) {
+	s.questHandler = &questEventHandler{
+		repo:       s.questEventRepo,
+		now:        time.Now,
+		activation: activation,
+		dispatch:   dispatch,
+		logger:     s.logger,
+	}
+}
+
+// QuestEvent is the HTTP entry-point exposed under
+// agentGroup.POST("/internal/quests/event", ..., s.InternalTokenMiddleware).
+func (s *Server) QuestEvent(c echo.Context) error {
+	return s.questHandler.Handle(c)
+}
+```
+
+The first import block in `server.go` will need `"github.com/vultisig/agent-backend/internal/service/airdrop/quests"` and `"github.com/labstack/echo/v4"` if not already there.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+```bash
+go test ./internal/api/ -run TestQuestEventHandler -v
+```
+
+Expected: PASS for all subtests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/api/airdrop_quest_event.go \
+         internal/api/airdrop_quest_event_test.go \
+         internal/api/server.go
+git commit -m "feat(airdrop): add POST /internal/quests/event handler"
+```
+
+---
+
+## Task 6: Wire the route into `cmd/server/main.go`
+
+**Why:** The handler is built but not reachable. Add the repo construction, the handler init, and the route registration under the internal-token middleware.
+
+**Files:**
+- Modify: `cmd/server/main.go`
+
+- [ ] **Step 1: Construct the repo + init the handler**
+
+In `cmd/server/main.go`, add after the `txProposalRepo` line (`cmd/server/main.go:210`):
+
+```go
+	questEventRepo := postgres.NewQuestEventRepository(db.Pool())
+```
+
+After the `server.SetInternalToken(...)` call that the shared-infra plan added (likely around the other setters near line 234), wire the quest repo + handler init. If shared-infra didn't add a `SetInternalToken` call yet, add it now too — both are required for the route to function:
+
+```go
+	server.SetInternalToken(cfg.Airdrop.InternalAPIKey)
+	server.SetQuestEventRepo(questEventRepo)
+	server.InitQuestEventHandler(
+		cfg.Airdrop.QuestActivationTimestamp,
+		quests.FromAirdropConfig(
+			cfg.Airdrop.SwapQuestMinUSD,
+			cfg.Airdrop.BridgeQuestMinUSD,
+			cfg.Airdrop.DefiActionContractAllowlist,
+		),
+	)
+```
+
+Add the import to the import block at the top of `cmd/server/main.go`:
+
+```go
+	"github.com/vultisig/agent-backend/internal/service/airdrop/quests"
+```
+
+- [ ] **Step 2: Register the route under the internal-token middleware**
+
+After the existing route registrations (around `cmd/server/main.go:340`), add:
+
+```go
+	// Internal endpoints — protected by X-Internal-Token shared secret.
+	// Called from elsewhere in this same binary (Stage 3 tx-proposal hook,
+	// Stage 4 relayer endpoints) and by ops curl.
+	internalGroup := e.Group("/internal", server.InternalTokenMiddleware)
+	internalGroup.POST("/quests/event", server.QuestEvent)
+```
+
+- [ ] **Step 3: Build and smoke-test**
+
+```bash
+make build
+
+# Set required env including the new airdrop vars (use defaults for the rest).
+INTERNAL_API_KEY=local-secret \
+QUEST_ACTIVATION_TIMESTAMP=2025-01-01T00:00:00Z \
+TRANSITION_WINDOW_START=2025-01-01T00:00:00Z \
+TRANSITION_WINDOW_END=2026-12-31T00:00:00Z \
+KMS_RELAYER_KEY_ARN=arn \
+EVM_RPC_URL=https://ethereum-rpc.publicnode.com \
+AIRDROP_CLAIM_CONTRACT_ADDRESS=0x0000000000000000000000000000000000000000 \
+CLAIM_WINDOW_OPEN_AT=2026-12-31T00:00:00Z \
+OPS_USERNAME=ops OPS_PASSWORD=ops \
+DATABASE_DSN="$DATABASE_DSN" \
+./bin/server &
+SERVER_PID=$!
+sleep 2
+
+# Reject without the header
+curl -i -s -X POST http://localhost:8080/internal/quests/event \
+  -H "Content-Type: application/json" \
+  -d '{"public_key":"pk1","quest_type":"swap","tool_call_id":"tc1","tx_hash":"0xabc","data":{"amount_usd":15,"router_address":"0xrouter"}}' \
+  | head -1
+# expect: HTTP/1.1 401 Unauthorized
+
+# Accept with the header
+curl -i -s -X POST http://localhost:8080/internal/quests/event \
+  -H "X-Internal-Token: local-secret" \
+  -H "Content-Type: application/json" \
+  -d '{"public_key":"pk1","quest_type":"swap","tool_call_id":"tc1","tx_hash":"0xabc","data":{"amount_usd":15,"token_in":"USDC","token_out":"ETH","chain_id":1,"router_address":"0xrouter"}}'
+# expect: HTTP/1.1 200 OK
+# body: {"recorded":true,"quest_completed":true,"quests_completed":1}
+
+# Repeat the same call — idempotent
+curl -i -s -X POST http://localhost:8080/internal/quests/event \
+  -H "X-Internal-Token: local-secret" \
+  -H "Content-Type: application/json" \
+  -d '{"public_key":"pk1","quest_type":"swap","tool_call_id":"tc1","tx_hash":"0xabc","data":{"amount_usd":15,"token_in":"USDC","token_out":"ETH","chain_id":1,"router_address":"0xrouter"}}'
+# expect: HTTP/1.1 200 OK
+# body: {"recorded":true,"quest_completed":false,"quests_completed":1}  -- WasInserted=false on retry
+
+kill $SERVER_PID
+```
+
+If the binary fails to build with "undefined: SERVER_PORT" or similar, check that the `/internal/quests/event` route registration matches what `Server.QuestEvent` expects (same name).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cmd/server/main.go
+git commit -m "feat(airdrop): wire /internal/quests/event into cmd/server"
+```
+
+---
+
+## Task 7: Hook the `SignTxProposal` handler
+
+**Why:** The mobile app reports a tx as signed-and-broadcast by calling `POST /agent/tx-proposals/:id/sign` with `{tx_hash}` (see `internal/api/tx_proposals.go:95-117`). After the existing `MarkSigned` succeeds, we need to fire `POST /internal/quests/event` for any quest-relevant action. This is the spec's "tool-result hook."
+
+> **2026-04-23 update:** the hook reads `tool_name` and `quest_metadata` directly from the now-marked-signed `agent_tx_proposals` row (populated at proposal-creation time per Task 0's cross-team prerequisite). It does NOT derive a quest from `action_type` heuristics. After `MarkSigned` succeeds:
+>
+> 1. Re-fetch the proposal (or extend `MarkSigned` to return it) so you have `tool_name` and `quest_metadata` in scope.
+> 2. If `tool_name` is empty (older proposals from before the migration, or tools that don't tag themselves), skip the hook — no quest event fires. Log at debug.
+> 3. Build the request body: `{ public_key, tool_call_id: proposal.ID, tx_hash: req.TxHash, tool_name: *proposal.ToolName, quest_metadata: proposal.QuestMetadata }`.
+> 4. POST in-process via the dispatcher (Step 1 below) with `X-Internal-Token`.
+> 5. Errors logged but do NOT propagate to the user's `/sign` response. Best-effort.
+>
+> Goroutine the POST (per the existing dispatcher pattern) so it doesn't add latency to the user's sign flow.
+
+**Files:**
+- Modify: `internal/api/tx_proposals.go` (add the hook after `MarkSigned`)
+- Create: `internal/api/airdrop_quest_dispatcher.go` (in-process HTTP poster — small, isolated)
+- Create: `internal/api/airdrop_quest_dispatcher_test.go`
+
+- [ ] **Step 1: Write the dispatcher test**
+
+Create `internal/api/airdrop_quest_dispatcher_test.go`:
+
+```go
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestPostQuestEvent_SuccessAndFailureLoggedNotPropagated(t *testing.T) {
+	// Spin up a fake /internal/quests/event server and confirm the dispatcher
+	// posts the right shape with the right header.
+	var got struct {
+		gotHeader string
+		gotBody   []byte
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got.gotHeader = r.Header.Get("X-Internal-Token")
+		got.gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"recorded":true,"quest_completed":true,"quests_completed":1}`))
+	}))
+	defer srv.Close()
+
+	d := &questEventDispatcher{
+		baseURL:  srv.URL,
+		token:    "test-token",
+		client:   &http.Client{Timeout: 2 * time.Second},
+		logger:   testLogger(t),
+	}
+	d.PostEvent(context.Background(), questEventRequest{
+		PublicKey: "pk1", QuestType: "swap", ToolCallID: "tc-1",
+		TxHash: "0xabc", Data: json.RawMessage(`{"amount_usd":15}`),
+	})
+
+	if got.gotHeader != "test-token" {
+		t.Errorf("header = %q, want test-token", got.gotHeader)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(got.gotBody, &parsed); err != nil {
+		t.Fatalf("body unmarshal: %v", err)
+	}
+	if parsed["public_key"] != "pk1" || parsed["quest_type"] != "swap" || parsed["tool_call_id"] != "tc-1" {
+		t.Errorf("forwarded body wrong: %+v", parsed)
+	}
+}
+
+func TestPostQuestEvent_ErrorIsSwallowed(t *testing.T) {
+	// Server returns 500 — the dispatcher must NOT panic or return an error;
+	// quest tracking is best-effort and never propagates to the user-facing
+	// response of the hooked handler.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	d := &questEventDispatcher{
+		baseURL: srv.URL, token: "x",
+		client: &http.Client{Timeout: 2 * time.Second},
+		logger: testLogger(t),
+	}
+	// Should not panic, nothing to assert except "doesn't crash."
+	d.PostEvent(context.Background(), questEventRequest{
+		PublicKey: "pk1", QuestType: "swap", ToolCallID: "tc-1", TxHash: "0xabc",
+	})
+}
+
+func TestPostQuestEvent_NoopIfNotQuestRelevant(t *testing.T) {
+	// Caller decides whether to invoke the dispatcher; the hook in
+	// SignTxProposal calls QuestTypeForTool and skips the dispatch when the
+	// action type doesn't map to a quest. Verified end-to-end in the smoke
+	// test of Task 8 — this unit test confirms the helper itself.
+	if _, ok := questFromActionType("send"); ok {
+		t.Errorf("send should not be quest-relevant")
+	}
+	if got, ok := questFromActionType("swap"); !ok || got != "swap" {
+		t.Errorf("swap should map to swap quest, got %q ok=%v", got, ok)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+go test ./internal/api/ -run "TestPostQuestEvent" -v
+```
+
+Expected: compile error — `questEventDispatcher`, `questFromActionType` undefined.
+
+- [ ] **Step 3: Implement the dispatcher**
+
+Create `internal/api/airdrop_quest_dispatcher.go`:
+
+```go
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/vultisig/agent-backend/internal/types"
+)
+
+// questEventDispatcher fires POST /internal/quests/event in-process from the
+// SignTxProposal hook. The "in-process but over HTTP" pattern is per spec:
+// keeps the boundary identical to the one ops uses with curl, so future
+// out-of-binary callers don't need a second code path. Dispatcher errors are
+// logged but never propagated to the user — quest tracking is best-effort.
+type questEventDispatcher struct {
+	baseURL string       // e.g. "http://127.0.0.1:8080"
+	token   string       // shared secret for X-Internal-Token
+	client  *http.Client
+	logger  *logrus.Logger
+}
+
+func newQuestEventDispatcher(serverPort, token string, logger *logrus.Logger) *questEventDispatcher {
+	return &questEventDispatcher{
+		baseURL: fmt.Sprintf("http://127.0.0.1:%s", serverPort),
+		token:   token,
+		client:  &http.Client{Timeout: 5 * time.Second},
+		logger:  logger,
+	}
+}
+
+// PostEvent fires the request synchronously. Caller is responsible for running
+// it in a goroutine if it shouldn't block the HTTP response. The hook in
+// SignTxProposal does run it in a goroutine — see that callsite.
+func (d *questEventDispatcher) PostEvent(ctx context.Context, req questEventRequest) {
+	body, err := json.Marshal(req)
+	if err != nil {
+		d.logger.WithError(err).Warn("quest dispatch: marshal failed")
+		return
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		d.baseURL+"/internal/quests/event", bytes.NewReader(body))
+	if err != nil {
+		d.logger.WithError(err).Warn("quest dispatch: build request failed")
+		return
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("X-Internal-Token", d.token)
+
+	resp, err := d.client.Do(httpReq)
+	if err != nil {
+		d.logger.WithError(err).WithFields(logrus.Fields{
+			"tool_call_id": req.ToolCallID,
+			"quest_type":   req.QuestType,
+		}).Warn("quest dispatch: request failed (event NOT recorded)")
+		return
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		d.logger.WithFields(logrus.Fields{
+			"status":       resp.StatusCode,
+			"tool_call_id": req.ToolCallID,
+			"quest_type":   req.QuestType,
+		}).Warn("quest dispatch: non-200 (event MAY not have been recorded)")
+	}
+}
+
+// questFromActionType maps an agent_tx_proposals.action_type value to the
+// quest type it triggers, if any. Mirrors quests.QuestTypeForTool but keyed
+// on the tx-proposal action_type instead of the raw tool name — those two
+// vocabularies happen to match for the launch v1 quests, but having the
+// indirection here keeps the door open for a future divergence.
+//
+// Mapping rationale (see also internal/service/airdrop/quests/dispatch.go):
+//   - "swap" / "build_swap_tx"  → swap quest
+//   - "bridge" / "build_bridge_tx" → bridge quest
+//   - "call_contract" / "build_evm_tx" → defi_action quest (validator
+//     filters by contract allowlist so a vanilla send doesn't qualify)
+func questFromActionType(actionType string) (types.QuestID, bool) {
+	switch actionType {
+	case "swap", "build_swap_tx":
+		return types.QuestSwap, true
+	case "bridge", "build_bridge_tx":
+		return types.QuestBridge, true
+	case "call_contract", "build_evm_tx":
+		return types.QuestDefiAction, true
+	}
+	return "", false
+}
+```
+
+- [ ] **Step 4: Add the hook to `SignTxProposal`**
+
+Modify `internal/api/tx_proposals.go`. The current implementation ends at line 117 returning the success JSON; add the hook between `MarkSigned` succeeding (line 113) and the response:
+
+```go
+// SignTxProposal marks a tx proposal as signed.
+func (s *Server) SignTxProposal(c echo.Context) error {
+	publicKey := GetPublicKey(c)
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, ErrorResponse{Error: "invalid proposal id"})
+	}
+
+	var req struct {
+		TxHash string `json:"tx_hash"`
+	}
+	if err := c.Bind(&req); err != nil || req.TxHash == "" {
+		return c.JSON(http.StatusBadRequest, ErrorResponse{Error: "tx_hash is required"})
+	}
+	if !txHashPattern.MatchString(req.TxHash) {
+		return c.JSON(http.StatusBadRequest, ErrorResponse{Error: "invalid tx_hash format"})
+	}
+
+	if err := s.txProposalRepo.MarkSigned(c.Request().Context(), id, publicKey, req.TxHash); err != nil {
+		return c.JSON(http.StatusNotFound, ErrorResponse{Error: "proposal not found or already resolved"})
+	}
+
+	// Airdrop Stage 3 hook — fire a quest event if the tx is quest-relevant.
+	// Best-effort: errors are logged inside the dispatcher and never
+	// propagated to the user. Run async so we don't add latency to the sign
+	// response.
+	s.dispatchQuestEventForSignedProposal(c.Request().Context(), id, publicKey, req.TxHash)
+
+	return c.JSON(http.StatusOK, map[string]string{"status": "signed"})
+}
+```
+
+Then add the dispatch helper at the bottom of `tx_proposals.go` (or in a new file `internal/api/tx_proposals_quest_hook.go` if you prefer clean separation — both are fine; pick the one that matches the rest of the package's style):
+
+```go
+// dispatchQuestEventForSignedProposal looks up the just-signed proposal,
+// translates its (action_type, action_params) into a quest event, and POSTs
+// to /internal/quests/event in-process. No-op if the proposal isn't
+// quest-relevant or if the airdrop dispatcher hasn't been wired (i.e. running
+// outside the airdrop campaign window or in a test that didn't init it).
+func (s *Server) dispatchQuestEventForSignedProposal(ctx context.Context, proposalID uuid.UUID, publicKey, txHash string) {
+	if s.questDispatcher == nil {
+		// Airdrop disabled / not wired. Silently no-op.
+		return
+	}
+
+	// Re-read the just-signed proposal to get action_type + action_params.
+	// We could plumb these through MarkSigned's return, but a re-read keeps
+	// the existing repo signature unchanged and the cost is sub-ms (PK lookup).
+	prop, err := s.txProposalRepo.GetByID(ctx, proposalID, publicKey)
+	if err != nil {
+		s.logger.WithError(err).WithField("proposal_id", proposalID.String()).
+			Warn("quest hook: cannot re-read just-signed proposal")
+		return
+	}
+
+	questID, ok := questFromActionType(prop.ActionType)
+	if !ok {
+		// Not a quest-relevant tool. Nothing to do.
+		return
+	}
+
+	// Build the per-quest payload from action_params + quote_data. The shape
+	// matches the spec's documented `data` schemas (see Task 5 handler).
+	payload := buildQuestPayload(questID, prop)
+
+	go s.questDispatcher.PostEvent(context.Background(), questEventRequest{
+		PublicKey:  publicKey,
+		QuestType:  string(questID),
+		ToolCallID: proposalID.String(),
+		TxHash:     txHash,
+		Data:       payload,
+	})
+}
+
+// buildQuestPayload extracts the quest-specific fields from the tx proposal's
+// action_params + quote_data. Returns an empty `{}` payload if the expected
+// fields aren't present — the validator will then reject with a "missing_*"
+// reason, which is the right outcome (we've recorded the broadcast for audit
+// but it doesn't count toward a quest).
+func buildQuestPayload(questID types.QuestID, prop *types.TxProposal) json.RawMessage {
+	merged := map[string]any{}
+	// action_params is the source of truth for tool inputs.
+	if len(prop.ActionParams) > 0 {
+		var ap map[string]any
+		if json.Unmarshal(prop.ActionParams, &ap) == nil {
+			for k, v := range ap {
+				merged[k] = v
+			}
+		}
+	}
+	// quote_data carries provider-side enrichment (e.g. amount_usd from the
+	// swap router quote). Quote fields take precedence over action_params
+	// since they reflect the actual quoted execution.
+	if len(prop.QuoteData) > 0 {
+		var qd map[string]any
+		if json.Unmarshal(prop.QuoteData, &qd) == nil {
+			for k, v := range qd {
+				merged[k] = v
+			}
+		}
+	}
+
+	out := map[string]any{}
+	switch questID {
+	case types.QuestSwap:
+		copyKeys(out, merged, "amount_usd", "token_in", "token_out", "chain_id", "router_address")
+	case types.QuestBridge:
+		copyKeys(out, merged, "amount_usd", "source_chain_id", "dest_chain_id")
+	case types.QuestDefiAction:
+		copyKeys(out, merged, "contract_address", "chain_id", "method")
+		// agent_tx_proposals.chain is "ethereum"/"arbitrum"/etc.; the validator
+		// only cares about contract_address + a chain hint, so plumb chain too.
+		if _, ok := out["chain_id"]; !ok && prop.Chain != "" {
+			out["chain"] = prop.Chain
+		}
+	}
+	b, _ := json.Marshal(out)
+	return b
+}
+
+func copyKeys(dst, src map[string]any, keys ...string) {
+	for _, k := range keys {
+		if v, ok := src[k]; ok {
+			dst[k] = v
+		}
+	}
+}
+```
+
+The new imports `tx_proposals.go` needs: `"context"`, `"encoding/json"`, plus `"github.com/vultisig/agent-backend/internal/types"`.
+
+- [ ] **Step 5: Add the dispatcher field + setter to `Server`**
+
+In `internal/api/server.go`, append to the `Server` struct:
+
+```go
+	questDispatcher *questEventDispatcher
+```
+
+And add a setter:
+
+```go
+// InitQuestDispatcher wires the in-process HTTP client used by SignTxProposal
+// to fire quest events. Pass the server's listening port (cfg.Server.Port) so
+// the dispatcher can target localhost:<port>/internal/quests/event.
+func (s *Server) InitQuestDispatcher(serverPort string) {
+	s.questDispatcher = newQuestEventDispatcher(serverPort, s.internalToken, s.logger)
+}
+```
+
+- [ ] **Step 6: Wire the dispatcher in `cmd/server/main.go`**
+
+After the existing quest handler init from Task 6 (Step 1), add:
+
+```go
+	server.InitQuestDispatcher(cfg.Server.Port)
+```
+
+- [ ] **Step 7: Run dispatcher tests**
+
+```bash
+go test ./internal/api/ -run "TestPostQuestEvent|TestQuestEventHandler" -v
+```
+
+Expected: PASS for all subtests. The whole `internal/api` package should still build and all existing tests pass:
+
+```bash
+go test ./internal/api/...
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add internal/api/airdrop_quest_dispatcher.go \
+         internal/api/airdrop_quest_dispatcher_test.go \
+         internal/api/tx_proposals.go \
+         internal/api/server.go \
+         cmd/server/main.go
+git commit -m "feat(airdrop): hook SignTxProposal to fire quest events"
+```
+
+---
+
+## Task 8: End-to-end test + push PR
+
+- [ ] **Step 1: Run the full unit test suite**
+
+```bash
+go test ./...
+```
+
+Expected: PASS. Investigate any failures before continuing.
+
+- [ ] **Step 2: Run integration tests against a real DB**
+
+```bash
+DATABASE_DSN="$DATABASE_DSN" go test ./internal/storage/postgres/ ./internal/api/ ./internal/service/airdrop/...
+```
+
+Expected: PASS. This catches the sqlc-generated repo paths against a real `agent_quest_events` + `agent_user_quests`.
+
+- [ ] **Step 3: End-to-end smoke against a running server**
+
+The full Stage 3 user-visible flow: a tx proposal gets signed → the hook fires → the event endpoint records it → the user's quest count moves.
+
+Boot the server with the same env block as Task 6 Step 3, then:
+
+```bash
+# Insert a synthetic tx proposal with action_type=swap directly in the DB
+# (skipping the agent flow that would normally create it).
+PROPOSAL_ID=$(uuidgen)
+SCHEDULED_TASK_ID=$(uuidgen)
+PUBLIC_KEY="pk-e2e-test"
+psql "$DATABASE_DSN" -c "
+INSERT INTO agent_tx_proposals (id, scheduled_task_id, public_key, action_type, action_params, quote_data, chain, description, status, expires_at)
+VALUES ('$PROPOSAL_ID', '$SCHEDULED_TASK_ID', '$PUBLIC_KEY', 'swap',
+        '{\"token_in\":\"USDC\",\"token_out\":\"ETH\",\"chain_id\":1,\"router_address\":\"0xrouter\"}',
+        '{\"amount_usd\":42}',
+        'ethereum', 'Swap 42 USDC for ETH', 'pending', NOW() + INTERVAL '1 hour');
+"
+
+# Mint a JWT for the test public key. In dev with DEV_SKIP_AUTH=true any
+# JWT-shaped token with a public_key claim is accepted.
+TOKEN="..."  # from local /auth/token call or DEV_SKIP_AUTH
+
+# POST sign — this should fire the quest hook in the background.
+curl -s -X POST "http://localhost:8080/agent/tx-proposals/$PROPOSAL_ID/sign" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"tx_hash":"0xdeadbeef"}'
+# expect: {"status":"signed"}
+
+# Give the goroutine a beat to land
+sleep 1
+
+# Check the event was recorded
+psql "$DATABASE_DSN" -c "
+SELECT tool_call_id, public_key, quest_id, status, reject_reason
+FROM agent_quest_events
+WHERE public_key = '$PUBLIC_KEY';
+"
+# expect: 1 row, quest_id=swap, status=counted
+
+# Check the quest is marked complete
+psql "$DATABASE_DSN" -c "
+SELECT quest_id FROM agent_user_quests WHERE public_key = '$PUBLIC_KEY';
+"
+# expect: 1 row, quest_id=swap
+
+# Repeat the sign call — should be a 404 from MarkSigned (already resolved)
+# AND no new quest event row (the hook never fires because MarkSigned errored).
+curl -s -X POST "http://localhost:8080/agent/tx-proposals/$PROPOSAL_ID/sign" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"tx_hash":"0xdeadbeef"}'
+# expect: {"error":"proposal not found or already resolved"}
+
+# Idempotency at the quest endpoint level: POST the same tool_call_id twice
+# directly to /internal/quests/event.
+curl -s -X POST http://localhost:8080/internal/quests/event \
+  -H "X-Internal-Token: local-secret" \
+  -H "Content-Type: application/json" \
+  -d "{\"public_key\":\"$PUBLIC_KEY\",\"quest_type\":\"bridge\",\"tool_call_id\":\"manual-tc-1\",\"tx_hash\":\"0xfeed\",\"data\":{\"amount_usd\":50,\"source_chain_id\":1,\"dest_chain_id\":42161}}"
+# expect: {"recorded":true,"quest_completed":true,"quests_completed":2}
+
+curl -s -X POST http://localhost:8080/internal/quests/event \
+  -H "X-Internal-Token: local-secret" \
+  -H "Content-Type: application/json" \
+  -d "{\"public_key\":\"$PUBLIC_KEY\",\"quest_type\":\"bridge\",\"tool_call_id\":\"manual-tc-1\",\"tx_hash\":\"0xfeed\",\"data\":{\"amount_usd\":50,\"source_chain_id\":1,\"dest_chain_id\":42161}}"
+# expect: {"recorded":true,"quest_completed":false,"quests_completed":2}  -- idempotent retry
+```
+
+- [ ] **Step 4: Activation gate check**
+
+```bash
+# Restart the server with QUEST_ACTIVATION_TIMESTAMP set in the future
+QUEST_ACTIVATION_TIMESTAMP=2099-01-01T00:00:00Z [...other env vars...] ./bin/server &
+
+curl -s -X POST http://localhost:8080/internal/quests/event \
+  -H "X-Internal-Token: local-secret" \
+  -H "Content-Type: application/json" \
+  -d '{"public_key":"pk1","quest_type":"swap","tool_call_id":"tc-pre","tx_hash":"0xabc","data":{"amount_usd":15,"router_address":"0xr"}}'
+# expect: {"error":"QUEST_NOT_ACTIVE"} (HTTP 403)
+```
+
+- [ ] **Step 5: Run lint**
+
+```bash
+make lint
+```
+
+Expected: no errors in the new files. Fix any flagged.
+
+- [ ] **Step 6: Push branch**
+
+```bash
+git push -u origin feat/airdrop-stage-3-quest-tracking
+```
+
+- [ ] **Step 7: Open PR**
+
+```bash
+gh pr create --title "feat(airdrop): Stage 3 quest tracking — event endpoint + tx-proposal hook" --body "$(cat <<'EOF'
+## Summary
+
+Adds the Vultiverse Airdrop Stage 3 quest-tracking surface:
+- \`POST /internal/quests/event\` — single ingestion endpoint behind \`X-Internal-Token\`
+- Five validators (swap, bridge, defi_action live; alert + dca stubbed pending Product lock)
+- Hook in \`SignTxProposal\` that fires quest events for swap / bridge / call_contract action types
+
+Spec source of truth: \`docs/airdrop-specs/stage-3-quest-tracking.md\`.
+
+## Architecture
+
+- New repo \`postgres.QuestEventRepository\` wraps two sqlc files; idempotent insert keyed on \`tool_call_id\`; \`xmax = 0\` trick on user-quest insert detects first-completion for the spec's \`quest_completed\` response field
+- Per-quest validators are pure functions in \`internal/service/airdrop/quests/validators/\` — one file per quest, trivially unit-testable for boundary cases
+- \`quests.Validate\` dispatches via a \`switch\` on \`quest_type\`; the same package's \`QuestTypeForTool\` map drives the tx-proposal hook
+- The hook is additive — five lines after \`MarkSigned\` succeeds in \`SignTxProposal\`. Errors logged, never propagated to the user (quest tracking is best-effort)
+- In-process HTTP for the dispatch (per spec's API-endpoint pattern) — uses \`cfg.Server.Port\` to target \`http://127.0.0.1:<port>/internal/quests/event\` with the \`X-Internal-Token\` header
+
+## Spec coverage
+- ✅ Event endpoint with the four documented status codes (200, 400 INVALID_QUEST_TYPE, 400 INVALID_PAYLOAD, 403 QUEST_NOT_ACTIVE)
+- ✅ Three live validators with boundary-case tests
+- ✅ Two stubs returning \`(false, "not_yet_implemented")\`
+- ✅ Idempotency at the DB layer (PK on \`tool_call_id\`); both fresh insert and retry return 200
+- ✅ Activation timestamp gate
+- ✅ Tool-result hook on \`SignTxProposal\`; failures logged not propagated
+- ⏭ Eligibility helper not in this PR — owned by Stage 1's plan
+
+## Hook target
+
+The hook lives in `SignTxProposal` at `internal/api/tx_proposals.go:95-117` (the codebase's existing "tool just signed and broadcast a tx" notification). It reads `tool_name` + `quest_metadata` directly from the proposal row (populated at proposal-creation time by the agent-backend per the 2026-04-23 cross-team contract — see Task 0). The proposal UUID serves as `tool_call_id`. No JSONB sniffing, no action_type heuristics.
+
+## Test plan
+- [ ] \`go test ./...\` passes (unit + integration with DATABASE_DSN set)
+- [ ] Manual end-to-end: sign a synthetic swap proposal → verify \`agent_quest_events\` + \`agent_user_quests\` rows
+- [ ] Idempotent POST to \`/internal/quests/event\` returns 200 both times, only one event row
+- [ ] Pre-activation request returns 403 QUEST_NOT_ACTIVE
+- [ ] Missing \`X-Internal-Token\` returns 401
+
+## Hard deadline
+Quest endpoint live in staging by Day 13 (quest-earning window opens). See Stage 0 decisions table.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Capture and report the PR URL.
+
+---
+
+## Self-review notes
+
+This plan was reviewed against `stage-3-quest-tracking.md` after writing. Items confirmed:
+
+- Single internal endpoint (`POST /internal/quests/event`) with the four documented status codes (200, 400 × 2 reasons, 403). Maps to spec §"Endpoints" + "Errors".
+- Three live validators (swap, bridge, defi_action), each as a pure function in its own file. Stubs (alert, dca) return `(false, "not_yet_implemented")` — matches spec §"The 5 quests" guidance that wiring exists for stubs.
+- `tool_call_id` is the events PK; insert is idempotent. Both fresh insert and retry return 200 with `recorded: true`. Maps to spec §"Behavior" steps 4–6 + §"Schema".
+- `xmax = 0` trick on user-quest insert detects first-completion → drives `quest_completed: true|false` response field. Maps to spec §"Response — 200".
+- Activation-timestamp gate enforced before validation. 403 QUEST_NOT_ACTIVE. Matches spec §"Behavior" step 2.
+- Per-quest data shapes (swap, bridge, defi_action) match spec exactly. The validator's "missing_*" reasons surface as `reject_reason` for audit.
+- The tx-proposal hook is additive — five lines after `MarkSigned` succeeds, errors logged not propagated. Goroutine'd so it doesn't add latency. Matches spec §"Wiring the runtime hook" step 4.
+- `quest_dispatch.go` (`internal/service/airdrop/quests/dispatch.go`) holds both the `tool_name → quest_type` map (for the hook) and the `quest_type → validator` switch (for the handler). Spec calls out that adding/renaming a triggering tool is a one-line change here. Confirmed.
+- All six configured env vars consumed: `INTERNAL_API_KEY` (middleware + dispatcher), `QUEST_ACTIVATION_TIMESTAMP` (handler gate), `QUEST_THRESHOLD` (NOT consumed in this stage — only Stage 1's eligibility helper reads it), `DEFI_ACTION_CONTRACT_ALLOWLIST` (defi_action validator), `SWAP_QUEST_MIN_USD` (swap validator), `BRIDGE_QUEST_MIN_USD` (bridge validator).
+
+Items intentionally NOT in this plan:
+
+- **`/internal/quests/eligibility` endpoint** — the spec explicitly says no such endpoint exists; Stage 4's relayer reads the same DB tables directly via Stage 1's `eligibility.go` helper.
+- **Eligibility helper changes** — Stage 1 owns `internal/service/airdrop/quests/eligibility.go`. Stage 3 only writes the rows it consumes.
+- **Prometheus metrics** (`airdrop_quest_event_total`, etc.) — listed in spec §"Observability". Adding them is a small follow-up; the structured logs in `logQuestEvent` give us per-event visibility now and the metric increments would just wrap the same code paths. Defer to a follow-up PR if the team wants dashboards before going live.
+
+### Hook target — resolved
+
+The hook lives in `SignTxProposal` at `internal/api/tx_proposals.go:95-117`. It reads `tool_name` + `quest_metadata` from the now-marked-signed proposal row — both columns are populated at proposal-creation time per Task 0's cross-team contract (MCP team + agent-backend team). The proposal UUID serves as `tool_call_id`. The original "POST /conversations/{id}/tool-result" reference in the spec was aspirational — that endpoint doesn't exist; `SignTxProposal` is the codebase's actual broadcast-notification path.
+
+### Major dependency outside this plan
+
+**Task 0 must land in `main` before any Stage 3 code can be E2E-tested.** That's owned by the MCP team (`vultisig/mcp` adds `quest_metadata` to build_* tool results) and the agent-backend team (migration + scheduler.go change to capture and persist). This plan describes the contract; the work itself is cross-team. Stage 0 row 12 tracks the schema sign-off.

--- a/plans/airdrop/2026-04-23-stage-4-claim-relayer.md
+++ b/plans/airdrop/2026-04-23-stage-4-claim-relayer.md
@@ -1,0 +1,4629 @@
+# Vultiverse Airdrop — Stage 4 (Claim Relayer) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Pay out VULT to claim-eligible winners on Day 28+. `POST /airdrop/claim` (JWT) builds + KMS-signs + broadcasts an EIP-1559 `claim(recipient)` tx against the deployed `AirdropClaim.sol`, recording the submission in `agent_claim_submissions` under a single `SELECT FOR UPDATE` lock on the `agent_relayer_state` singleton. A confirmation-monitor goroutine inside the existing `cmd/scheduler` flips submitted → confirmed/failed against the chain. Operator UI at `/ops/*` (Basic Auth, server-rendered HTML) covers balance, stuck-claims, and rebroadcast-with-bump.
+
+**Architecture:** New per-stage code lives under `internal/service/airdrop/relayer/` (calldata, tx building, claim service, confirmation monitor, rebroadcast service) and `internal/storage/postgres/` (claim + relayer-state repos). Three new HTTP surfaces: `internal/api/airdrop_claim.go` (JWT), `internal/api/relayer/` (X-Internal-Token), `internal/api/ops/` (Basic Auth, HTML). The shared-infra packages from `feat/airdrop-shared-infra` (`internal/service/airdrop/kms`, `internal/service/airdrop/ethclient`, `InternalTokenMiddleware`) and the eligibility helper from `feat/airdrop-stage-1-boarding` (`internal/service/airdrop/quests/eligibility.go`) are imported as-is. The EVM client wrapper gains one helper this stage (`EstimateGas`); KMS signer is unmodified. The confirmation monitor goroutine is launched from `cmd/scheduler/main.go` via `safego.Go` alongside the existing `sched.Run(ctx)` loop — same process, same signal handler, same shutdown.
+
+**Tech Stack:**
+- Go 1.25, Echo v4
+- pgx/v5 with `pool.BeginTx(ctx, pgx.TxOptions{})` + `Queries.WithTx(tx)` for the SELECT FOR UPDATE pipeline
+- `github.com/ethereum/go-ethereum` v1.17.2 — `core/types` (DynamicFeeTx, LatestSignerForChainID, Transaction.WithSignature), `crypto` (Keccak256, Ecrecover), `common` (Address, Hash, hexutil)
+- `github.com/aws/aws-sdk-go-v2/service/kms` — already wired through `internal/service/airdrop/kms.Signer`
+- `html/template` (stdlib) for `/ops/*` pages — first use of html/template in this repo
+- Anvil from Foundry (`brew install foundry`) for integration-test EVM fixture
+- `safego.Go(logger, name, fn)` for the confirmation monitor and any panic-isolated background work
+
+**Spec source of truth:** `docs/airdrop-specs/stage-4-claim-relayer.md`. Cross-reference: `shared-concerns.md` (auth model, env inventory) and `sibling-on-chain-contract.md` (`claim(address)` ABI).
+
+**Working directory for all tasks:** `/Users/apotheosis/git/vultisig/agent-backend/`
+
+**Branch:** `feat/airdrop-stage-4-claim-relayer`. Branch off `main` once `feat/airdrop-shared-infra` and `feat/airdrop-stage-1-boarding` have merged. Commit after every task.
+
+**Hard deadline:** Live in production by Day 28 (see Stage 0 decisions table for the wall-clock date). The relayer is the only stage that touches mainnet — bring it up in staging behind `CLAIM_ENABLED=false` first, smoke-test against Sepolia or a Foundry-deployed fixture, then flip the kill switch on Day 28.
+
+---
+
+## Pre-flight (do once before Task 1)
+
+Confirm the prerequisite branches have merged and the airdrop tables exist locally:
+
+```bash
+cd /Users/apotheosis/git/vultisig/agent-backend
+git checkout main && git pull
+psql "$DATABASE_DSN" -c "\d agent_claim_submissions"
+psql "$DATABASE_DSN" -c "\d agent_relayer_state"
+psql "$DATABASE_DSN" -c "\d agent_raffle_winners"
+psql "$DATABASE_DSN" -c "SELECT * FROM agent_relayer_state;"
+```
+
+Expected: all three `\d` calls describe the tables; the `SELECT` returns one row with `id=1, next_nonce=NULL`. If any are missing, run `make migrate-up` first.
+
+Confirm the Stage 1 eligibility helper is present:
+
+```bash
+ls internal/service/airdrop/quests/eligibility.go
+```
+
+If it isn't there, Stage 1's PR hasn't merged — stop and resolve before proceeding.
+
+Install Foundry (Anvil) if not already on the machine:
+
+```bash
+brew install foundry
+anvil --version
+```
+
+Expected: prints a version like `anvil 0.2.0 (...)`. The Anvil binary is used by Task 1 and Task 7 for EVM-side integration tests.
+
+```bash
+git checkout -b feat/airdrop-stage-4-claim-relayer
+```
+
+---
+
+## Task 1: Extend the EVM client wrapper with `EstimateGas`, plus an Anvil-backed test helper
+
+**Why:** The relayer needs an EIP-1559 gas-limit estimate (`eth_estimateGas`) before broadcasting; the shared-infra wrapper at `internal/service/airdrop/ethclient/client.go:18` exposes `LatestBaseFee`, `SuggestGasTipCap`, `NonceAt`, `SendRawTransaction`, `GetTransactionReceipt`, `BalanceOf`, `Balance` — but no `EstimateGas`. Add it as a small first-task extension, then introduce a shared `anviltest` helper that subsequent tasks reuse.
+
+**Files:**
+- Modify: `internal/service/airdrop/ethclient/client.go` — add `EstimateGas` method
+- Create: `internal/service/airdrop/ethclient/anviltest/anvil.go` — test helper for spinning up Anvil
+- Modify: `internal/service/airdrop/ethclient/client_test.go` — add round-trip test against Anvil
+
+- [ ] **Step 1: Write the failing test against Anvil**
+
+Append to `internal/service/airdrop/ethclient/client_test.go`:
+
+```go
+import (
+	"github.com/vultisig/agent-backend/internal/service/airdrop/ethclient/anviltest"
+)
+
+// TestEstimateGasAgainstAnvil spins up an Anvil instance, deploys nothing,
+// and asks for the gas estimate of a plain ETH transfer. Anvil's deterministic
+// chain returns 21000 for a value-only tx with empty data.
+func TestEstimateGasAgainstAnvil(t *testing.T) {
+	anvil, err := anviltest.Start(t)
+	if err != nil {
+		t.Skipf("anvil not available (install foundry: brew install foundry): %v", err)
+	}
+	c, err := NewClient(anvil.URL())
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	from := common.HexToAddress("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266") // anvil[0]
+	to := common.HexToAddress("0x70997970C51812dc3A010C7d01b50e0d17dc79C8")   // anvil[1]
+
+	gas, err := c.EstimateGas(context.Background(), from, to, nil, big.NewInt(1))
+	if err != nil {
+		t.Fatalf("EstimateGas: %v", err)
+	}
+	if gas != 21000 {
+		t.Errorf("EstimateGas for value transfer = %d, want 21000", gas)
+	}
+}
+```
+
+- [ ] **Step 2: Implement the Anvil test helper**
+
+Create `internal/service/airdrop/ethclient/anviltest/anvil.go`:
+
+```go
+// Package anviltest spins up a Foundry Anvil node for integration tests.
+// Requires the `anvil` binary on PATH (install via `brew install foundry`).
+package anviltest
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os/exec"
+	"testing"
+	"time"
+)
+
+// Anvil wraps a running anvil subprocess.
+type Anvil struct {
+	cmd  *exec.Cmd
+	port int
+}
+
+// Start launches anvil on a free port. Cleans up on test end.
+func Start(t *testing.T) (*Anvil, error) {
+	t.Helper()
+	if _, err := exec.LookPath("anvil"); err != nil {
+		return nil, fmt.Errorf("anvil binary not found on PATH: %w", err)
+	}
+
+	port, err := freePort()
+	if err != nil {
+		return nil, fmt.Errorf("alloc port: %w", err)
+	}
+
+	cmd := exec.Command("anvil",
+		"--port", fmt.Sprint(port),
+		"--block-time", "1",
+		"--silent",
+	)
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("start anvil: %w", err)
+	}
+
+	a := &Anvil{cmd: cmd, port: port}
+	t.Cleanup(func() { _ = a.cmd.Process.Kill() })
+
+	// Poll until the port accepts connections (anvil takes ~50ms to boot)
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", port), 100*time.Millisecond)
+		if err == nil {
+			_ = conn.Close()
+			return a, nil
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	_ = a.cmd.Process.Kill()
+	return nil, fmt.Errorf("anvil did not become reachable on port %d within 5s", port)
+}
+
+// URL returns the JSON-RPC URL.
+func (a *Anvil) URL() string {
+	return fmt.Sprintf("http://127.0.0.1:%d", a.port)
+}
+
+// Port returns the bound port (handy for tests that need to point other clients at it).
+func (a *Anvil) Port() int { return a.port }
+
+// Wait waits up to dur for the anvil process to exit.
+func (a *Anvil) Wait(ctx context.Context, dur time.Duration) error {
+	done := make(chan error, 1)
+	go func() { done <- a.cmd.Wait() }()
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(dur):
+		return fmt.Errorf("timeout waiting for anvil exit")
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func freePort() (int, error) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return 0, err
+	}
+	defer l.Close()
+	return l.Addr().(*net.TCPAddr).Port, nil
+}
+```
+
+- [ ] **Step 3: Run test to verify it fails (no `EstimateGas` yet)**
+
+```bash
+go test ./internal/service/airdrop/ethclient/ -run TestEstimateGasAgainstAnvil -v
+```
+
+Expected: compile error — `c.EstimateGas` undefined.
+
+- [ ] **Step 4: Add `EstimateGas` to the Client interface and implementation**
+
+Edit `internal/service/airdrop/ethclient/client.go`. Add to the `Client` interface (near line 32, after `Balance`):
+
+```go
+	// EstimateGas returns the gas required to execute the call (eth_estimateGas).
+	// Used to size the EIP-1559 tx's GasLimit before signing.
+	EstimateGas(ctx context.Context, from, to common.Address, data []byte, value *big.Int) (uint64, error)
+```
+
+Add the method implementation at the bottom of the file:
+
+```go
+func (c *client) EstimateGas(ctx context.Context, from, to common.Address, data []byte, value *big.Int) (uint64, error) {
+	return c.rpc.EstimateGas(ctx, ethereum.CallMsg{
+		From:  from,
+		To:    &to,
+		Data:  data,
+		Value: value,
+	})
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+```bash
+go test ./internal/service/airdrop/ethclient/ -run TestEstimateGasAgainstAnvil -v
+```
+
+Expected: PASS. If anvil isn't installed the test skips with the install hint.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/service/airdrop/ethclient/client.go \
+         internal/service/airdrop/ethclient/client_test.go \
+         internal/service/airdrop/ethclient/anviltest/anvil.go
+git commit -m "feat(airdrop): add EstimateGas to ethclient + anviltest helper"
+```
+
+---
+
+## Task 2: sqlc queries for `agent_claim_submissions` + `agent_relayer_state`
+
+> **Schema update (2026-04-23):** the `previous_tx_hashes TEXT[]` column was dropped. Throughout this task and Tasks 3, 11, 12, 13: drop the column from the schema fixture, drop the field from the Go struct, drop it from the queries (no `array_append` in the rebroadcast query — just `UPDATE ... SET tx_hash = $newHash, max_fee_gwei = $bumpedMax, max_priority_fee_gwei = $bumpedTip`). The audit trail of prior bumps lives in the structured log lines emitted by the rebroadcast service (one line per bump tagged `old_tx_hash`, `new_tx_hash`, `bump_gwei`, `operator`).
+
+**Why:** The claim service needs nine queries: lock-and-read state, init-nonce-if-null, increment-nonce, insert claim, get-by-public-key (idempotent retry), list-pending-for-monitor, mark-confirmed, mark-failed, mark-rebroadcast (update tx_hash + bumped fees in place), plus a stuck-claims read for ops. Bundle them in two sqlc files mirroring the existing `internal/storage/postgres/sqlc/*.sql` pattern.
+
+**Files:**
+- Create: `internal/storage/postgres/sqlc/airdrop_claims.sql`
+- Create: `internal/storage/postgres/sqlc/airdrop_relayer_state.sql`
+- Modify: `internal/storage/postgres/schema/schema.sql` — append the two airdrop tables so sqlc can resolve the column types
+- Generated: `internal/storage/postgres/queries/airdrop_claims.sql.go` (do not hand-edit)
+- Generated: `internal/storage/postgres/queries/airdrop_relayer_state.sql.go` (do not hand-edit)
+
+- [ ] **Step 1: Append airdrop tables to the sqlc schema file**
+
+`sqlc.yaml` points at `internal/storage/postgres/schema/schema.sql` for type resolution. Append to the bottom of `internal/storage/postgres/schema/schema.sql`:
+
+```sql
+-- ============================================================================
+-- Vultiverse Airdrop tables (see internal/storage/postgres/migrations/2026042300000{1..6}_*.sql)
+-- These exist in this file solely so sqlc can resolve column types when
+-- generating queries against the airdrop_*.sql query files.
+-- ============================================================================
+
+CREATE TYPE airdrop_registration_source AS ENUM ('seed', 'vault_share');
+CREATE TYPE airdrop_quest_id            AS ENUM ('swap', 'bridge', 'defi_action', 'alert', 'dca');
+CREATE TYPE airdrop_quest_event_status  AS ENUM ('counted', 'rejected');
+CREATE TYPE airdrop_claim_status        AS ENUM ('submitted', 'confirmed', 'failed');
+
+CREATE TABLE agent_airdrop_registrations (
+    public_key        TEXT                        PRIMARY KEY,
+    source            airdrop_registration_source NOT NULL,
+    recipient_address TEXT                        NOT NULL,
+    registered_at     TIMESTAMPTZ                 NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE agent_raffle_winners (
+    public_key TEXT          PRIMARY KEY,
+    recipient  TEXT          NOT NULL,
+    amount     NUMERIC(78,0) NOT NULL,
+    loaded_at  TIMESTAMPTZ   NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE agent_quest_events (
+    tool_call_id  TEXT                       PRIMARY KEY,
+    public_key    TEXT                       NOT NULL,
+    quest_id      airdrop_quest_id           NOT NULL,
+    tx_hash       TEXT                       NOT NULL,
+    status        airdrop_quest_event_status NOT NULL,
+    reject_reason TEXT,
+    payload       JSONB                      NOT NULL,
+    created_at    TIMESTAMPTZ                NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE agent_user_quests (
+    public_key   TEXT             NOT NULL,
+    quest_id     airdrop_quest_id NOT NULL,
+    completed_at TIMESTAMPTZ      NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (public_key, quest_id)
+);
+
+CREATE TABLE agent_claim_submissions (
+    public_key            TEXT                 NOT NULL,
+    nonce                 BIGINT               NOT NULL UNIQUE,
+    recipient             TEXT                 NOT NULL,
+    amount                NUMERIC(78, 0)       NOT NULL,
+    tx_hash               TEXT                 NOT NULL,
+    previous_tx_hashes    TEXT[]               NOT NULL DEFAULT '{}',
+    status                airdrop_claim_status NOT NULL,
+    max_fee_gwei          INTEGER              NOT NULL,
+    max_priority_fee_gwei INTEGER              NOT NULL,
+    block_number          BIGINT,
+    failure_reason        TEXT,
+    submitted_at          TIMESTAMPTZ          NOT NULL,
+    confirmed_at          TIMESTAMPTZ,
+    failed_at             TIMESTAMPTZ
+);
+
+CREATE TABLE agent_relayer_state (
+    id          INT PRIMARY KEY DEFAULT 1 CHECK (id = 1),
+    next_nonce  BIGINT,
+    last_synced TIMESTAMPTZ     NOT NULL DEFAULT NOW()
+);
+```
+
+If Stage 1's plan already added the first four tables (registrations, winners, quest_events, user_quests) to this file, leave the existing copies in place and only append the claim_submissions + relayer_state blocks. `grep -n "agent_airdrop_registrations\|agent_relayer_state" internal/storage/postgres/schema/schema.sql` to check before pasting.
+
+- [ ] **Step 2: Write the claims query file**
+
+Create `internal/storage/postgres/sqlc/airdrop_claims.sql`:
+
+```sql
+-- name: InsertClaimSubmission :one
+INSERT INTO agent_claim_submissions (
+    public_key, nonce, recipient, amount, tx_hash,
+    status, max_fee_gwei, max_priority_fee_gwei, submitted_at
+) VALUES (
+    $1, $2, $3, $4, $5, 'submitted', $6, $7, NOW()
+)
+RETURNING *;
+
+-- name: GetActiveClaimByPublicKey :one
+-- Returns the user's submitted-or-confirmed claim if any. Idempotent-retry
+-- path uses this inside the SELECT FOR UPDATE transaction.
+SELECT * FROM agent_claim_submissions
+WHERE public_key = $1
+  AND status IN ('submitted', 'confirmed')
+LIMIT 1;
+
+-- name: ListPendingClaims :many
+-- Confirmation monitor scan. Index idx_claim_submissions_pending makes this
+-- O(unconfirmed). Limit caps per-tick work; the next tick picks up the rest.
+SELECT * FROM agent_claim_submissions
+WHERE status = 'submitted'
+ORDER BY submitted_at ASC
+LIMIT $1;
+
+-- name: ListStuckClaims :many
+-- /internal/relayer/stuck-claims and /ops/stuck-claims source. Filters
+-- submitted-state rows older than $1 minutes, sorted by oldest-first.
+SELECT * FROM agent_claim_submissions
+WHERE status = 'submitted'
+  AND submitted_at < NOW() - make_interval(mins => $1::int)
+ORDER BY submitted_at ASC;
+
+-- name: MarkClaimConfirmed :exec
+UPDATE agent_claim_submissions
+SET status = 'confirmed',
+    confirmed_at = NOW(),
+    block_number = $2
+WHERE nonce = $1;
+
+-- name: MarkClaimFailed :exec
+UPDATE agent_claim_submissions
+SET status = 'failed',
+    failed_at = NOW(),
+    failure_reason = $2
+WHERE nonce = $1;
+
+-- name: GetClaimByPublicKey :one
+-- Rebroadcast lookup. Returns the most recent claim (any status) for the user.
+SELECT * FROM agent_claim_submissions
+WHERE public_key = $1
+ORDER BY submitted_at DESC
+LIMIT 1;
+
+-- name: UpdateClaimRebroadcast :exec
+-- Same-nonce rebroadcast. Pushes the previous tx_hash onto the audit array,
+-- updates the live tx_hash + bumped fee fields, leaves status='submitted'.
+UPDATE agent_claim_submissions
+SET previous_tx_hashes    = array_append(previous_tx_hashes, tx_hash),
+    tx_hash               = $2,
+    max_fee_gwei          = $3,
+    max_priority_fee_gwei = $4
+WHERE nonce = $1
+  AND status = 'submitted';
+```
+
+- [ ] **Step 3: Write the relayer-state query file**
+
+Create `internal/storage/postgres/sqlc/airdrop_relayer_state.sql`:
+
+```sql
+-- name: LockRelayerState :one
+-- The serialising lock for every claim submission. Must run inside a tx —
+-- caller does pool.BeginTx → queries.WithTx → LockRelayerState → ... → COMMIT.
+SELECT * FROM agent_relayer_state
+WHERE id = 1
+FOR UPDATE;
+
+-- name: GetRelayerState :one
+-- Lock-free read for the balance endpoint and the auto-init "is it nil?" probe.
+SELECT * FROM agent_relayer_state
+WHERE id = 1;
+
+-- name: SetRelayerNonce :exec
+-- Used by both the auto-init path (first boot) and the increment path
+-- (every successful claim). last_synced updates so we can spot a stuck nonce.
+UPDATE agent_relayer_state
+SET next_nonce  = $1,
+    last_synced = NOW()
+WHERE id = 1;
+```
+
+- [ ] **Step 4: Run sqlc generation**
+
+```bash
+grep -n sqlc Makefile
+```
+
+If a `make sqlc` target exists, use it. Otherwise:
+
+```bash
+sqlc generate
+```
+
+If sqlc isn't installed:
+
+```bash
+go install github.com/sqlc-dev/sqlc/cmd/sqlc@latest
+```
+
+Expected: two new files appear:
+- `internal/storage/postgres/queries/airdrop_claims.sql.go`
+- `internal/storage/postgres/queries/airdrop_relayer_state.sql.go`
+
+Plus updates to `internal/storage/postgres/queries/models.go` for the new table struct types and the `AirdropClaimStatus` enum.
+
+- [ ] **Step 5: Verify the generated code compiles**
+
+```bash
+go build ./internal/storage/postgres/...
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/storage/postgres/sqlc/airdrop_claims.sql \
+         internal/storage/postgres/sqlc/airdrop_relayer_state.sql \
+         internal/storage/postgres/schema/schema.sql \
+         internal/storage/postgres/queries/airdrop_claims.sql.go \
+         internal/storage/postgres/queries/airdrop_relayer_state.sql.go \
+         internal/storage/postgres/queries/models.go
+git commit -m "feat(airdrop): add sqlc queries for claim submissions + relayer state"
+```
+
+---
+
+## Task 3: Repositories — `ClaimRepository` and `RelayerStateRepository`
+
+**Why:** Wraps the sqlc Queries with domain types. Both repos expose a `WithTx(tx pgx.Tx)` variant so the claim service can run the lock+insert+update sequence in a single transaction.
+
+**Files:**
+- Create: `internal/types/airdrop_claim.go` — `ClaimSubmission`, `RelayerState`, `ClaimStatus` constants
+- Create: `internal/storage/postgres/airdrop_claim.go` — `ClaimRepository`
+- Create: `internal/storage/postgres/airdrop_relayer_state.go` — `RelayerStateRepository`
+- Create: `internal/storage/postgres/airdrop_claim_test.go`
+- Create: `internal/storage/postgres/airdrop_relayer_state_test.go`
+
+- [ ] **Step 1: Add the domain types**
+
+Create `internal/types/airdrop_claim.go`:
+
+```go
+package types
+
+import (
+	"math/big"
+	"time"
+)
+
+type ClaimStatus string
+
+const (
+	ClaimSubmitted ClaimStatus = "submitted"
+	ClaimConfirmed ClaimStatus = "confirmed"
+	ClaimFailed    ClaimStatus = "failed"
+)
+
+type ClaimSubmission struct {
+	PublicKey          string
+	Nonce              int64
+	Recipient          string
+	Amount             *big.Int
+	TxHash             string
+	PreviousTxHashes   []string
+	Status             ClaimStatus
+	MaxFeeGwei         int32
+	MaxPriorityFeeGwei int32
+	BlockNumber        *int64 // nil unless confirmed
+	FailureReason      *string
+	SubmittedAt        time.Time
+	ConfirmedAt        *time.Time
+	FailedAt           *time.Time
+}
+
+type RelayerState struct {
+	NextNonce  *int64 // nil before first boot
+	LastSynced time.Time
+}
+```
+
+- [ ] **Step 2: Write the claim repo test**
+
+Create `internal/storage/postgres/airdrop_claim_test.go`:
+
+```go
+package postgres_test
+
+import (
+	"context"
+	"math/big"
+	"os"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/vultisig/agent-backend/internal/storage/postgres"
+	"github.com/vultisig/agent-backend/internal/types"
+)
+
+func newClaimTestPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	dsn := os.Getenv("TEST_DATABASE_DSN")
+	if dsn == "" {
+		dsn = os.Getenv("DATABASE_DSN")
+	}
+	if dsn == "" {
+		t.Skip("TEST_DATABASE_DSN or DATABASE_DSN not set")
+	}
+	pool, err := pgxpool.New(context.Background(), dsn)
+	if err != nil {
+		t.Fatalf("pgxpool.New: %v", err)
+	}
+	t.Cleanup(func() { pool.Close() })
+	_, err = pool.Exec(context.Background(), `TRUNCATE agent_claim_submissions;`)
+	if err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+	return pool
+}
+
+func TestClaimRepo_InsertAndGet(t *testing.T) {
+	pool := newClaimTestPool(t)
+	repo := postgres.NewClaimRepository(pool)
+	ctx := context.Background()
+
+	row, err := repo.Insert(ctx, "pk1", 7, "0xaaa", big.NewInt(1500), "0xtx1", 50, 2)
+	if err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+	if row.Nonce != 7 || row.TxHash != "0xtx1" || row.Status != types.ClaimSubmitted {
+		t.Errorf("unexpected row: %+v", row)
+	}
+
+	got, err := repo.GetActiveByPublicKey(ctx, "pk1")
+	if err != nil {
+		t.Fatalf("GetActiveByPublicKey: %v", err)
+	}
+	if got.Nonce != 7 {
+		t.Errorf("nonce = %d, want 7", got.Nonce)
+	}
+
+	// Same-user second insert with a fresh nonce must violate the partial unique index
+	_, err = repo.Insert(ctx, "pk1", 8, "0xaaa", big.NewInt(1500), "0xtx2", 50, 2)
+	if err == nil {
+		t.Errorf("second submission for same user should fail unique index")
+	}
+}
+
+func TestClaimRepo_MarkConfirmed(t *testing.T) {
+	pool := newClaimTestPool(t)
+	repo := postgres.NewClaimRepository(pool)
+	ctx := context.Background()
+
+	_, _ = repo.Insert(ctx, "pk1", 9, "0xaaa", big.NewInt(1500), "0xtx", 50, 2)
+	if err := repo.MarkConfirmed(ctx, 9, 19400000); err != nil {
+		t.Fatalf("MarkConfirmed: %v", err)
+	}
+
+	// Now GetActiveByPublicKey still finds it (confirmed counts as active for idempotency)
+	got, err := repo.GetActiveByPublicKey(ctx, "pk1")
+	if err != nil {
+		t.Fatalf("GetActiveByPublicKey: %v", err)
+	}
+	if got.Status != types.ClaimConfirmed {
+		t.Errorf("status = %s, want confirmed", got.Status)
+	}
+	if got.BlockNumber == nil || *got.BlockNumber != 19400000 {
+		t.Errorf("block_number = %v, want 19400000", got.BlockNumber)
+	}
+}
+
+func TestClaimRepo_ListStuck(t *testing.T) {
+	pool := newClaimTestPool(t)
+	repo := postgres.NewClaimRepository(pool)
+	ctx := context.Background()
+
+	// Insert one fresh and one with submitted_at=NOW()-30min via direct UPDATE
+	_, _ = repo.Insert(ctx, "pk1", 1, "0xaaa", big.NewInt(1500), "0xtx1", 50, 2)
+	_, _ = repo.Insert(ctx, "pk2", 2, "0xbbb", big.NewInt(1500), "0xtx2", 50, 2)
+	_, err := pool.Exec(ctx, `UPDATE agent_claim_submissions SET submitted_at = NOW() - interval '30 minutes' WHERE nonce = 2`)
+	if err != nil {
+		t.Fatalf("backdate: %v", err)
+	}
+
+	stuck, err := repo.ListStuck(ctx, 10) // older than 10 minutes
+	if err != nil {
+		t.Fatalf("ListStuck: %v", err)
+	}
+	if len(stuck) != 1 || stuck[0].Nonce != 2 {
+		t.Errorf("ListStuck = %+v, want one row with nonce=2", stuck)
+	}
+}
+
+func TestClaimRepo_Rebroadcast(t *testing.T) {
+	pool := newClaimTestPool(t)
+	repo := postgres.NewClaimRepository(pool)
+	ctx := context.Background()
+
+	_, _ = repo.Insert(ctx, "pk1", 5, "0xaaa", big.NewInt(1500), "0xold", 50, 2)
+	if err := repo.UpdateRebroadcast(ctx, 5, "0xnew", 100, 4); err != nil {
+		t.Fatalf("UpdateRebroadcast: %v", err)
+	}
+
+	got, _ := repo.GetActiveByPublicKey(ctx, "pk1")
+	if got.TxHash != "0xnew" {
+		t.Errorf("tx_hash = %s, want 0xnew", got.TxHash)
+	}
+	if len(got.PreviousTxHashes) != 1 || got.PreviousTxHashes[0] != "0xold" {
+		t.Errorf("previous_tx_hashes = %v, want [0xold]", got.PreviousTxHashes)
+	}
+	if got.MaxFeeGwei != 100 || got.MaxPriorityFeeGwei != 4 {
+		t.Errorf("fees = (%d, %d), want (100, 4)", got.MaxFeeGwei, got.MaxPriorityFeeGwei)
+	}
+}
+```
+
+- [ ] **Step 3: Write the relayer-state repo test**
+
+Create `internal/storage/postgres/airdrop_relayer_state_test.go`:
+
+```go
+package postgres_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/vultisig/agent-backend/internal/storage/postgres"
+)
+
+func newRelayerStateTestPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	dsn := os.Getenv("TEST_DATABASE_DSN")
+	if dsn == "" {
+		dsn = os.Getenv("DATABASE_DSN")
+	}
+	if dsn == "" {
+		t.Skip("TEST_DATABASE_DSN or DATABASE_DSN not set")
+	}
+	pool, err := pgxpool.New(context.Background(), dsn)
+	if err != nil {
+		t.Fatalf("pgxpool.New: %v", err)
+	}
+	t.Cleanup(func() { pool.Close() })
+	// Reset to nil-nonce baseline (singleton row created by migration 6)
+	_, err = pool.Exec(context.Background(), `UPDATE agent_relayer_state SET next_nonce = NULL WHERE id = 1`)
+	if err != nil {
+		t.Fatalf("reset: %v", err)
+	}
+	return pool
+}
+
+func TestRelayerStateRepo_GetReturnsNilNonceInitially(t *testing.T) {
+	pool := newRelayerStateTestPool(t)
+	repo := postgres.NewRelayerStateRepository(pool)
+
+	st, err := repo.Get(context.Background())
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if st.NextNonce != nil {
+		t.Errorf("expected nil next_nonce initially, got %v", *st.NextNonce)
+	}
+}
+
+func TestRelayerStateRepo_LockAndSetWithinTx(t *testing.T) {
+	pool := newRelayerStateTestPool(t)
+	repo := postgres.NewRelayerStateRepository(pool)
+	ctx := context.Background()
+
+	tx, err := pool.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		t.Fatalf("BeginTx: %v", err)
+	}
+	defer tx.Rollback(ctx)
+
+	st, err := repo.LockWithTx(ctx, tx)
+	if err != nil {
+		t.Fatalf("LockWithTx: %v", err)
+	}
+	if st.NextNonce != nil {
+		t.Errorf("expected nil nonce, got %v", *st.NextNonce)
+	}
+	if err := repo.SetNonceWithTx(ctx, tx, 42); err != nil {
+		t.Fatalf("SetNonceWithTx: %v", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+
+	after, _ := repo.Get(ctx)
+	if after.NextNonce == nil || *after.NextNonce != 42 {
+		t.Errorf("after commit next_nonce = %v, want 42", after.NextNonce)
+	}
+}
+```
+
+- [ ] **Step 4: Run tests to verify they fail**
+
+```bash
+go test ./internal/storage/postgres/ -run 'TestClaimRepo|TestRelayerStateRepo' -v
+```
+
+Expected: compile errors — `NewClaimRepository`, `NewRelayerStateRepository` undefined.
+
+- [ ] **Step 5: Implement `ClaimRepository`**
+
+Create `internal/storage/postgres/airdrop_claim.go`:
+
+```go
+package postgres
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/big"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/vultisig/agent-backend/internal/storage/postgres/queries"
+	"github.com/vultisig/agent-backend/internal/types"
+)
+
+type ClaimRepository struct {
+	pool *pgxpool.Pool
+	q    *queries.Queries
+}
+
+func NewClaimRepository(pool *pgxpool.Pool) *ClaimRepository {
+	return &ClaimRepository{pool: pool, q: queries.New(pool)}
+}
+
+func (r *ClaimRepository) Insert(
+	ctx context.Context,
+	publicKey string,
+	nonce int64,
+	recipient string,
+	amount *big.Int,
+	txHash string,
+	maxFeeGwei int32,
+	maxPriorityFeeGwei int32,
+) (*types.ClaimSubmission, error) {
+	return r.insert(ctx, r.q, publicKey, nonce, recipient, amount, txHash, maxFeeGwei, maxPriorityFeeGwei)
+}
+
+// InsertWithTx is the txn-scoped variant the claim service calls inside the
+// SELECT FOR UPDATE block.
+func (r *ClaimRepository) InsertWithTx(
+	ctx context.Context, tx pgx.Tx,
+	publicKey string, nonce int64, recipient string, amount *big.Int,
+	txHash string, maxFeeGwei int32, maxPriorityFeeGwei int32,
+) (*types.ClaimSubmission, error) {
+	return r.insert(ctx, r.q.WithTx(tx), publicKey, nonce, recipient, amount, txHash, maxFeeGwei, maxPriorityFeeGwei)
+}
+
+func (r *ClaimRepository) insert(
+	ctx context.Context, q *queries.Queries,
+	publicKey string, nonce int64, recipient string, amount *big.Int,
+	txHash string, maxFeeGwei int32, maxPriorityFeeGwei int32,
+) (*types.ClaimSubmission, error) {
+	amountNum := pgtype.Numeric{}
+	if err := amountNum.Scan(amount.String()); err != nil {
+		return nil, fmt.Errorf("scan amount: %w", err)
+	}
+	row, err := q.InsertClaimSubmission(ctx, &queries.InsertClaimSubmissionParams{
+		PublicKey:          publicKey,
+		Nonce:              nonce,
+		Recipient:          recipient,
+		Amount:             amountNum,
+		TxHash:             txHash,
+		MaxFeeGwei:         maxFeeGwei,
+		MaxPriorityFeeGwei: maxPriorityFeeGwei,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("insert claim submission: %w", err)
+	}
+	return claimFromDB(row), nil
+}
+
+// GetActiveByPublicKey returns the user's submitted-or-confirmed claim row,
+// ErrNotFound if none. Used both by the claim handler (idempotent retry) and
+// by the rebroadcast service to validate the user has a live submission.
+func (r *ClaimRepository) GetActiveByPublicKey(ctx context.Context, publicKey string) (*types.ClaimSubmission, error) {
+	return r.getActiveByPublicKey(ctx, r.q, publicKey)
+}
+
+func (r *ClaimRepository) GetActiveByPublicKeyWithTx(ctx context.Context, tx pgx.Tx, publicKey string) (*types.ClaimSubmission, error) {
+	return r.getActiveByPublicKey(ctx, r.q.WithTx(tx), publicKey)
+}
+
+func (r *ClaimRepository) getActiveByPublicKey(ctx context.Context, q *queries.Queries, publicKey string) (*types.ClaimSubmission, error) {
+	row, err := q.GetActiveClaimByPublicKey(ctx, publicKey)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("get active claim: %w", err)
+	}
+	return claimFromDB(row), nil
+}
+
+// GetByPublicKey returns the most recent claim row regardless of status.
+// Used for rebroadcast and ops display.
+func (r *ClaimRepository) GetByPublicKey(ctx context.Context, publicKey string) (*types.ClaimSubmission, error) {
+	row, err := r.q.GetClaimByPublicKey(ctx, publicKey)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("get claim by public key: %w", err)
+	}
+	return claimFromDB(row), nil
+}
+
+// ListPending returns up to `limit` submitted-state rows for the confirmation
+// monitor. Sorted oldest-first so we drain the backlog FIFO.
+func (r *ClaimRepository) ListPending(ctx context.Context, limit int32) ([]types.ClaimSubmission, error) {
+	rows, err := r.q.ListPendingClaims(ctx, limit)
+	if err != nil {
+		return nil, fmt.Errorf("list pending: %w", err)
+	}
+	out := make([]types.ClaimSubmission, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, *claimFromDB(row))
+	}
+	return out, nil
+}
+
+func (r *ClaimRepository) ListStuck(ctx context.Context, olderThanMinutes int32) ([]types.ClaimSubmission, error) {
+	rows, err := r.q.ListStuckClaims(ctx, olderThanMinutes)
+	if err != nil {
+		return nil, fmt.Errorf("list stuck: %w", err)
+	}
+	out := make([]types.ClaimSubmission, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, *claimFromDB(row))
+	}
+	return out, nil
+}
+
+func (r *ClaimRepository) MarkConfirmed(ctx context.Context, nonce int64, blockNumber int64) error {
+	if err := r.q.MarkClaimConfirmed(ctx, &queries.MarkClaimConfirmedParams{
+		Nonce:       nonce,
+		BlockNumber: pgtype.Int8{Int64: blockNumber, Valid: true},
+	}); err != nil {
+		return fmt.Errorf("mark confirmed: %w", err)
+	}
+	return nil
+}
+
+func (r *ClaimRepository) MarkFailed(ctx context.Context, nonce int64, reason string) error {
+	if err := r.q.MarkClaimFailed(ctx, &queries.MarkClaimFailedParams{
+		Nonce:         nonce,
+		FailureReason: pgtype.Text{String: reason, Valid: true},
+	}); err != nil {
+		return fmt.Errorf("mark failed: %w", err)
+	}
+	return nil
+}
+
+func (r *ClaimRepository) UpdateRebroadcast(
+	ctx context.Context,
+	nonce int64,
+	newTxHash string,
+	maxFeeGwei int32,
+	maxPriorityFeeGwei int32,
+) error {
+	if err := r.q.UpdateClaimRebroadcast(ctx, &queries.UpdateClaimRebroadcastParams{
+		Nonce:              nonce,
+		TxHash:             newTxHash,
+		MaxFeeGwei:         maxFeeGwei,
+		MaxPriorityFeeGwei: maxPriorityFeeGwei,
+	}); err != nil {
+		return fmt.Errorf("update rebroadcast: %w", err)
+	}
+	return nil
+}
+
+func claimFromDB(row *queries.AgentClaimSubmission) *types.ClaimSubmission {
+	out := &types.ClaimSubmission{
+		PublicKey:          row.PublicKey,
+		Nonce:              row.Nonce,
+		Recipient:          row.Recipient,
+		TxHash:             row.TxHash,
+		PreviousTxHashes:   row.PreviousTxHashes,
+		Status:             types.ClaimStatus(row.Status),
+		MaxFeeGwei:         row.MaxFeeGwei,
+		MaxPriorityFeeGwei: row.MaxPriorityFeeGwei,
+		SubmittedAt:        row.SubmittedAt.Time,
+	}
+	// pgtype.Numeric → *big.Int via the canonical decimal string
+	if amountStr, err := row.Amount.Value(); err == nil && amountStr != nil {
+		amount := new(big.Int)
+		amount.SetString(fmt.Sprintf("%v", amountStr), 10)
+		out.Amount = amount
+	}
+	if row.BlockNumber.Valid {
+		v := row.BlockNumber.Int64
+		out.BlockNumber = &v
+	}
+	if row.FailureReason.Valid {
+		v := row.FailureReason.String
+		out.FailureReason = &v
+	}
+	if row.ConfirmedAt.Valid {
+		v := row.ConfirmedAt.Time
+		out.ConfirmedAt = &v
+	}
+	if row.FailedAt.Valid {
+		v := row.FailedAt.Time
+		out.FailedAt = &v
+	}
+	return out
+}
+```
+
+The exact field names on the generated struct (`AgentClaimSubmission`) and param structs (`InsertClaimSubmissionParams`, etc.) come from sqlc — open `internal/storage/postgres/queries/airdrop_claims.sql.go` after Step 4 of Task 2 to confirm. The shape above matches sqlc's `pgx/v5` defaults with `emit_params_struct_pointers: true` (per `sqlc.yaml`).
+
+- [ ] **Step 6: Implement `RelayerStateRepository`**
+
+Create `internal/storage/postgres/airdrop_relayer_state.go`:
+
+```go
+package postgres
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/vultisig/agent-backend/internal/storage/postgres/queries"
+	"github.com/vultisig/agent-backend/internal/types"
+)
+
+type RelayerStateRepository struct {
+	pool *pgxpool.Pool
+	q    *queries.Queries
+}
+
+func NewRelayerStateRepository(pool *pgxpool.Pool) *RelayerStateRepository {
+	return &RelayerStateRepository{pool: pool, q: queries.New(pool)}
+}
+
+// Get is a lock-free read for the balance endpoint and the auto-init probe.
+func (r *RelayerStateRepository) Get(ctx context.Context) (*types.RelayerState, error) {
+	row, err := r.q.GetRelayerState(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get relayer state: %w", err)
+	}
+	return relayerStateFromDB(row), nil
+}
+
+// LockWithTx runs SELECT ... FOR UPDATE inside the supplied transaction.
+// Caller must have BEGUN the tx and must COMMIT or ROLLBACK it.
+func (r *RelayerStateRepository) LockWithTx(ctx context.Context, tx pgx.Tx) (*types.RelayerState, error) {
+	row, err := r.q.WithTx(tx).LockRelayerState(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("lock relayer state: %w", err)
+	}
+	return relayerStateFromDB(row), nil
+}
+
+// SetNonceWithTx writes the next_nonce inside the supplied transaction.
+func (r *RelayerStateRepository) SetNonceWithTx(ctx context.Context, tx pgx.Tx, nextNonce int64) error {
+	if err := r.q.WithTx(tx).SetRelayerNonce(ctx, pgtype.Int8{Int64: nextNonce, Valid: true}); err != nil {
+		return fmt.Errorf("set relayer nonce: %w", err)
+	}
+	return nil
+}
+
+// Pool exposes the underlying pgxpool — the claim service needs it to call
+// BeginTx directly. Returns the same *pgxpool.Pool the constructor was given.
+func (r *RelayerStateRepository) Pool() *pgxpool.Pool { return r.pool }
+
+func relayerStateFromDB(row *queries.AgentRelayerState) *types.RelayerState {
+	out := &types.RelayerState{LastSynced: row.LastSynced.Time}
+	if row.NextNonce.Valid {
+		v := row.NextNonce.Int64
+		out.NextNonce = &v
+	}
+	return out
+}
+```
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+```bash
+go test ./internal/storage/postgres/ -run 'TestClaimRepo|TestRelayerStateRepo' -v
+```
+
+Expected: PASS for all subtests, given `DATABASE_DSN` is set.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add internal/types/airdrop_claim.go \
+         internal/storage/postgres/airdrop_claim.go \
+         internal/storage/postgres/airdrop_claim_test.go \
+         internal/storage/postgres/airdrop_relayer_state.go \
+         internal/storage/postgres/airdrop_relayer_state_test.go
+git commit -m "feat(airdrop): add ClaimRepository + RelayerStateRepository"
+```
+
+---
+
+## Task 4: Calldata builder for `claim(address)`
+
+**Why:** The contract surface is `function claim(address recipient)` (`sibling-on-chain-contract.md:66`). Calldata is `keccak256("claim(address)")[:4] ++ left_pad32(recipient)` — 36 bytes total. Hand-rolled — easier to test against a fixed fixture than dragging in `accounts/abi`'s parser, and avoids any "did the ABI shape change" surprise.
+
+**Files:**
+- Create: `internal/service/airdrop/relayer/calldata.go`
+- Create: `internal/service/airdrop/relayer/calldata_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/service/airdrop/relayer/calldata_test.go`:
+
+```go
+package relayer
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+// TestClaimSelector confirms the 4-byte function selector matches keccak256("claim(address)")[:4].
+// Computed independently with go-ethereum's keccak so we don't trust a hardcoded constant blindly.
+func TestClaimSelector(t *testing.T) {
+	want := crypto.Keccak256([]byte("claim(address)"))[:4]
+	if hex.EncodeToString(claimSelector) != hex.EncodeToString(want) {
+		t.Errorf("claimSelector = %x, want %x", claimSelector, want)
+	}
+	// Sanity-check the actual bytes — keccak256("claim(address)") is well-known
+	// (matches what cast's `cast sig "claim(address)"` returns).
+	wantHex := "1e83409a"
+	if hex.EncodeToString(claimSelector) != wantHex {
+		t.Errorf("claimSelector hex = %x, want %s", claimSelector, wantHex)
+	}
+}
+
+func TestBuildClaimCalldata(t *testing.T) {
+	recipient := common.HexToAddress("0x70997970C51812dc3A010C7d01b50e0d17dc79C8") // anvil[1]
+
+	got := BuildClaimCalldata(recipient)
+	if len(got) != 36 {
+		t.Fatalf("calldata length = %d, want 36", len(got))
+	}
+
+	// Selector
+	if hex.EncodeToString(got[:4]) != "1e83409a" {
+		t.Errorf("selector bytes = %x, want 1e83409a", got[:4])
+	}
+	// 12 zero pad bytes
+	for i := 4; i < 16; i++ {
+		if got[i] != 0 {
+			t.Errorf("byte %d = %d, want zero pad", i, got[i])
+		}
+	}
+	// 20 address bytes
+	if hex.EncodeToString(got[16:]) != "70997970c51812dc3a010c7d01b50e0d17dc79c8" {
+		t.Errorf("address bytes = %x, want 70997970...", got[16:])
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+go test ./internal/service/airdrop/relayer/ -v
+```
+
+Expected: compile error — package, selector, builder all undefined.
+
+- [ ] **Step 3: Implement the calldata builder**
+
+Create `internal/service/airdrop/relayer/calldata.go`:
+
+```go
+// Package relayer implements the Stage 4 airdrop claim relayer:
+// calldata + tx building, KMS-signed broadcast under a serialising
+// SELECT FOR UPDATE lock, confirmation monitoring, and same-nonce rebroadcast.
+package relayer
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// claimSelector is the 4-byte function selector for AirdropClaim.claim(address).
+// Equal to keccak256("claim(address)")[:4]. Verified by TestClaimSelector.
+var claimSelector = []byte{0x1e, 0x83, 0x40, 0x9a}
+
+// BuildClaimCalldata returns the 36-byte EVM calldata payload for
+// AirdropClaim.claim(recipient): 4-byte selector ++ 32-byte left-padded recipient.
+//
+// The contract is `function claim(address recipient) external` — see
+// sibling-on-chain-contract.md. The amount lives on-chain in the contract's
+// allowance(recipient) mapping, populated by the multisig's setWinners batch.
+func BuildClaimCalldata(recipient common.Address) []byte {
+	out := make([]byte, 0, 36)
+	out = append(out, claimSelector...)
+	out = append(out, make([]byte, 12)...) // left-pad address to 32 bytes
+	out = append(out, recipient.Bytes()...)
+	return out
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+go test ./internal/service/airdrop/relayer/ -v
+```
+
+Expected: PASS for both subtests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/service/airdrop/relayer/calldata.go internal/service/airdrop/relayer/calldata_test.go
+git commit -m "feat(airdrop): add claim(address) calldata builder"
+```
+
+---
+
+## Task 5: EIP-1559 tx builder + KMS sign assembly
+
+**Why:** Pure function: take (chainID, nonce, gasParams, to, calldata) → unsigned `types.DynamicFeeTx` → ask KMS signer for `(r, s, v)` over the EIP-155 signing hash → produce signed RLP bytes. Splitting build from sign keeps the unit tests trivial — sign exercises the KMS round-trip path tested in shared infra.
+
+**Files:**
+- Create: `internal/service/airdrop/relayer/tx.go`
+- Create: `internal/service/airdrop/relayer/tx_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/service/airdrop/relayer/tx_test.go`:
+
+```go
+package relayer
+
+import (
+	"bytes"
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+// fakeSigner implements the kms.Signer interface using a local secp256k1 key.
+// Lets us exercise BuildAndSignTx without an AWS KMS round-trip.
+type fakeSigner struct {
+	priv *crypto.PrivateKey
+}
+
+func newFakeSigner(t *testing.T) *fakeSigner {
+	priv, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	return &fakeSigner{priv: (*crypto.PrivateKey)(priv)}
+}
+
+func (f *fakeSigner) Address() common.Address {
+	return crypto.PubkeyToAddress((*crypto.PublicKey)(f.priv).ECDSA().PublicKey)
+}
+
+func (f *fakeSigner) SignDigest(_ context.Context, digest []byte) ([]byte, error) {
+	return crypto.Sign(digest, (*crypto.PrivateKey)(f.priv).ECDSA())
+}
+
+// crypto.PrivateKey/PublicKey shims — go-ethereum uses *ecdsa.PrivateKey directly,
+// no shim needed in production. Replace this scaffold with the real signer interface
+// if convenient; the shape that matters is (Address() common.Address, SignDigest(...)).
+
+func TestBuildAndSignTx(t *testing.T) {
+	signer := newFakeSigner(t)
+	chainID := big.NewInt(1)
+
+	to := common.HexToAddress("0x1111111111111111111111111111111111111111")
+	calldata := []byte{0xde, 0xad, 0xbe, 0xef}
+	params := TxParams{
+		ChainID:              chainID,
+		Nonce:                7,
+		GasLimit:             100000,
+		MaxFeePerGasWei:      big.NewInt(50_000_000_000), // 50 gwei
+		MaxPriorityFeeWei:    big.NewInt(2_000_000_000),  //  2 gwei
+		To:                   to,
+		Calldata:             calldata,
+	}
+
+	signedBytes, txHash, err := BuildAndSignTx(context.Background(), signer, params)
+	if err != nil {
+		t.Fatalf("BuildAndSignTx: %v", err)
+	}
+	if len(signedBytes) == 0 {
+		t.Fatal("signedBytes empty")
+	}
+	if txHash == (common.Hash{}) {
+		t.Fatal("txHash zero")
+	}
+
+	// Decode the signed bytes and confirm the recovered sender matches the signer's address.
+	tx := new(types.Transaction)
+	if err := tx.UnmarshalBinary(signedBytes); err != nil {
+		t.Fatalf("UnmarshalBinary: %v", err)
+	}
+	if tx.Type() != types.DynamicFeeTxType {
+		t.Errorf("tx type = %d, want %d (DynamicFeeTxType)", tx.Type(), types.DynamicFeeTxType)
+	}
+	if tx.Nonce() != 7 {
+		t.Errorf("nonce = %d, want 7", tx.Nonce())
+	}
+	if tx.Gas() != 100000 {
+		t.Errorf("gas = %d, want 100000", tx.Gas())
+	}
+	if !bytes.Equal(tx.Data(), calldata) {
+		t.Errorf("data = %x, want %x", tx.Data(), calldata)
+	}
+
+	gethSigner := types.LatestSignerForChainID(chainID)
+	sender, err := types.Sender(gethSigner, tx)
+	if err != nil {
+		t.Fatalf("recover sender: %v", err)
+	}
+	if sender != signer.Address() {
+		t.Errorf("recovered sender = %s, want %s", sender.Hex(), signer.Address().Hex())
+	}
+}
+```
+
+A note on the fake-signer scaffold above: in practice the simplest fake is `func(ctx, digest) ([]byte, error) { return crypto.Sign(digest, priv) }` with `priv *ecdsa.PrivateKey`. Drop the `crypto.PrivateKey` shim and use `*ecdsa.PrivateKey` directly — go-ethereum's `crypto.Sign` returns the 65-byte `(r||s||v)` signature directly, which is exactly what `BuildAndSignTx` expects from the KMS signer too. The shim is shown above only to keep the test diff focused; replace with `*ecdsa.PrivateKey` when you write it.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+go test ./internal/service/airdrop/relayer/ -run TestBuildAndSignTx -v
+```
+
+Expected: compile error — `TxParams`, `BuildAndSignTx` undefined.
+
+- [ ] **Step 3: Implement the tx builder**
+
+Create `internal/service/airdrop/relayer/tx.go`:
+
+```go
+package relayer
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+
+	"github.com/vultisig/agent-backend/internal/service/airdrop/kms"
+)
+
+// TxParams holds everything needed to build the unsigned EIP-1559 tx.
+type TxParams struct {
+	ChainID           *big.Int
+	Nonce             uint64
+	GasLimit          uint64
+	MaxFeePerGasWei   *big.Int
+	MaxPriorityFeeWei *big.Int
+	To                common.Address
+	Calldata          []byte
+}
+
+// BuildAndSignTx assembles an EIP-1559 (DynamicFeeTx) transaction with the
+// supplied parameters, asks the KMS signer for a signature over the
+// EIP-155 signing hash for ChainID, attaches it, and returns the
+// canonical-marshalled signed bytes plus the resulting tx hash.
+//
+// Pure of any RPC: caller is responsible for sourcing the gas params + nonce
+// and for broadcasting `signedBytes` afterward.
+func BuildAndSignTx(ctx context.Context, signer kms.Signer, p TxParams) (signedBytes []byte, txHash common.Hash, err error) {
+	unsigned := types.NewTx(&types.DynamicFeeTx{
+		ChainID:   p.ChainID,
+		Nonce:     p.Nonce,
+		GasTipCap: p.MaxPriorityFeeWei,
+		GasFeeCap: p.MaxFeePerGasWei,
+		Gas:       p.GasLimit,
+		To:        &p.To,
+		Value:     big.NewInt(0),
+		Data:      p.Calldata,
+	})
+
+	gethSigner := types.LatestSignerForChainID(p.ChainID)
+	digest := gethSigner.Hash(unsigned).Bytes()
+
+	sigRSV, err := signer.SignDigest(ctx, digest)
+	if err != nil {
+		return nil, common.Hash{}, fmt.Errorf("sign digest: %w", err)
+	}
+	if len(sigRSV) != 65 {
+		return nil, common.Hash{}, fmt.Errorf("sign returned %d bytes, want 65", len(sigRSV))
+	}
+
+	signed, err := unsigned.WithSignature(gethSigner, sigRSV)
+	if err != nil {
+		return nil, common.Hash{}, fmt.Errorf("attach signature: %w", err)
+	}
+
+	out, err := signed.MarshalBinary()
+	if err != nil {
+		return nil, common.Hash{}, fmt.Errorf("marshal signed tx: %w", err)
+	}
+	return out, signed.Hash(), nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+go test ./internal/service/airdrop/relayer/ -run TestBuildAndSignTx -v
+```
+
+Expected: PASS. Recovered sender matches the fake signer's address.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/service/airdrop/relayer/tx.go internal/service/airdrop/relayer/tx_test.go
+git commit -m "feat(airdrop): add EIP-1559 tx builder + KMS-signed assembly"
+```
+
+---
+
+## Task 6: Auto-init relayer nonce on first boot
+
+**Why:** Per cleanup pass — `agent_relayer_state.next_nonce` is NULL after migration; on first boot the relayer queries `eth_getTransactionCount(relayer_address, 'pending')` and writes the result inside a `SELECT FOR UPDATE` txn. Subsequent boots see a non-null nonce and no-op. Removes a Day 28 manual-psql footgun.
+
+**Files:**
+- Create: `internal/service/airdrop/relayer/nonce.go`
+- Create: `internal/service/airdrop/relayer/nonce_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/service/airdrop/relayer/nonce_test.go`:
+
+```go
+package relayer
+
+import (
+	"context"
+	"errors"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+// fakeRPCNonce implements the slice of ethclient.Client InitNonceIfNeeded uses.
+type fakeRPCNonce struct {
+	nonceAt func(ctx context.Context, addr common.Address, block *big.Int) (uint64, error)
+	called  int
+}
+
+func (f *fakeRPCNonce) NonceAt(ctx context.Context, addr common.Address, block *big.Int) (uint64, error) {
+	f.called++
+	return f.nonceAt(ctx, addr, block)
+}
+
+// Stub the rest of the Client interface (unused by InitNonceIfNeeded) — return errors so
+// any accidental call fails loudly.
+func (f *fakeRPCNonce) LatestBaseFee(_ context.Context) (*big.Int, error)               { return nil, errors.New("unused") }
+func (f *fakeRPCNonce) SuggestGasTipCap(_ context.Context) (*big.Int, error)            { return nil, errors.New("unused") }
+func (f *fakeRPCNonce) SendRawTransaction(_ context.Context, _ []byte) (common.Hash, error) {
+	return common.Hash{}, errors.New("unused")
+}
+func (f *fakeRPCNonce) GetTransactionReceipt(_ context.Context, _ common.Hash) (*types.Receipt, error) {
+	return nil, errors.New("unused")
+}
+func (f *fakeRPCNonce) BalanceOf(_ context.Context, _, _ common.Address) (*big.Int, error) {
+	return nil, errors.New("unused")
+}
+func (f *fakeRPCNonce) Balance(_ context.Context, _ common.Address) (*big.Int, error) {
+	return nil, errors.New("unused")
+}
+func (f *fakeRPCNonce) EstimateGas(_ context.Context, _, _ common.Address, _ []byte, _ *big.Int) (uint64, error) {
+	return 0, errors.New("unused")
+}
+
+func TestInitNonceIfNeeded_PopulatesWhenNil(t *testing.T) {
+	pool := newNonceTestPool(t)               // helper that resets relayer_state to nil-nonce
+	repo := postgres.NewRelayerStateRepository(pool)
+	rpc := &fakeRPCNonce{
+		nonceAt: func(_ context.Context, _ common.Address, _ *big.Int) (uint64, error) {
+			return 17, nil
+		},
+	}
+
+	addr := common.HexToAddress("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266")
+	if err := InitNonceIfNeeded(context.Background(), repo, rpc, addr); err != nil {
+		t.Fatalf("InitNonceIfNeeded: %v", err)
+	}
+
+	st, _ := repo.Get(context.Background())
+	if st.NextNonce == nil || *st.NextNonce != 17 {
+		t.Errorf("after init, next_nonce = %v, want 17", st.NextNonce)
+	}
+	if rpc.called != 1 {
+		t.Errorf("rpc.NonceAt called %d times, want 1", rpc.called)
+	}
+}
+
+func TestInitNonceIfNeeded_NoOpWhenAlreadySet(t *testing.T) {
+	pool := newNonceTestPool(t)
+	if _, err := pool.Exec(context.Background(), `UPDATE agent_relayer_state SET next_nonce = 99 WHERE id = 1`); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	repo := postgres.NewRelayerStateRepository(pool)
+	rpc := &fakeRPCNonce{
+		nonceAt: func(_ context.Context, _ common.Address, _ *big.Int) (uint64, error) {
+			t.Fatal("rpc.NonceAt should not be called when nonce is already populated")
+			return 0, nil
+		},
+	}
+
+	addr := common.HexToAddress("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266")
+	if err := InitNonceIfNeeded(context.Background(), repo, rpc, addr); err != nil {
+		t.Fatalf("InitNonceIfNeeded: %v", err)
+	}
+
+	st, _ := repo.Get(context.Background())
+	if st.NextNonce == nil || *st.NextNonce != 99 {
+		t.Errorf("nonce changed to %v, want 99", st.NextNonce)
+	}
+}
+```
+
+The test imports `github.com/vultisig/agent-backend/internal/storage/postgres`. Reuse the `newNonceTestPool` helper from `airdrop_relayer_state_test.go` — copy/paste it into this test file with the same body, or extract into a shared `_test_util.go` if you'd rather avoid the duplication.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+go test ./internal/service/airdrop/relayer/ -run TestInitNonce -v
+```
+
+Expected: compile error — `InitNonceIfNeeded` undefined.
+
+- [ ] **Step 3: Implement the auto-init helper**
+
+Create `internal/service/airdrop/relayer/nonce.go`:
+
+```go
+package relayer
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/vultisig/agent-backend/internal/service/airdrop/ethclient"
+	"github.com/vultisig/agent-backend/internal/storage/postgres"
+)
+
+// InitNonceIfNeeded populates agent_relayer_state.next_nonce on first boot.
+// Called from cmd/server/main.go and cmd/scheduler/main.go right after the
+// repos are constructed. Subsequent boots no-op.
+//
+// Concurrency note: SELECT FOR UPDATE serialises against any other process
+// (including a concurrent /airdrop/claim handler) — only one writer ever
+// observes the nil nonce.
+func InitNonceIfNeeded(
+	ctx context.Context,
+	repo *postgres.RelayerStateRepository,
+	rpc ethclient.Client,
+	relayerAddress common.Address,
+) error {
+	tx, err := repo.Pool().BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	st, err := repo.LockWithTx(ctx, tx)
+	if err != nil {
+		return fmt.Errorf("lock relayer state: %w", err)
+	}
+	if st.NextNonce != nil {
+		// Already set — nothing to do. Rollback (no-op) and exit.
+		return nil
+	}
+
+	chainNonce, err := rpc.NonceAt(ctx, relayerAddress, nil) // nil = latest (== pending in geth client)
+	if err != nil {
+		return fmt.Errorf("query chain nonce: %w", err)
+	}
+
+	if err := repo.SetNonceWithTx(ctx, tx, int64(chainNonce)); err != nil {
+		return fmt.Errorf("set nonce: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("commit: %w", err)
+	}
+	return nil
+}
+```
+
+Note: the spec asks for `eth_getTransactionCount(addr, 'pending')`. go-ethereum's `NonceAt(ctx, addr, nil)` calls `eth_getTransactionCount(addr, 'latest')`. The `pending` variant exists at `PendingNonceAt`. For the auto-init case the difference doesn't matter — the relayer wallet has zero in-flight transactions on first boot, so `latest == pending`. Using the existing wrapper avoids adding a one-off `PendingNonceAt` method to the wrapper just for this call site.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+go test ./internal/service/airdrop/relayer/ -run TestInitNonce -v
+```
+
+Expected: PASS for both subtests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/service/airdrop/relayer/nonce.go internal/service/airdrop/relayer/nonce_test.go
+git commit -m "feat(airdrop): add auto-init nonce helper for relayer state"
+```
+
+---
+
+## Task 7: Claim service — full submit pipeline
+
+**Why:** The heart of Stage 4. Single function call from the HTTP handler: `service.Submit(ctx, publicKey)` runs the entire `BEGIN → SELECT FOR UPDATE → idempotency check → load winner → gas estimate → build → sign → broadcast → INSERT → UPDATE state → COMMIT` sequence. ROLLBACK on any failure. Tests exercise both serialisation (50 distinct users → 50 distinct nonces) and idempotency (50 same-user → 1 tx + 49 retries returning the same hash).
+
+**Files:**
+- Create: `internal/service/airdrop/relayer/claim.go`
+- Create: `internal/service/airdrop/relayer/claim_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `internal/service/airdrop/relayer/claim_test.go`:
+
+```go
+package relayer
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"errors"
+	"math/big"
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/vultisig/agent-backend/internal/storage/postgres"
+)
+
+// ---- helpers ----
+
+func newClaimServiceTestPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	dsn := os.Getenv("TEST_DATABASE_DSN")
+	if dsn == "" {
+		dsn = os.Getenv("DATABASE_DSN")
+	}
+	if dsn == "" {
+		t.Skip("TEST_DATABASE_DSN or DATABASE_DSN not set")
+	}
+	pool, err := pgxpool.New(context.Background(), dsn)
+	if err != nil {
+		t.Fatalf("pgxpool: %v", err)
+	}
+	t.Cleanup(func() { pool.Close() })
+	_, err = pool.Exec(context.Background(), `
+		TRUNCATE agent_claim_submissions;
+		UPDATE agent_relayer_state SET next_nonce = 0 WHERE id = 1;
+		TRUNCATE agent_raffle_winners;
+	`)
+	if err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+	return pool
+}
+
+func seedWinner(t *testing.T, pool *pgxpool.Pool, pk, recipient string, amountWei *big.Int) {
+	t.Helper()
+	_, err := pool.Exec(context.Background(),
+		`INSERT INTO agent_raffle_winners (public_key, recipient, amount) VALUES ($1, $2, $3::numeric)`,
+		pk, recipient, amountWei.String())
+	if err != nil {
+		t.Fatalf("seed winner: %v", err)
+	}
+}
+
+// fakeRPC implements ethclient.Client with controllable responses.
+type fakeRPC struct {
+	mu        sync.Mutex
+	sentTxs   []common.Hash
+	estimateGasFunc func() (uint64, error)
+}
+
+func (f *fakeRPC) LatestBaseFee(_ context.Context) (*big.Int, error) {
+	return big.NewInt(20_000_000_000), nil // 20 gwei
+}
+func (f *fakeRPC) SuggestGasTipCap(_ context.Context) (*big.Int, error) {
+	return big.NewInt(2_000_000_000), nil // 2 gwei
+}
+func (f *fakeRPC) NonceAt(_ context.Context, _ common.Address, _ *big.Int) (uint64, error) {
+	return 0, nil
+}
+func (f *fakeRPC) SendRawTransaction(_ context.Context, signed []byte) (common.Hash, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	tx := new(types.Transaction)
+	if err := tx.UnmarshalBinary(signed); err != nil {
+		return common.Hash{}, err
+	}
+	f.sentTxs = append(f.sentTxs, tx.Hash())
+	return tx.Hash(), nil
+}
+func (f *fakeRPC) GetTransactionReceipt(_ context.Context, _ common.Hash) (*types.Receipt, error) {
+	return nil, errors.New("unused")
+}
+func (f *fakeRPC) BalanceOf(_ context.Context, _, _ common.Address) (*big.Int, error) {
+	return nil, errors.New("unused")
+}
+func (f *fakeRPC) Balance(_ context.Context, _ common.Address) (*big.Int, error) {
+	return nil, errors.New("unused")
+}
+func (f *fakeRPC) EstimateGas(_ context.Context, _, _ common.Address, _ []byte, _ *big.Int) (uint64, error) {
+	if f.estimateGasFunc != nil {
+		return f.estimateGasFunc()
+	}
+	return 80_000, nil
+}
+
+// localSigner mimics kms.Signer using an in-memory ecdsa key.
+type localSigner struct{ priv *ecdsa.PrivateKey }
+
+func newLocalSigner(t *testing.T) *localSigner {
+	t.Helper()
+	priv, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	return &localSigner{priv: priv}
+}
+
+func (l *localSigner) Address() common.Address              { return crypto.PubkeyToAddress(l.priv.PublicKey) }
+func (l *localSigner) SignDigest(_ context.Context, d []byte) ([]byte, error) {
+	return crypto.Sign(d, l.priv)
+}
+
+// ---- tests ----
+
+func TestClaimService_Submit_Fresh(t *testing.T) {
+	pool := newClaimServiceTestPool(t)
+	claimRepo := postgres.NewClaimRepository(pool)
+	stateRepo := postgres.NewRelayerStateRepository(pool)
+
+	winnerPK := "pk-fresh"
+	recipient := common.HexToAddress("0x70997970C51812dc3A010C7d01b50e0d17dc79C8")
+	seedWinner(t, pool, winnerPK, recipient.Hex(), big.NewInt(1_500_000_000_000_000_000))
+
+	svc := NewClaimService(ClaimServiceConfig{
+		ChainID:         big.NewInt(1),
+		ContractAddress: common.HexToAddress("0xCCCCCcCCCcCCCCcCcCCCCCcCcCCCcCCcCcCCCcCC"),
+		ClaimRepo:       claimRepo,
+		StateRepo:       stateRepo,
+		WinnerLookup:    pgxWinnerLookup{pool: pool},
+		RPC:             &fakeRPC{},
+		Signer:          newLocalSigner(t),
+	})
+
+	row, err := svc.Submit(context.Background(), winnerPK)
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+	if row.Nonce != 0 {
+		t.Errorf("nonce = %d, want 0 (first claim)", row.Nonce)
+	}
+	if row.TxHash == "" {
+		t.Error("tx_hash empty")
+	}
+
+	// State nonce must have advanced
+	st, _ := stateRepo.Get(context.Background())
+	if st.NextNonce == nil || *st.NextNonce != 1 {
+		t.Errorf("after submit, next_nonce = %v, want 1", st.NextNonce)
+	}
+}
+
+func TestClaimService_Submit_IdempotentRetry(t *testing.T) {
+	pool := newClaimServiceTestPool(t)
+	claimRepo := postgres.NewClaimRepository(pool)
+	stateRepo := postgres.NewRelayerStateRepository(pool)
+	winnerPK := "pk-retry"
+	recipient := common.HexToAddress("0x70997970C51812dc3A010C7d01b50e0d17dc79C8")
+	seedWinner(t, pool, winnerPK, recipient.Hex(), big.NewInt(1_500_000_000_000_000_000))
+
+	rpc := &fakeRPC{}
+	svc := NewClaimService(ClaimServiceConfig{
+		ChainID: big.NewInt(1), ContractAddress: common.HexToAddress("0xCCCC"),
+		ClaimRepo: claimRepo, StateRepo: stateRepo,
+		WinnerLookup: pgxWinnerLookup{pool: pool}, RPC: rpc, Signer: newLocalSigner(t),
+	})
+
+	first, _ := svc.Submit(context.Background(), winnerPK)
+	second, err := svc.Submit(context.Background(), winnerPK)
+	if err != nil {
+		t.Fatalf("retry: %v", err)
+	}
+	if first.TxHash != second.TxHash {
+		t.Errorf("retry returned %s, want first tx %s", second.TxHash, first.TxHash)
+	}
+	if len(rpc.sentTxs) != 1 {
+		t.Errorf("rpc broadcasts = %d, want 1 (second call should not broadcast)", len(rpc.sentTxs))
+	}
+	st, _ := stateRepo.Get(context.Background())
+	if *st.NextNonce != 1 {
+		t.Errorf("nonce advanced too far: %v, want 1", *st.NextNonce)
+	}
+}
+
+func TestClaimService_Submit_ConcurrentDistinctUsers_DistinctNonces(t *testing.T) {
+	pool := newClaimServiceTestPool(t)
+	claimRepo := postgres.NewClaimRepository(pool)
+	stateRepo := postgres.NewRelayerStateRepository(pool)
+
+	const N = 50
+	for i := 0; i < N; i++ {
+		pk := "pk-conc-" + string(rune('a'+i))
+		seedWinner(t, pool, pk, "0x70997970C51812dc3A010C7d01b50e0d17dc79C8", big.NewInt(1500))
+	}
+
+	svc := NewClaimService(ClaimServiceConfig{
+		ChainID: big.NewInt(1), ContractAddress: common.HexToAddress("0xCCCC"),
+		ClaimRepo: claimRepo, StateRepo: stateRepo,
+		WinnerLookup: pgxWinnerLookup{pool: pool}, RPC: &fakeRPC{}, Signer: newLocalSigner(t),
+	})
+
+	var wg sync.WaitGroup
+	results := make([]*ClaimResult, N)
+	errs := make([]error, N)
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			pk := "pk-conc-" + string(rune('a'+i))
+			results[i], errs[i] = svc.Submit(context.Background(), pk)
+		}(i)
+	}
+	wg.Wait()
+
+	seenNonces := map[int64]bool{}
+	for i := 0; i < N; i++ {
+		if errs[i] != nil {
+			t.Errorf("user %d: %v", i, errs[i])
+			continue
+		}
+		if seenNonces[results[i].Nonce] {
+			t.Errorf("duplicate nonce %d (users %d)", results[i].Nonce, i)
+		}
+		seenNonces[results[i].Nonce] = true
+	}
+	if len(seenNonces) != N {
+		t.Errorf("got %d distinct nonces, want %d", len(seenNonces), N)
+	}
+}
+
+func TestClaimService_Submit_ConcurrentSameUser_SingleTx(t *testing.T) {
+	pool := newClaimServiceTestPool(t)
+	claimRepo := postgres.NewClaimRepository(pool)
+	stateRepo := postgres.NewRelayerStateRepository(pool)
+	winnerPK := "pk-same"
+	seedWinner(t, pool, winnerPK, "0x70997970C51812dc3A010C7d01b50e0d17dc79C8", big.NewInt(1500))
+
+	rpc := &fakeRPC{}
+	svc := NewClaimService(ClaimServiceConfig{
+		ChainID: big.NewInt(1), ContractAddress: common.HexToAddress("0xCCCC"),
+		ClaimRepo: claimRepo, StateRepo: stateRepo,
+		WinnerLookup: pgxWinnerLookup{pool: pool}, RPC: rpc, Signer: newLocalSigner(t),
+	})
+
+	const N = 50
+	var wg sync.WaitGroup
+	hashes := make([]string, N)
+	errs := make([]error, N)
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			r, err := svc.Submit(context.Background(), winnerPK)
+			errs[i] = err
+			if r != nil {
+				hashes[i] = r.TxHash
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	// All errors should be nil; all hashes should match.
+	first := hashes[0]
+	for i := 0; i < N; i++ {
+		if errs[i] != nil {
+			t.Errorf("call %d: %v", i, errs[i])
+		}
+		if hashes[i] != first {
+			t.Errorf("call %d hash %s != first %s", i, hashes[i], first)
+		}
+	}
+	if len(rpc.sentTxs) != 1 {
+		t.Errorf("rpc broadcasts = %d, want 1 (49 must be idempotent retries)", len(rpc.sentTxs))
+	}
+}
+
+func TestClaimService_Submit_NotAWinner(t *testing.T) {
+	pool := newClaimServiceTestPool(t)
+	svc := NewClaimService(ClaimServiceConfig{
+		ChainID: big.NewInt(1), ContractAddress: common.HexToAddress("0xCCCC"),
+		ClaimRepo: postgres.NewClaimRepository(pool),
+		StateRepo: postgres.NewRelayerStateRepository(pool),
+		WinnerLookup: pgxWinnerLookup{pool: pool},
+		RPC: &fakeRPC{}, Signer: newLocalSigner(t),
+	})
+
+	_, err := svc.Submit(context.Background(), "pk-not-winner")
+	if !errors.Is(err, ErrNotAWinner) {
+		t.Errorf("err = %v, want ErrNotAWinner", err)
+	}
+}
+
+func TestClaimService_Submit_RPCFailure_RollsBackNonce(t *testing.T) {
+	pool := newClaimServiceTestPool(t)
+	winnerPK := "pk-rpc-fail"
+	seedWinner(t, pool, winnerPK, "0x70997970C51812dc3A010C7d01b50e0d17dc79C8", big.NewInt(1500))
+
+	rpc := &fakeRPC{estimateGasFunc: func() (uint64, error) { return 0, errors.New("rpc down") }}
+	svc := NewClaimService(ClaimServiceConfig{
+		ChainID: big.NewInt(1), ContractAddress: common.HexToAddress("0xCCCC"),
+		ClaimRepo: postgres.NewClaimRepository(pool),
+		StateRepo: postgres.NewRelayerStateRepository(pool),
+		WinnerLookup: pgxWinnerLookup{pool: pool},
+		RPC: rpc, Signer: newLocalSigner(t),
+	})
+
+	_, err := svc.Submit(context.Background(), winnerPK)
+	if !errors.Is(err, ErrRPCUnavailable) {
+		t.Errorf("err = %v, want ErrRPCUnavailable", err)
+	}
+	st, _ := postgres.NewRelayerStateRepository(pool).Get(context.Background())
+	if st.NextNonce == nil || *st.NextNonce != 0 {
+		t.Errorf("nonce advanced after rollback: %v, want 0", st.NextNonce)
+	}
+}
+```
+
+The test references a `pgxWinnerLookup` adapter — see Step 4 below where it's introduced as a tiny shim around the pool so the service can take an interface (not the concrete pool) and tests can pass a mock if they need to.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+go test ./internal/service/airdrop/relayer/ -run TestClaimService -v
+```
+
+Expected: compile error — `NewClaimService`, `ClaimServiceConfig`, `ClaimResult`, `ErrNotAWinner`, `ErrRPCUnavailable`, `pgxWinnerLookup` undefined.
+
+- [ ] **Step 3: Implement the claim service**
+
+Create `internal/service/airdrop/relayer/claim.go`:
+
+```go
+package relayer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/vultisig/agent-backend/internal/service/airdrop/ethclient"
+	"github.com/vultisig/agent-backend/internal/service/airdrop/kms"
+	"github.com/vultisig/agent-backend/internal/storage/postgres"
+	"github.com/vultisig/agent-backend/internal/types"
+)
+
+// Sentinel errors. The HTTP handler maps these to the documented status codes.
+var (
+	ErrNotAWinner       = errors.New("public key is not in agent_raffle_winners")
+	ErrRPCUnavailable   = errors.New("rpc unavailable or returned a transient error")
+	ErrKMSUnavailable   = errors.New("kms sign call failed")
+	ErrBroadcastReject  = errors.New("rpc accepted call but rejected the tx (e.g. nonce reuse, insufficient funds)")
+)
+
+// WinnerLookup returns (recipient, amount) for a public key, or ErrNotAWinner.
+// Defined as an interface so claim_test.go can pass a stub. Production uses pgxWinnerLookup.
+type WinnerLookup interface {
+	Lookup(ctx context.Context, publicKey string) (recipient common.Address, amount *big.Int, err error)
+}
+
+type pgxWinnerLookup struct{ pool *pgxpool.Pool }
+
+func NewPgxWinnerLookup(pool *pgxpool.Pool) WinnerLookup { return pgxWinnerLookup{pool: pool} }
+
+func (p pgxWinnerLookup) Lookup(ctx context.Context, publicKey string) (common.Address, *big.Int, error) {
+	var recipient string
+	var amountStr string
+	err := p.pool.QueryRow(ctx,
+		`SELECT recipient, amount::text FROM agent_raffle_winners WHERE public_key = $1`,
+		publicKey,
+	).Scan(&recipient, &amountStr)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return common.Address{}, nil, ErrNotAWinner
+		}
+		return common.Address{}, nil, fmt.Errorf("lookup winner: %w", err)
+	}
+	amount, ok := new(big.Int).SetString(amountStr, 10)
+	if !ok {
+		return common.Address{}, nil, fmt.Errorf("parse amount %q", amountStr)
+	}
+	return common.HexToAddress(recipient), amount, nil
+}
+
+// ClaimResult is the data returned to the HTTP layer.
+type ClaimResult struct {
+	TxHash      string
+	Status      types.ClaimStatus
+	Nonce       int64
+	SubmittedAt string // RFC3339 — caller renders into JSON
+	ConfirmedAt string // RFC3339, empty unless idempotent retry hit a confirmed row
+}
+
+// ClaimServiceConfig wires the dependencies the service needs.
+type ClaimServiceConfig struct {
+	ChainID         *big.Int
+	ContractAddress common.Address
+	ClaimRepo       *postgres.ClaimRepository
+	StateRepo       *postgres.RelayerStateRepository
+	WinnerLookup    WinnerLookup
+	RPC             ethclient.Client
+	Signer          kms.Signer
+}
+
+type ClaimService struct {
+	cfg ClaimServiceConfig
+}
+
+func NewClaimService(cfg ClaimServiceConfig) *ClaimService { return &ClaimService{cfg: cfg} }
+
+// Submit runs the full claim pipeline under one Postgres transaction.
+//
+// Sequence (matches stage-4-claim-relayer.md "Behavior" steps 5-17):
+//   1. BEGIN
+//   2. SELECT FOR UPDATE on agent_relayer_state WHERE id=1
+//   3. SELECT existing claim row for this public_key (idempotent retry → return)
+//   4. Look up (recipient, amount) from agent_raffle_winners
+//   5. Fetch baseFee + tipCap from RPC; maxFee = 2*baseFee + tip
+//   6. Build calldata for claim(recipient)
+//   7. EstimateGas
+//   8. BuildAndSignTx (KMS sign)
+//   9. SendRawTransaction
+//  10. INSERT agent_claim_submissions row
+//  11. UPDATE agent_relayer_state SET next_nonce = next_nonce + 1
+//  12. COMMIT
+//
+// Any error from steps 4-9 → ROLLBACK (state unchanged, no claim row, user can retry).
+func (s *ClaimService) Submit(ctx context.Context, publicKey string) (*ClaimResult, error) {
+	tx, err := s.cfg.StateRepo.Pool().BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	// 2. Lock the state row — serialises all claim handlers.
+	state, err := s.cfg.StateRepo.LockWithTx(ctx, tx)
+	if err != nil {
+		return nil, fmt.Errorf("lock relayer state: %w", err)
+	}
+	if state.NextNonce == nil {
+		return nil, fmt.Errorf("relayer next_nonce is nil — InitNonceIfNeeded must run before Submit")
+	}
+
+	// 3. Idempotent-retry check (inside the same tx so we see committed rows from racing siblings).
+	if existing, err := s.cfg.ClaimRepo.GetActiveByPublicKeyWithTx(ctx, tx, publicKey); err == nil {
+		// Found — return the existing row, don't broadcast.
+		if cErr := tx.Commit(ctx); cErr != nil {
+			return nil, fmt.Errorf("commit (idempotent path): %w", cErr)
+		}
+		return claimResultFromRow(existing), nil
+	} else if !errors.Is(err, postgres.ErrNotFound) {
+		return nil, fmt.Errorf("idempotent-retry check: %w", err)
+	}
+
+	nonce := uint64(*state.NextNonce)
+
+	// 4. Winner lookup.
+	recipient, amount, err := s.cfg.WinnerLookup.Lookup(ctx, publicKey)
+	if err != nil {
+		return nil, err // ErrNotAWinner or wrapped
+	}
+
+	// 5. Gas estimates. Map any RPC error to ErrRPCUnavailable so the handler can return 503.
+	baseFee, err := s.cfg.RPC.LatestBaseFee(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("%w: base fee: %v", ErrRPCUnavailable, err)
+	}
+	tipCap, err := s.cfg.RPC.SuggestGasTipCap(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("%w: tip cap: %v", ErrRPCUnavailable, err)
+	}
+	maxFee := new(big.Int).Add(new(big.Int).Mul(baseFee, big.NewInt(2)), tipCap)
+
+	// 6. Calldata.
+	calldata := BuildClaimCalldata(recipient)
+
+	// 7. Gas estimate.
+	gasLimit, err := s.cfg.RPC.EstimateGas(ctx, s.cfg.Signer.Address(), s.cfg.ContractAddress, calldata, nil)
+	if err != nil {
+		return nil, fmt.Errorf("%w: estimate gas: %v", ErrRPCUnavailable, err)
+	}
+	// Pad 20% to absorb intra-block variance.
+	gasLimit = gasLimit + gasLimit/5
+
+	// 8. Build + KMS-sign the EIP-1559 tx.
+	signedBytes, txHash, err := BuildAndSignTx(ctx, s.cfg.Signer, TxParams{
+		ChainID:           s.cfg.ChainID,
+		Nonce:             nonce,
+		GasLimit:          gasLimit,
+		MaxFeePerGasWei:   maxFee,
+		MaxPriorityFeeWei: tipCap,
+		To:                s.cfg.ContractAddress,
+		Calldata:          calldata,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrKMSUnavailable, err)
+	}
+
+	// 9. Broadcast.
+	if _, err := s.cfg.RPC.SendRawTransaction(ctx, signedBytes); err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrBroadcastReject, err)
+	}
+
+	// 10. Insert the claim row inside the same tx.
+	maxFeeGwei := int32(new(big.Int).Div(maxFee, big.NewInt(1_000_000_000)).Int64())
+	tipGwei := int32(new(big.Int).Div(tipCap, big.NewInt(1_000_000_000)).Int64())
+	row, err := s.cfg.ClaimRepo.InsertWithTx(ctx, tx,
+		publicKey, int64(nonce), recipient.Hex(), amount, txHash.Hex(),
+		maxFeeGwei, tipGwei,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("insert claim row: %w", err)
+	}
+
+	// 11. Advance the state nonce.
+	if err := s.cfg.StateRepo.SetNonceWithTx(ctx, tx, int64(nonce)+1); err != nil {
+		return nil, fmt.Errorf("advance nonce: %w", err)
+	}
+
+	// 12. Commit.
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("commit: %w", err)
+	}
+
+	return claimResultFromRow(row), nil
+}
+
+func claimResultFromRow(row *types.ClaimSubmission) *ClaimResult {
+	out := &ClaimResult{
+		TxHash:      row.TxHash,
+		Status:      row.Status,
+		Nonce:       row.Nonce,
+		SubmittedAt: row.SubmittedAt.Format("2006-01-02T15:04:05Z07:00"),
+	}
+	if row.ConfirmedAt != nil {
+		out.ConfirmedAt = row.ConfirmedAt.Format("2006-01-02T15:04:05Z07:00")
+	}
+	return out
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+go test ./internal/service/airdrop/relayer/ -run TestClaimService -v -timeout 60s
+```
+
+Expected: PASS for all subtests, given `DATABASE_DSN` is set. The two concurrent tests (`...DistinctUsers...` and `...SameUser...`) take a few seconds each because they actually serialise through Postgres locks.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/service/airdrop/relayer/claim.go internal/service/airdrop/relayer/claim_test.go
+git commit -m "feat(airdrop): add claim service with FOR UPDATE serialisation + idempotent retry"
+```
+
+---
+
+## Task 8: `POST /airdrop/claim` HTTP handler
+
+**Why:** Wraps the service. Window check, kill-switch check, eligibility check (in-process call to `quests.IsClaimEligible`), then delegates to `service.Submit`. Maps service errors to the documented status codes (`stage-4-claim-relayer.md:74-85`).
+
+**Files:**
+- Create: `internal/api/airdrop_claim.go`
+- Create: `internal/api/airdrop_claim_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/api/airdrop_claim_test.go`:
+
+```go
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/vultisig/agent-backend/internal/service/airdrop/relayer"
+	"github.com/vultisig/agent-backend/internal/types"
+)
+
+type fakeClaimSvc struct {
+	submit func(ctx context.Context, publicKey string) (*relayer.ClaimResult, error)
+}
+
+func (f *fakeClaimSvc) Submit(ctx context.Context, publicKey string) (*relayer.ClaimResult, error) {
+	return f.submit(ctx, publicKey)
+}
+
+type fakeEligibility struct {
+	eligible bool
+	reason   string
+	err      error
+}
+
+func (f *fakeEligibility) IsClaimEligible(_ context.Context, _ string, _ int) (bool, string, error) {
+	return f.eligible, f.reason, f.err
+}
+
+func TestClaimHandler_StatusCodeMatrix(t *testing.T) {
+	openAt := time.Date(2026, 5, 15, 0, 0, 0, 0, time.UTC)
+	now := func(after time.Duration) time.Time { return openAt.Add(after) }
+
+	cases := []struct {
+		name        string
+		clock       time.Time
+		killSwitch  bool
+		elig        *fakeEligibility
+		submitErr   error
+		submitOK    *relayer.ClaimResult
+		wantStatus  int
+		wantErrKey  string
+	}{
+		{
+			name: "before window → 403 CLAIM_WINDOW_NOT_OPEN",
+			clock: openAt.Add(-time.Hour), killSwitch: true,
+			elig: &fakeEligibility{eligible: true},
+			wantStatus: 403, wantErrKey: "CLAIM_WINDOW_NOT_OPEN",
+		},
+		{
+			name: "kill switch flipped → 403 CLAIM_DISABLED",
+			clock: now(time.Hour), killSwitch: false,
+			elig: &fakeEligibility{eligible: true},
+			wantStatus: 403, wantErrKey: "CLAIM_DISABLED",
+		},
+		{
+			name: "not eligible → 403 NOT_CLAIM_ELIGIBLE",
+			clock: now(time.Hour), killSwitch: true,
+			elig: &fakeEligibility{eligible: false, reason: "only_2_quests_complete"},
+			wantStatus: 403, wantErrKey: "NOT_CLAIM_ELIGIBLE",
+		},
+		{
+			name: "RPC error → 503 RPC_UNAVAILABLE",
+			clock: now(time.Hour), killSwitch: true,
+			elig: &fakeEligibility{eligible: true},
+			submitErr: relayer.ErrRPCUnavailable,
+			wantStatus: 503, wantErrKey: "RPC_UNAVAILABLE",
+		},
+		{
+			name: "KMS error → 503 KMS_UNAVAILABLE",
+			clock: now(time.Hour), killSwitch: true,
+			elig: &fakeEligibility{eligible: true},
+			submitErr: relayer.ErrKMSUnavailable,
+			wantStatus: 503, wantErrKey: "KMS_UNAVAILABLE",
+		},
+		{
+			name: "broadcast rejected → 500 BROADCAST_REJECTED",
+			clock: now(time.Hour), killSwitch: true,
+			elig: &fakeEligibility{eligible: true},
+			submitErr: relayer.ErrBroadcastReject,
+			wantStatus: 500, wantErrKey: "BROADCAST_REJECTED",
+		},
+		{
+			name: "happy path → 200 with tx_hash",
+			clock: now(time.Hour), killSwitch: true,
+			elig: &fakeEligibility{eligible: true},
+			submitOK: &relayer.ClaimResult{TxHash: "0xabc", Status: types.ClaimSubmitted, Nonce: 7, SubmittedAt: "2026-05-15T18:00:00Z"},
+			wantStatus: 200,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := &fakeClaimSvc{submit: func(_ context.Context, _ string) (*relayer.ClaimResult, error) {
+				if tc.submitErr != nil {
+					return nil, tc.submitErr
+				}
+				return tc.submitOK, nil
+			}}
+			h := &claimHandler{
+				svc:               svc,
+				eligibility:       tc.elig,
+				questThreshold:    3,
+				claimWindowOpenAt: openAt,
+				claimEnabled:      tc.killSwitch,
+				now:               func() time.Time { return tc.clock },
+			}
+
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodPost, "/airdrop/claim", nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+			c.Set("public_key", "pk-test")
+
+			if err := h.Handle(c); err != nil {
+				t.Fatalf("handler: %v", err)
+			}
+			if rec.Code != tc.wantStatus {
+				t.Errorf("status = %d, want %d (body=%s)", rec.Code, tc.wantStatus, rec.Body.String())
+			}
+			if tc.wantErrKey != "" {
+				var body map[string]any
+				_ = json.Unmarshal(rec.Body.Bytes(), &body)
+				if body["error"] != tc.wantErrKey {
+					t.Errorf("error = %v, want %s", body["error"], tc.wantErrKey)
+				}
+			}
+			if tc.wantStatus == 200 {
+				var body map[string]any
+				_ = json.Unmarshal(rec.Body.Bytes(), &body)
+				if body["tx_hash"] != "0xabc" {
+					t.Errorf("tx_hash = %v, want 0xabc", body["tx_hash"])
+				}
+				if body["status"] != "submitted" {
+					t.Errorf("status = %v, want submitted", body["status"])
+				}
+			}
+		})
+	}
+
+	// Defensive: ensure no unused imports
+	_ = errors.New
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+go test ./internal/api/ -run TestClaimHandler -v
+```
+
+Expected: compile error — `claimHandler` undefined.
+
+- [ ] **Step 3: Implement the handler**
+
+Create `internal/api/airdrop_claim.go`:
+
+```go
+package api
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/vultisig/agent-backend/internal/service/airdrop/relayer"
+)
+
+// claimSubmitter is the slice of ClaimService the handler depends on.
+type claimSubmitter interface {
+	Submit(ctx context.Context, publicKey string) (*relayer.ClaimResult, error)
+}
+
+// eligibilityChecker is the slice of quests.IsClaimEligible the handler uses.
+// Wrapped behind an interface so tests don't need a real DB.
+type eligibilityChecker interface {
+	IsClaimEligible(ctx context.Context, publicKey string, threshold int) (bool, string, error)
+}
+
+type claimHandler struct {
+	svc               claimSubmitter
+	eligibility       eligibilityChecker
+	questThreshold    int
+	claimWindowOpenAt time.Time
+	claimEnabled      bool
+	now               func() time.Time
+}
+
+type claimResponse struct {
+	TxHash      string `json:"tx_hash"`
+	Status      string `json:"status"`
+	Nonce       int64  `json:"nonce"`
+	SubmittedAt string `json:"submitted_at"`
+	ConfirmedAt string `json:"confirmed_at,omitempty"`
+}
+
+type broadcastRejectedResponse struct {
+	Error  string `json:"error"`
+	Detail string `json:"detail"`
+}
+
+func (h *claimHandler) Handle(c echo.Context) error {
+	publicKey := GetPublicKey(c)
+	if publicKey == "" {
+		return c.JSON(http.StatusUnauthorized, ErrorResponse{Error: "missing public key"})
+	}
+
+	// 1. Window check.
+	if h.now().Before(h.claimWindowOpenAt) {
+		return c.JSON(http.StatusForbidden, ErrorResponse{Error: "CLAIM_WINDOW_NOT_OPEN"})
+	}
+
+	// 2. Kill switch.
+	if !h.claimEnabled {
+		return c.JSON(http.StatusForbidden, ErrorResponse{Error: "CLAIM_DISABLED"})
+	}
+
+	// 3. Eligibility (DB read; in-process; not an HTTP roundtrip).
+	eligible, _, err := h.eligibility.IsClaimEligible(c.Request().Context(), publicKey, h.questThreshold)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "ELIGIBILITY_LOOKUP_FAILED"})
+	}
+	if !eligible {
+		return c.JSON(http.StatusForbidden, ErrorResponse{Error: "NOT_CLAIM_ELIGIBLE"})
+	}
+
+	// 4. Submit.
+	result, err := h.svc.Submit(c.Request().Context(), publicKey)
+	if err != nil {
+		switch {
+		case errors.Is(err, relayer.ErrNotAWinner):
+			return c.JSON(http.StatusForbidden, ErrorResponse{Error: "NOT_CLAIM_ELIGIBLE"})
+		case errors.Is(err, relayer.ErrRPCUnavailable):
+			return c.JSON(http.StatusServiceUnavailable, ErrorResponse{Error: "RPC_UNAVAILABLE"})
+		case errors.Is(err, relayer.ErrKMSUnavailable):
+			return c.JSON(http.StatusServiceUnavailable, ErrorResponse{Error: "KMS_UNAVAILABLE"})
+		case errors.Is(err, relayer.ErrBroadcastReject):
+			return c.JSON(http.StatusInternalServerError, broadcastRejectedResponse{
+				Error:  "BROADCAST_REJECTED",
+				Detail: err.Error(),
+			})
+		default:
+			return c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "INTERNAL_ERROR"})
+		}
+	}
+
+	return c.JSON(http.StatusOK, claimResponse{
+		TxHash:      result.TxHash,
+		Status:      string(result.Status),
+		Nonce:       result.Nonce,
+		SubmittedAt: result.SubmittedAt,
+		ConfirmedAt: result.ConfirmedAt,
+	})
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+go test ./internal/api/ -run TestClaimHandler -v
+```
+
+Expected: PASS for all subtests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/api/airdrop_claim.go internal/api/airdrop_claim_test.go
+git commit -m "feat(airdrop): add POST /airdrop/claim handler"
+```
+
+---
+
+## Task 9: Confirmation monitor — goroutine inside `cmd/scheduler`
+
+**Why:** A single background loop that polls submitted-but-unconfirmed claims every `CONFIRMATION_POLL_INTERVAL_SECONDS` and flips them to confirmed/failed against chain receipts. The spec is explicit: *"Lives in `cmd/scheduler/` alongside the existing `agent_scheduled_tasks` poller (reuses the existing scheduler binary; no new process)"* (`stage-4-claim-relayer.md:203`). Restart-safety comes free: the monitor's first tick on each boot picks up any rows still in `submitted` from before the crash.
+
+**Files:**
+- Create: `internal/service/airdrop/relayer/monitor.go`
+- Create: `internal/service/airdrop/relayer/monitor_test.go`
+- Modify: `cmd/scheduler/main.go` — wire and launch the monitor via `safego.Go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/service/airdrop/relayer/monitor_test.go`:
+
+```go
+package relayer
+
+import (
+	"context"
+	"errors"
+	"math/big"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/sirupsen/logrus"
+
+	"github.com/vultisig/agent-backend/internal/storage/postgres"
+	tt "github.com/vultisig/agent-backend/internal/types"
+)
+
+func newMonitorTestPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	dsn := os.Getenv("TEST_DATABASE_DSN")
+	if dsn == "" {
+		dsn = os.Getenv("DATABASE_DSN")
+	}
+	if dsn == "" {
+		t.Skip("TEST_DATABASE_DSN or DATABASE_DSN not set")
+	}
+	pool, err := pgxpool.New(context.Background(), dsn)
+	if err != nil {
+		t.Fatalf("pgxpool: %v", err)
+	}
+	t.Cleanup(func() { pool.Close() })
+	_, err = pool.Exec(context.Background(), `TRUNCATE agent_claim_submissions;`)
+	if err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+	return pool
+}
+
+// fakeReceiptRPC drives the monitor's GetTransactionReceipt path.
+type fakeReceiptRPC struct {
+	receipts map[common.Hash]*types.Receipt
+}
+
+func (f *fakeReceiptRPC) LatestBaseFee(_ context.Context) (*big.Int, error) { return nil, errors.New("unused") }
+func (f *fakeReceiptRPC) SuggestGasTipCap(_ context.Context) (*big.Int, error) { return nil, errors.New("unused") }
+func (f *fakeReceiptRPC) NonceAt(_ context.Context, _ common.Address, _ *big.Int) (uint64, error) { return 0, errors.New("unused") }
+func (f *fakeReceiptRPC) SendRawTransaction(_ context.Context, _ []byte) (common.Hash, error) { return common.Hash{}, errors.New("unused") }
+func (f *fakeReceiptRPC) GetTransactionReceipt(_ context.Context, h common.Hash) (*types.Receipt, error) {
+	if r, ok := f.receipts[h]; ok {
+		return r, nil
+	}
+	return nil, ethereum.NotFound
+}
+func (f *fakeReceiptRPC) BalanceOf(_ context.Context, _, _ common.Address) (*big.Int, error) { return nil, errors.New("unused") }
+func (f *fakeReceiptRPC) Balance(_ context.Context, _ common.Address) (*big.Int, error) { return nil, errors.New("unused") }
+func (f *fakeReceiptRPC) EstimateGas(_ context.Context, _, _ common.Address, _ []byte, _ *big.Int) (uint64, error) { return 0, errors.New("unused") }
+
+func seedSubmittedClaim(t *testing.T, pool *pgxpool.Pool, repo *postgres.ClaimRepository, pk string, nonce int64, txHash string) {
+	t.Helper()
+	_, err := repo.Insert(context.Background(), pk, nonce, "0xaaa", big.NewInt(1500), txHash, 50, 2)
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+}
+
+func TestMonitor_OneTick_FlipsConfirmed(t *testing.T) {
+	pool := newMonitorTestPool(t)
+	repo := postgres.NewClaimRepository(pool)
+	hash := common.HexToHash("0xabc1")
+	seedSubmittedClaim(t, pool, repo, "pk1", 1, hash.Hex())
+
+	rpc := &fakeReceiptRPC{
+		receipts: map[common.Hash]*types.Receipt{
+			hash: {Status: types.ReceiptStatusSuccessful, BlockNumber: big.NewInt(19_400_000), TxHash: hash},
+		},
+	}
+	mon := NewMonitor(MonitorConfig{
+		ClaimRepo:           repo,
+		RPC:                 rpc,
+		PollInterval:        100 * time.Millisecond,
+		BatchLimit:          100,
+		Logger:              logrus.New(),
+	})
+
+	if err := mon.Tick(context.Background()); err != nil {
+		t.Fatalf("Tick: %v", err)
+	}
+
+	row, _ := repo.GetActiveByPublicKey(context.Background(), "pk1")
+	if row.Status != tt.ClaimConfirmed {
+		t.Errorf("status = %s, want confirmed", row.Status)
+	}
+	if row.BlockNumber == nil || *row.BlockNumber != 19_400_000 {
+		t.Errorf("block_number = %v, want 19_400_000", row.BlockNumber)
+	}
+}
+
+func TestMonitor_OneTick_FlipsFailedOnRevert(t *testing.T) {
+	pool := newMonitorTestPool(t)
+	repo := postgres.NewClaimRepository(pool)
+	hash := common.HexToHash("0xabc2")
+	seedSubmittedClaim(t, pool, repo, "pk2", 2, hash.Hex())
+
+	rpc := &fakeReceiptRPC{
+		receipts: map[common.Hash]*types.Receipt{
+			hash: {Status: types.ReceiptStatusFailed, BlockNumber: big.NewInt(19_400_001), TxHash: hash},
+		},
+	}
+	mon := NewMonitor(MonitorConfig{ClaimRepo: repo, RPC: rpc, PollInterval: 100 * time.Millisecond, BatchLimit: 100, Logger: logrus.New()})
+
+	if err := mon.Tick(context.Background()); err != nil {
+		t.Fatalf("Tick: %v", err)
+	}
+
+	// Failed rows are no longer "active" (status != submitted/confirmed)
+	if _, err := repo.GetActiveByPublicKey(context.Background(), "pk2"); !errors.Is(err, postgres.ErrNotFound) {
+		t.Errorf("expected ErrNotFound for failed row, got %v", err)
+	}
+}
+
+func TestMonitor_OneTick_NoReceiptYet_LeavesAsSubmitted(t *testing.T) {
+	pool := newMonitorTestPool(t)
+	repo := postgres.NewClaimRepository(pool)
+	seedSubmittedClaim(t, pool, repo, "pk3", 3, "0xpending")
+
+	mon := NewMonitor(MonitorConfig{ClaimRepo: repo, RPC: &fakeReceiptRPC{}, PollInterval: 100 * time.Millisecond, BatchLimit: 100, Logger: logrus.New()})
+
+	if err := mon.Tick(context.Background()); err != nil {
+		t.Fatalf("Tick: %v", err)
+	}
+	row, _ := repo.GetActiveByPublicKey(context.Background(), "pk3")
+	if row.Status != tt.ClaimSubmitted {
+		t.Errorf("status = %s, want submitted (no receipt yet)", row.Status)
+	}
+}
+
+func TestMonitor_RestartSafety(t *testing.T) {
+	// Simulates: service crashed after a broadcast left a submitted row in DB.
+	// On next boot, monitor's first Tick must catch the row even though no
+	// "live" handler is around to nudge it.
+	pool := newMonitorTestPool(t)
+	repo := postgres.NewClaimRepository(pool)
+	hash := common.HexToHash("0xrestart")
+	seedSubmittedClaim(t, pool, repo, "pk-restart", 99, hash.Hex())
+
+	rpc := &fakeReceiptRPC{receipts: map[common.Hash]*types.Receipt{
+		hash: {Status: types.ReceiptStatusSuccessful, BlockNumber: big.NewInt(19_400_002), TxHash: hash},
+	}}
+	mon := NewMonitor(MonitorConfig{ClaimRepo: repo, RPC: rpc, PollInterval: 100 * time.Millisecond, BatchLimit: 100, Logger: logrus.New()})
+
+	// Run() with a short-lived ctx — should pick up the row on its initial boot tick.
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	_ = mon.Run(ctx) // Run blocks until ctx done; returns ctx.Err()
+
+	row, _ := repo.GetActiveByPublicKey(context.Background(), "pk-restart")
+	if row.Status != tt.ClaimConfirmed {
+		t.Errorf("after Run, status = %s, want confirmed", row.Status)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+go test ./internal/service/airdrop/relayer/ -run TestMonitor -v
+```
+
+Expected: compile error — `Monitor`, `MonitorConfig`, `NewMonitor` undefined.
+
+- [ ] **Step 3: Implement the monitor**
+
+Create `internal/service/airdrop/relayer/monitor.go`:
+
+```go
+package relayer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/sirupsen/logrus"
+
+	"github.com/vultisig/agent-backend/internal/service/airdrop/ethclient"
+	"github.com/vultisig/agent-backend/internal/storage/postgres"
+)
+
+// MonitorConfig wires the dependencies the confirmation monitor needs.
+type MonitorConfig struct {
+	ClaimRepo    *postgres.ClaimRepository
+	RPC          ethclient.Client
+	PollInterval time.Duration // CONFIRMATION_POLL_INTERVAL_SECONDS, e.g. 15s
+	BatchLimit   int32         // max rows scanned per tick (spec: 100)
+	Logger       *logrus.Logger
+}
+
+// Monitor is the background goroutine that flips submitted claims to
+// confirmed/failed by polling chain receipts. Lives inside cmd/scheduler.
+type Monitor struct {
+	cfg MonitorConfig
+}
+
+func NewMonitor(cfg MonitorConfig) *Monitor {
+	if cfg.BatchLimit == 0 {
+		cfg.BatchLimit = 100
+	}
+	return &Monitor{cfg: cfg}
+}
+
+// Run loops forever. Runs Tick once at startup (catches anything left over
+// from a crash) then on each tick of cfg.PollInterval.
+func (m *Monitor) Run(ctx context.Context) error {
+	if m.cfg.PollInterval <= 0 {
+		return fmt.Errorf("invalid poll interval: %v", m.cfg.PollInterval)
+	}
+	m.cfg.Logger.WithField("poll_interval", m.cfg.PollInterval).Info("airdrop confirmation monitor started")
+
+	// Boot tick — guarantees no submitted row is forgotten across restarts.
+	if err := m.Tick(ctx); err != nil {
+		m.cfg.Logger.WithError(err).Warn("airdrop monitor: initial tick failed")
+	}
+
+	ticker := time.NewTicker(m.cfg.PollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			m.cfg.Logger.Info("airdrop confirmation monitor stopping")
+			return ctx.Err()
+		case <-ticker.C:
+			if err := m.Tick(ctx); err != nil {
+				m.cfg.Logger.WithError(err).Warn("airdrop monitor: tick failed")
+			}
+		}
+	}
+}
+
+// Tick runs one scan of submitted-state rows. Exposed for tests + the boot tick.
+func (m *Monitor) Tick(ctx context.Context) error {
+	pending, err := m.cfg.ClaimRepo.ListPending(ctx, m.cfg.BatchLimit)
+	if err != nil {
+		return fmt.Errorf("list pending: %w", err)
+	}
+	if len(pending) == 0 {
+		return nil
+	}
+
+	for _, row := range pending {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		txHash := common.HexToHash(row.TxHash)
+		receipt, err := m.cfg.RPC.GetTransactionReceipt(ctx, txHash)
+		if errors.Is(err, ethereum.NotFound) {
+			// No receipt yet — try again next tick. Common case.
+			continue
+		}
+		if err != nil {
+			m.cfg.Logger.WithError(err).WithFields(logrus.Fields{
+				"nonce":   row.Nonce,
+				"tx_hash": row.TxHash,
+			}).Warn("airdrop monitor: receipt lookup failed")
+			continue
+		}
+		m.processReceipt(ctx, row.Nonce, receipt)
+	}
+	return nil
+}
+
+func (m *Monitor) processReceipt(ctx context.Context, nonce int64, r *types.Receipt) {
+	log := m.cfg.Logger.WithFields(logrus.Fields{
+		"nonce":        nonce,
+		"tx_hash":      r.TxHash.Hex(),
+		"block_number": r.BlockNumber.Int64(),
+	})
+	switch r.Status {
+	case types.ReceiptStatusSuccessful:
+		if err := m.cfg.ClaimRepo.MarkConfirmed(ctx, nonce, r.BlockNumber.Int64()); err != nil {
+			log.WithError(err).Error("airdrop monitor: mark confirmed failed")
+			return
+		}
+		log.Info("airdrop monitor: confirmed")
+	case types.ReceiptStatusFailed:
+		if err := m.cfg.ClaimRepo.MarkFailed(ctx, nonce, "reverted"); err != nil {
+			log.WithError(err).Error("airdrop monitor: mark failed failed")
+			return
+		}
+		log.Warn("airdrop monitor: tx reverted on chain")
+	}
+}
+```
+
+- [ ] **Step 4: Wire into `cmd/scheduler/main.go`**
+
+The existing scheduler entrypoint (`cmd/scheduler/main.go:181-183`) blocks on `sched.Run(ctx)` until shutdown. Add the monitor as a sibling goroutine launched via `safego.Go` *before* `sched.Run`. Both share the same ctx + signal handler — when SIGTERM cancels ctx, both loops return cleanly.
+
+Add imports:
+
+```go
+import (
+	"github.com/vultisig/agent-backend/internal/service/airdrop/ethclient"
+	"github.com/vultisig/agent-backend/internal/service/airdrop/relayer"
+	"github.com/vultisig/agent-backend/internal/util/safego"
+)
+```
+
+Insert this block just before `sched.SetAnalytics(analyticsClient)` (around line 169 of the current file):
+
+```go
+	// Airdrop confirmation monitor — slots into the same scheduler binary so
+	// the airdrop pipeline doesn't need a third process. ctx is the same one
+	// that cancels sched.Run on SIGTERM, so both stop together.
+	rpc, err := ethclient.NewClient(cfg.Airdrop.EVMRPCURL)
+	if err != nil {
+		logger.WithError(err).Fatal("airdrop: failed to dial EVM RPC")
+	}
+	claimRepo := postgres.NewClaimRepository(db.Pool())
+	confMonitor := relayer.NewMonitor(relayer.MonitorConfig{
+		ClaimRepo:    claimRepo,
+		RPC:          rpc,
+		PollInterval: time.Duration(cfg.Airdrop.ConfirmationPollIntervalSeconds) * time.Second,
+		BatchLimit:   100,
+		Logger:       logger,
+	})
+	safego.Go(logger, "airdrop.confirmation_monitor", func() {
+		if err := confMonitor.Run(ctx); err != nil && !errors.Is(err, context.Canceled) {
+			logger.WithError(err).Error("airdrop confirmation monitor exited with error")
+		}
+	})
+```
+
+(`errors` is already imported in the file.)
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+go test ./internal/service/airdrop/relayer/ -run TestMonitor -v -timeout 30s
+```
+
+Expected: PASS for all four monitor tests, given `DATABASE_DSN` is set. The `TestMonitor_RestartSafety` runs `mon.Run(ctx)` with a 500ms timeout — boot tick fires immediately; Run returns `context.DeadlineExceeded` after 500ms.
+
+- [ ] **Step 6: Verify the scheduler binary still builds**
+
+```bash
+go build ./cmd/scheduler/
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/service/airdrop/relayer/monitor.go \
+         internal/service/airdrop/relayer/monitor_test.go \
+         cmd/scheduler/main.go
+git commit -m "feat(airdrop): add confirmation monitor goroutine inside cmd/scheduler"
+```
+
+---
+
+## Task 10: Balance read service (no internal HTTP handler)
+
+> **Scope update (2026-04-23):** the `/internal/relayer/balance` HTTP route is dropped. Build the data-loading function as a method on the relayer service (`internal/service/airdrop/relayer/`) returning a typed `BalanceSnapshot`. Task 13 (ops UI) calls it directly to render `/ops/balance`. Skip the `internal/api/relayer/` package, the InternalTokenMiddleware wiring, and the route registration steps below. Keep the Anvil-backed integration test — repurpose it to exercise the service method instead of the HTTP handler.
+
+**Files:**
+- Create: `internal/api/relayer/balance.go`
+- Create: `internal/api/relayer/balance_test.go`
+- Create: `internal/api/relayer/doc.go` — package comment
+
+- [ ] **Step 1: Add the package doc**
+
+Create `internal/api/relayer/doc.go`:
+
+```go
+// Package relayer holds the /internal/relayer/* HTTP handlers — ops-only
+// surfaces guarded by InternalTokenMiddleware. The /ops UI calls these
+// endpoints in-process to render its pages.
+package relayer
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `internal/api/relayer/balance_test.go`:
+
+```go
+package relayer
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/labstack/echo/v4"
+	"github.com/sirupsen/logrus"
+
+	"github.com/vultisig/agent-backend/internal/types"
+	tt "github.com/vultisig/agent-backend/internal/types"
+)
+
+type fakeBalanceRPC struct {
+	balance        *big.Int
+	balanceOf      *big.Int
+	tipCap         *big.Int
+	baseFee        *big.Int
+	headBlock      uint64
+}
+
+func (f *fakeBalanceRPC) Balance(_ context.Context, _ common.Address) (*big.Int, error) { return f.balance, nil }
+func (f *fakeBalanceRPC) BalanceOf(_ context.Context, _, _ common.Address) (*big.Int, error) { return f.balanceOf, nil }
+func (f *fakeBalanceRPC) SuggestGasTipCap(_ context.Context) (*big.Int, error) { return f.tipCap, nil }
+func (f *fakeBalanceRPC) LatestBaseFee(_ context.Context) (*big.Int, error) { return f.baseFee, nil }
+func (f *fakeBalanceRPC) NonceAt(_ context.Context, _ common.Address, _ *big.Int) (uint64, error) { return f.headBlock, nil }
+func (f *fakeBalanceRPC) SendRawTransaction(_ context.Context, _ []byte) (common.Hash, error) { return common.Hash{}, errors.New("unused") }
+func (f *fakeBalanceRPC) GetTransactionReceipt(_ context.Context, _ common.Hash) (*types.Receipt, error) { return nil, errors.New("unused") }
+func (f *fakeBalanceRPC) EstimateGas(_ context.Context, _, _ common.Address, _ []byte, _ *big.Int) (uint64, error) { return 0, errors.New("unused") }
+
+type fakeStateRepo struct {
+	state *tt.RelayerState
+}
+
+func (f *fakeStateRepo) Get(_ context.Context) (*tt.RelayerState, error) { return f.state, nil }
+
+func TestBalanceHandler_HappyPath(t *testing.T) {
+	five := new(big.Int)
+	five.SetString("5000000000000000000", 10) // 5 ETH
+	vult := new(big.Int)
+	vult.SetString("1417500000000000000000000", 10) // 1,417,500 VULT
+	nonce := int64(42)
+
+	h := &BalanceHandler{
+		RPC:                 &fakeBalanceRPC{balance: five, balanceOf: vult, tipCap: big.NewInt(2_000_000_000), baseFee: big.NewInt(20_000_000_000), headBlock: 19_400_000},
+		StateRepo:           &fakeStateRepo{state: &tt.RelayerState{NextNonce: &nonce}},
+		RelayerAddress:      common.HexToAddress("0x0000000000000000000000000000000000000001"),
+		ContractAddress:     common.HexToAddress("0x0000000000000000000000000000000000000002"),
+		LowBalanceWei:       big.NewInt(500_000_000_000_000_000), // 0.5 ETH
+		LowBalanceEthString: "0.5",
+		Logger:              logrus.New(),
+	}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/internal/relayer/balance", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	if err := h.Handle(c); err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200 (body=%s)", rec.Code, rec.Body.String())
+	}
+
+	var body map[string]any
+	_ = json.Unmarshal(rec.Body.Bytes(), &body)
+	if body["eth_balance_wei"] != "5000000000000000000" {
+		t.Errorf("eth_balance_wei = %v", body["eth_balance_wei"])
+	}
+	if body["vult_contract_balance_wei"] != "1417500000000000000000000" {
+		t.Errorf("vult_contract_balance_wei = %v", body["vult_contract_balance_wei"])
+	}
+	if body["low_balance_warning"] != false {
+		t.Errorf("low_balance_warning = %v, want false (5 ETH > 0.5)", body["low_balance_warning"])
+	}
+	if body["next_nonce"].(float64) != 42 {
+		t.Errorf("next_nonce = %v, want 42", body["next_nonce"])
+	}
+	if _, ok := body["estimated_claims_remaining"]; !ok {
+		t.Errorf("missing estimated_claims_remaining")
+	}
+}
+
+func TestBalanceHandler_LowBalanceFlag(t *testing.T) {
+	tinyBalance := big.NewInt(100_000_000_000_000_000) // 0.1 ETH
+	nonce := int64(0)
+
+	h := &BalanceHandler{
+		RPC:                 &fakeBalanceRPC{balance: tinyBalance, balanceOf: big.NewInt(0), tipCap: big.NewInt(2_000_000_000), baseFee: big.NewInt(20_000_000_000), headBlock: 19_400_000},
+		StateRepo:           &fakeStateRepo{state: &tt.RelayerState{NextNonce: &nonce}},
+		RelayerAddress:      common.HexToAddress("0x0001"),
+		ContractAddress:     common.HexToAddress("0x0002"),
+		LowBalanceWei:       big.NewInt(500_000_000_000_000_000),
+		LowBalanceEthString: "0.5",
+		Logger:              logrus.New(),
+	}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/internal/relayer/balance", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	_ = h.Handle(c)
+
+	var body map[string]any
+	_ = json.Unmarshal(rec.Body.Bytes(), &body)
+	if body["low_balance_warning"] != true {
+		t.Errorf("low_balance_warning = %v, want true (0.1 ETH < 0.5)", body["low_balance_warning"])
+	}
+}
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+```bash
+go test ./internal/api/relayer/ -v
+```
+
+Expected: compile error — `BalanceHandler` undefined.
+
+- [ ] **Step 4: Implement the handler**
+
+Create `internal/api/relayer/balance.go`:
+
+```go
+package relayer
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"net/http"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/labstack/echo/v4"
+	"github.com/sirupsen/logrus"
+
+	"github.com/vultisig/agent-backend/internal/types"
+)
+
+// rpcBalance is the slice of ethclient.Client BalanceHandler depends on.
+type rpcBalance interface {
+	Balance(ctx context.Context, account common.Address) (*big.Int, error)
+	BalanceOf(ctx context.Context, token, account common.Address) (*big.Int, error)
+	LatestBaseFee(ctx context.Context) (*big.Int, error)
+	SuggestGasTipCap(ctx context.Context) (*big.Int, error)
+	NonceAt(ctx context.Context, addr common.Address, block *big.Int) (uint64, error)
+}
+
+type stateGetter interface {
+	Get(ctx context.Context) (*types.RelayerState, error)
+}
+
+// BalanceHandler implements GET /internal/relayer/balance.
+type BalanceHandler struct {
+	RPC                 rpcBalance
+	StateRepo           stateGetter
+	RelayerAddress      common.Address
+	ContractAddress     common.Address
+	LowBalanceWei       *big.Int
+	LowBalanceEthString string // raw string for echo back ("0.5")
+	Logger              *logrus.Logger
+}
+
+type balanceResponse struct {
+	RelayerAddress           string `json:"relayer_address"`
+	EthBalanceWei            string `json:"eth_balance_wei"`
+	EthBalanceHuman          string `json:"eth_balance_human"`
+	VultContractBalanceWei   string `json:"vult_contract_balance_wei"`
+	VultContractBalanceHuman string `json:"vult_contract_balance_human"`
+	LowBalanceWarning        bool   `json:"low_balance_warning"`
+	LowBalanceThresholdEth   string `json:"low_balance_threshold_eth"`
+	EstimatedClaimsRemaining int64  `json:"estimated_claims_remaining"`
+	NextNonce                int64  `json:"next_nonce"`
+	RpcBlockHeight           uint64 `json:"rpc_block_height"`
+}
+
+// avgGasPerClaim is the per-claim gas estimate from the contract spec
+// (sibling-on-chain-contract.md:111). Used for estimated_claims_remaining math.
+const avgGasPerClaim = 62_000
+
+func (h *BalanceHandler) Handle(c echo.Context) error {
+	ctx := c.Request().Context()
+
+	ethBal, err := h.RPC.Balance(ctx, h.RelayerAddress)
+	if err != nil {
+		h.Logger.WithError(err).Error("balance: rpc Balance failed")
+		return c.JSON(http.StatusServiceUnavailable, map[string]string{"error": "RPC_UNAVAILABLE"})
+	}
+
+	vultBal, err := h.RPC.BalanceOf(ctx, h.ContractAddress, h.ContractAddress)
+	if err != nil {
+		h.Logger.WithError(err).Error("balance: rpc BalanceOf failed")
+		return c.JSON(http.StatusServiceUnavailable, map[string]string{"error": "RPC_UNAVAILABLE"})
+	}
+
+	baseFee, _ := h.RPC.LatestBaseFee(ctx)
+	tipCap, _ := h.RPC.SuggestGasTipCap(ctx)
+	gasPrice := new(big.Int).Add(baseFee, tipCap) // approximate per-gas cost
+	estimatedRemaining := int64(0)
+	if gasPrice.Sign() > 0 {
+		costPerClaim := new(big.Int).Mul(gasPrice, big.NewInt(avgGasPerClaim))
+		if costPerClaim.Sign() > 0 {
+			estimatedRemaining = new(big.Int).Quo(ethBal, costPerClaim).Int64()
+		}
+	}
+
+	st, err := h.StateRepo.Get(ctx)
+	if err != nil {
+		h.Logger.WithError(err).Error("balance: state lookup failed")
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "STATE_LOOKUP_FAILED"})
+	}
+	nextNonce := int64(0)
+	if st.NextNonce != nil {
+		nextNonce = *st.NextNonce
+	}
+
+	// rpc block height — read via the BlockNumber method on the ethclient wrapper
+	// (added in shared-infra plan, Task 5). Cheap, latest-block read.
+	headHeight, err := h.RPC.BlockNumber(ctx)
+	if err != nil {
+		h.Logger.WithError(err).Warn("balance: rpc block height fetch failed; reporting 0")
+		headHeight = 0
+	}
+
+	resp := balanceResponse{
+		RelayerAddress:           h.RelayerAddress.Hex(),
+		EthBalanceWei:            ethBal.String(),
+		EthBalanceHuman:          formatWeiToEth(ethBal, 3),
+		VultContractBalanceWei:   vultBal.String(),
+		VultContractBalanceHuman: formatWeiToEth(vultBal, 3), // VULT has 18 decimals
+		LowBalanceWarning:        ethBal.Cmp(h.LowBalanceWei) < 0,
+		LowBalanceThresholdEth:   h.LowBalanceEthString,
+		EstimatedClaimsRemaining: estimatedRemaining,
+		NextNonce:                nextNonce,
+		RpcBlockHeight:           headHeight,
+	}
+	return c.JSON(http.StatusOK, resp)
+}
+
+// formatWeiToEth divides wei by 1e18 and formats with `decimals` precision.
+func formatWeiToEth(wei *big.Int, decimals int) string {
+	if wei == nil {
+		return "0"
+	}
+	// integer / fractional split via DivMod against 1e18
+	one := new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil)
+	intPart := new(big.Int)
+	frac := new(big.Int)
+	intPart.QuoRem(wei, one, frac)
+	// Pad fractional to 18 digits, then truncate to `decimals`
+	fracStr := frac.String()
+	for len(fracStr) < 18 {
+		fracStr = "0" + fracStr
+	}
+	if decimals > len(fracStr) {
+		decimals = len(fracStr)
+	}
+	return fmt.Sprintf("%s.%s", intPart.String(), fracStr[:decimals])
+}
+```
+
+The `RpcBlockHeight` field is populated via the wrapper's `BlockNumber(ctx)` method (added in shared-infra Task 5). On RPC error the field reports 0 with a warning log — the rest of the balance response still renders so ops aren't blocked by a transient RPC blip.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+go test ./internal/api/relayer/ -v
+```
+
+Expected: PASS for both subtests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/api/relayer/doc.go internal/api/relayer/balance.go internal/api/relayer/balance_test.go
+git commit -m "feat(airdrop): add GET /internal/relayer/balance handler"
+```
+
+---
+
+## Task 11: Stuck-claims read service (no internal HTTP handler)
+
+> **Scope update (2026-04-23):** the `/internal/relayer/stuck-claims` HTTP route is dropped. Build the listing as a method on the relayer service returning `[]StuckClaim`. Task 13 (ops UI) calls it directly to render `/ops/stuck-claims`. Skip the `internal/api/relayer/` package and the route registration. Repurpose any handler-level tests to exercise the service method.
+
+**Files:**
+- Create: `internal/api/relayer/stuck_claims.go`
+- Create: `internal/api/relayer/stuck_claims_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/api/relayer/stuck_claims_test.go`:
+
+```go
+package relayer
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/sirupsen/logrus"
+
+	"github.com/vultisig/agent-backend/internal/types"
+)
+
+type fakeStuckRepo struct {
+	rows []types.ClaimSubmission
+}
+
+func (f *fakeStuckRepo) ListStuck(_ context.Context, _ int32) ([]types.ClaimSubmission, error) {
+	return f.rows, nil
+}
+
+func TestStuckClaimsHandler_DefaultThreshold(t *testing.T) {
+	now := time.Now().UTC()
+	repo := &fakeStuckRepo{rows: []types.ClaimSubmission{
+		{PublicKey: "pkA", Nonce: 7, TxHash: "0x111", SubmittedAt: now.Add(-23 * time.Minute), MaxFeeGwei: 50, MaxPriorityFeeGwei: 2},
+		{PublicKey: "pkB", Nonce: 9, TxHash: "0x222", SubmittedAt: now.Add(-15 * time.Minute), MaxFeeGwei: 50, MaxPriorityFeeGwei: 2, PreviousTxHashes: []string{"0xprior"}},
+	}}
+
+	h := &StuckClaimsHandler{Repo: repo, Logger: logrus.New()}
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/internal/relayer/stuck-claims", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	if err := h.Handle(c); err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	if rec.Code != 200 {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	var body map[string]any
+	_ = json.Unmarshal(rec.Body.Bytes(), &body)
+	if body["count"].(float64) != 2 {
+		t.Errorf("count = %v, want 2", body["count"])
+	}
+	rows := body["stuck_claims"].([]any)
+	if len(rows) != 2 {
+		t.Fatalf("got %d rows, want 2", len(rows))
+	}
+	first := rows[0].(map[string]any)
+	if first["public_key"] != "pkA" {
+		t.Errorf("first row public_key = %v", first["public_key"])
+	}
+	if _, ok := first["minutes_pending"]; !ok {
+		t.Error("missing minutes_pending field")
+	}
+	second := rows[1].(map[string]any)
+	prev := second["previous_tx_hashes"].([]any)
+	if len(prev) != 1 || prev[0] != "0xprior" {
+		t.Errorf("previous_tx_hashes = %v, want [0xprior]", prev)
+	}
+}
+
+func TestStuckClaimsHandler_CustomThreshold(t *testing.T) {
+	repo := &fakeStuckRepo{rows: nil}
+	h := &StuckClaimsHandler{Repo: repo, Logger: logrus.New()}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/internal/relayer/stuck-claims?older_than_minutes=30", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	_ = h.Handle(c)
+
+	var body map[string]any
+	_ = json.Unmarshal(rec.Body.Bytes(), &body)
+	if body["count"].(float64) != 0 {
+		t.Errorf("count = %v, want 0", body["count"])
+	}
+	if _, ok := body["stuck_claims"]; !ok {
+		t.Error("missing stuck_claims field even when empty (must be [], not absent)")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+go test ./internal/api/relayer/ -run TestStuckClaims -v
+```
+
+Expected: compile error — `StuckClaimsHandler` undefined.
+
+- [ ] **Step 3: Implement the handler**
+
+Create `internal/api/relayer/stuck_claims.go`:
+
+```go
+package relayer
+
+import (
+	"context"
+	"net/http"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/sirupsen/logrus"
+
+	"github.com/vultisig/agent-backend/internal/types"
+)
+
+type stuckRepo interface {
+	ListStuck(ctx context.Context, olderThanMinutes int32) ([]types.ClaimSubmission, error)
+}
+
+type StuckClaimsHandler struct {
+	Repo   stuckRepo
+	Logger *logrus.Logger
+}
+
+type stuckClaimRow struct {
+	PublicKey          string   `json:"public_key"`
+	TxHash             string   `json:"tx_hash"`
+	Nonce              int64    `json:"nonce"`
+	SubmittedAt        string   `json:"submitted_at"`
+	MinutesPending     int64    `json:"minutes_pending"`
+	MaxFeeGwei         int32    `json:"max_fee_gwei"`
+	MaxPriorityFeeGwei int32    `json:"max_priority_fee_gwei"`
+	PreviousTxHashes   []string `json:"previous_tx_hashes"`
+}
+
+type stuckClaimsResponse struct {
+	StuckClaims []stuckClaimRow `json:"stuck_claims"`
+	Count       int             `json:"count"`
+}
+
+func (h *StuckClaimsHandler) Handle(c echo.Context) error {
+	threshold := int32(10) // default per spec
+	if raw := c.QueryParam("older_than_minutes"); raw != "" {
+		n, err := strconv.Atoi(raw)
+		if err != nil || n <= 0 {
+			return c.JSON(http.StatusBadRequest, map[string]string{"error": "invalid older_than_minutes"})
+		}
+		threshold = int32(n)
+	}
+
+	rows, err := h.Repo.ListStuck(c.Request().Context(), threshold)
+	if err != nil {
+		h.Logger.WithError(err).Error("stuck-claims: list failed")
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "STUCK_LOOKUP_FAILED"})
+	}
+
+	// Sort by minutes_pending DESC (oldest first) per spec.
+	sort.SliceStable(rows, func(i, j int) bool {
+		return rows[i].SubmittedAt.Before(rows[j].SubmittedAt)
+	})
+
+	out := stuckClaimsResponse{StuckClaims: make([]stuckClaimRow, 0, len(rows)), Count: len(rows)}
+	now := time.Now().UTC()
+	for _, r := range rows {
+		prev := r.PreviousTxHashes
+		if prev == nil {
+			prev = []string{}
+		}
+		out.StuckClaims = append(out.StuckClaims, stuckClaimRow{
+			PublicKey:          r.PublicKey,
+			TxHash:             r.TxHash,
+			Nonce:              r.Nonce,
+			SubmittedAt:        r.SubmittedAt.Format(time.RFC3339),
+			MinutesPending:     int64(now.Sub(r.SubmittedAt).Minutes()),
+			MaxFeeGwei:         r.MaxFeeGwei,
+			MaxPriorityFeeGwei: r.MaxPriorityFeeGwei,
+			PreviousTxHashes:   prev,
+		})
+	}
+	return c.JSON(http.StatusOK, out)
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+go test ./internal/api/relayer/ -v
+```
+
+Expected: PASS for all four `TestBalanceHandler*` and `TestStuckClaims*` subtests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/api/relayer/stuck_claims.go internal/api/relayer/stuck_claims_test.go
+git commit -m "feat(airdrop): add GET /internal/relayer/stuck-claims handler"
+```
+
+---
+
+## Task 12: Rebroadcast service — same nonce + bumped fees
+
+**Why:** When a tx gets stuck (RPC throttling, low fee at the time of submit), ops bumps the gas and re-broadcasts. The new tx must reuse the same nonce so the original is replaced in the mempool — only one of the two can confirm, and the previous tx_hash is appended to the audit array.
+
+**Files:**
+- Create: `internal/service/airdrop/relayer/rebroadcast.go`
+- Create: `internal/service/airdrop/relayer/rebroadcast_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/service/airdrop/relayer/rebroadcast_test.go`:
+
+```go
+package relayer
+
+import (
+	"context"
+	"errors"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/vultisig/agent-backend/internal/storage/postgres"
+	tt "github.com/vultisig/agent-backend/internal/types"
+)
+
+func TestRebroadcastService_BumpsFeesAndAppendsHash(t *testing.T) {
+	pool := newClaimServiceTestPool(t)
+	repo := postgres.NewClaimRepository(pool)
+
+	// Seed a submitted claim at 50/2 gwei
+	winnerPK := "pk-rebroadcast"
+	seedWinner(t, pool, winnerPK, "0x70997970C51812dc3A010C7d01b50e0d17dc79C8", big.NewInt(1500))
+	original, err := repo.Insert(context.Background(),
+		winnerPK, 5, "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
+		big.NewInt(1500), "0xORIG", 50, 2)
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	rpc := &fakeRPC{}
+	signer := newLocalSigner(t)
+	svc := NewRebroadcastService(RebroadcastConfig{
+		ChainID: big.NewInt(1), ContractAddress: common.HexToAddress("0xCCCC"),
+		ClaimRepo: repo, RPC: rpc, Signer: signer,
+	})
+
+	result, err := svc.Rebroadcast(context.Background(), winnerPK, 50)
+	if err != nil {
+		t.Fatalf("Rebroadcast: %v", err)
+	}
+	if result.NewTxHash == original.TxHash {
+		t.Errorf("new tx_hash = old tx_hash; expected new bumped tx")
+	}
+	if result.OldTxHash != "0xORIG" {
+		t.Errorf("OldTxHash = %s, want 0xORIG", result.OldTxHash)
+	}
+
+	// Verify DB state
+	row, _ := repo.GetActiveByPublicKey(context.Background(), winnerPK)
+	if row.Nonce != 5 {
+		t.Errorf("nonce changed: %d, want 5", row.Nonce)
+	}
+	if row.TxHash == "0xORIG" {
+		t.Errorf("tx_hash unchanged after rebroadcast")
+	}
+	if len(row.PreviousTxHashes) != 1 || row.PreviousTxHashes[0] != "0xORIG" {
+		t.Errorf("previous_tx_hashes = %v, want [0xORIG]", row.PreviousTxHashes)
+	}
+	if row.MaxFeeGwei <= 50 {
+		t.Errorf("max_fee_gwei = %d, want > 50 (bumped by 50)", row.MaxFeeGwei)
+	}
+	if row.MaxPriorityFeeGwei != 2+50 {
+		t.Errorf("max_priority_fee_gwei = %d, want 52", row.MaxPriorityFeeGwei)
+	}
+	if len(rpc.sentTxs) != 1 {
+		t.Errorf("rpc broadcasts = %d, want 1", len(rpc.sentTxs))
+	}
+}
+
+func TestRebroadcastService_RejectsConfirmedClaim(t *testing.T) {
+	pool := newClaimServiceTestPool(t)
+	repo := postgres.NewClaimRepository(pool)
+	winnerPK := "pk-confirmed"
+	seedWinner(t, pool, winnerPK, "0x70997970C51812dc3A010C7d01b50e0d17dc79C8", big.NewInt(1500))
+	_, _ = repo.Insert(context.Background(), winnerPK, 8, "0x70997970C51812dc3A010C7d01b50e0d17dc79C8", big.NewInt(1500), "0xCONF", 50, 2)
+	if err := repo.MarkConfirmed(context.Background(), 8, 19_400_000); err != nil {
+		t.Fatalf("MarkConfirmed: %v", err)
+	}
+
+	svc := NewRebroadcastService(RebroadcastConfig{
+		ChainID: big.NewInt(1), ContractAddress: common.HexToAddress("0xCCCC"),
+		ClaimRepo: repo, RPC: &fakeRPC{}, Signer: newLocalSigner(t),
+	})
+	_, err := svc.Rebroadcast(context.Background(), winnerPK, 50)
+	if !errors.Is(err, ErrAlreadyConfirmed) {
+		t.Errorf("err = %v, want ErrAlreadyConfirmed", err)
+	}
+	_ = tt.ClaimConfirmed // keep import live
+}
+
+func TestRebroadcastService_NoSubmissionForUser(t *testing.T) {
+	pool := newClaimServiceTestPool(t)
+	repo := postgres.NewClaimRepository(pool)
+	svc := NewRebroadcastService(RebroadcastConfig{
+		ChainID: big.NewInt(1), ContractAddress: common.HexToAddress("0xCCCC"),
+		ClaimRepo: repo, RPC: &fakeRPC{}, Signer: newLocalSigner(t),
+	})
+	_, err := svc.Rebroadcast(context.Background(), "nobody", 50)
+	if !errors.Is(err, ErrNoSubmission) {
+		t.Errorf("err = %v, want ErrNoSubmission", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+go test ./internal/service/airdrop/relayer/ -run TestRebroadcastService -v
+```
+
+Expected: compile error — `RebroadcastService`, `RebroadcastConfig`, `ErrAlreadyConfirmed`, `ErrNoSubmission` undefined.
+
+- [ ] **Step 3: Implement the rebroadcast service**
+
+Create `internal/service/airdrop/relayer/rebroadcast.go`:
+
+```go
+package relayer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/vultisig/agent-backend/internal/service/airdrop/ethclient"
+	"github.com/vultisig/agent-backend/internal/service/airdrop/kms"
+	"github.com/vultisig/agent-backend/internal/storage/postgres"
+	"github.com/vultisig/agent-backend/internal/types"
+)
+
+var (
+	ErrNoSubmission     = errors.New("no claim submission for this public_key")
+	ErrAlreadyConfirmed = errors.New("claim already confirmed; rebroadcast not needed")
+)
+
+type RebroadcastConfig struct {
+	ChainID         *big.Int
+	ContractAddress common.Address
+	ClaimRepo       *postgres.ClaimRepository
+	RPC             ethclient.Client
+	Signer          kms.Signer
+}
+
+type RebroadcastService struct {
+	cfg RebroadcastConfig
+}
+
+func NewRebroadcastService(cfg RebroadcastConfig) *RebroadcastService {
+	return &RebroadcastService{cfg: cfg}
+}
+
+type RebroadcastResult struct {
+	OldTxHash string
+	NewTxHash string
+	Nonce     int64
+	NewMaxFeeGwei int32
+	NewTipGwei    int32
+}
+
+// Rebroadcast re-signs an EIP-1559 tx for the same nonce with bumped fees and broadcasts it.
+//   bumpGwei is added to BOTH max_fee and max_priority_fee.
+// The previous tx_hash is appended to previous_tx_hashes; the row's tx_hash + fee
+// fields are updated. Status stays 'submitted'.
+func (s *RebroadcastService) Rebroadcast(ctx context.Context, publicKey string, bumpGwei int32) (*RebroadcastResult, error) {
+	// 1. Find the row.
+	row, err := s.cfg.ClaimRepo.GetByPublicKey(ctx, publicKey)
+	if err != nil {
+		if errors.Is(err, postgres.ErrNotFound) {
+			return nil, ErrNoSubmission
+		}
+		return nil, fmt.Errorf("lookup claim: %w", err)
+	}
+	if row.Status == types.ClaimConfirmed {
+		return nil, ErrAlreadyConfirmed
+	}
+	if row.Status != types.ClaimSubmitted {
+		return nil, fmt.Errorf("claim status is %s; can only rebroadcast 'submitted' rows", row.Status)
+	}
+
+	// 2. Bump fees. Bump in gwei → wei for the tx; bumped values written back as gwei.
+	newMaxFeeGwei := row.MaxFeeGwei + bumpGwei
+	newTipGwei := row.MaxPriorityFeeGwei + bumpGwei
+	maxFeeWei := new(big.Int).Mul(big.NewInt(int64(newMaxFeeGwei)), big.NewInt(1_000_000_000))
+	tipWei := new(big.Int).Mul(big.NewInt(int64(newTipGwei)), big.NewInt(1_000_000_000))
+
+	// 3. Rebuild calldata + estimate gas.
+	calldata := BuildClaimCalldata(common.HexToAddress(row.Recipient))
+	gasLimit, err := s.cfg.RPC.EstimateGas(ctx, s.cfg.Signer.Address(), s.cfg.ContractAddress, calldata, nil)
+	if err != nil {
+		return nil, fmt.Errorf("estimate gas: %w", err)
+	}
+	gasLimit = gasLimit + gasLimit/5 // 20% pad, same as initial submit
+
+	// 4. Sign + broadcast at the SAME nonce.
+	signedBytes, txHash, err := BuildAndSignTx(ctx, s.cfg.Signer, TxParams{
+		ChainID:           s.cfg.ChainID,
+		Nonce:             uint64(row.Nonce),
+		GasLimit:          gasLimit,
+		MaxFeePerGasWei:   maxFeeWei,
+		MaxPriorityFeeWei: tipWei,
+		To:                s.cfg.ContractAddress,
+		Calldata:          calldata,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("build+sign: %w", err)
+	}
+	if _, err := s.cfg.RPC.SendRawTransaction(ctx, signedBytes); err != nil {
+		return nil, fmt.Errorf("broadcast: %w", err)
+	}
+
+	// 5. Update DB — append old hash, set new hash + fees.
+	if err := s.cfg.ClaimRepo.UpdateRebroadcast(ctx, row.Nonce, txHash.Hex(), newMaxFeeGwei, newTipGwei); err != nil {
+		return nil, fmt.Errorf("db update: %w", err)
+	}
+
+	return &RebroadcastResult{
+		OldTxHash:     row.TxHash,
+		NewTxHash:     txHash.Hex(),
+		Nonce:         row.Nonce,
+		NewMaxFeeGwei: newMaxFeeGwei,
+		NewTipGwei:    newTipGwei,
+	}, nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+go test ./internal/service/airdrop/relayer/ -run TestRebroadcastService -v
+```
+
+Expected: PASS for all three subtests, given `DATABASE_DSN` is set.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/service/airdrop/relayer/rebroadcast.go internal/service/airdrop/relayer/rebroadcast_test.go
+git commit -m "feat(airdrop): add rebroadcast service (same nonce + bumped fees)"
+```
+
+---
+
+## Task 13: Operator UI — `/ops/*` HTML pages with inline Basic Auth
+
+**Why:** Server-rendered HTML, no JS build, CSS inlined. Auto-refresh via `<meta http-equiv="refresh" content="30">`. Per the cleanup pass: **inline the Basic Auth check** — `c.Request().BasicAuth()` plus `subtle.ConstantTimeCompare` against `cfg.Airdrop.OpsUsername` + `cfg.Airdrop.OpsPassword`. No shared middleware.
+
+**Files:**
+- Create: `internal/api/ops/handler.go` — Basic Auth wrapper + struct
+- Create: `internal/api/ops/landing.go` — `GET /ops`
+- Create: `internal/api/ops/balance.go` — `GET /ops/balance`
+- Create: `internal/api/ops/stuck_claims.go` — `GET /ops/stuck-claims`
+- Create: `internal/api/ops/rebroadcast.go` — `POST /ops/rebroadcast`
+- Create: `internal/api/ops/templates/layout.html`
+- Create: `internal/api/ops/templates/landing.html`
+- Create: `internal/api/ops/templates/balance.html`
+- Create: `internal/api/ops/templates/stuck_claims.html`
+- Create: `internal/api/ops/templates/rebroadcast_result.html`
+- Create: `internal/api/ops/handler_test.go` — Basic Auth + landing render
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/api/ops/handler_test.go`:
+
+```go
+package ops
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/sirupsen/logrus"
+)
+
+func TestOpsBasicAuth_Rejects(t *testing.T) {
+	h := &Handler{Username: "admin", Password: "s3cret", Logger: logrus.New()}
+	if err := h.LoadTemplates(); err != nil {
+		t.Fatalf("LoadTemplates: %v", err)
+	}
+
+	cases := []struct {
+		name        string
+		header      string
+		wantStatus  int
+		wantWWWAuth bool
+	}{
+		{"no header", "", http.StatusUnauthorized, true},
+		{"wrong creds", basicAuth("admin", "wrong"), http.StatusUnauthorized, true},
+		{"wrong user", basicAuth("nope", "s3cret"), http.StatusUnauthorized, true},
+		{"correct creds", basicAuth("admin", "s3cret"), http.StatusOK, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodGet, "/ops", nil)
+			if tc.header != "" {
+				req.Header.Set("Authorization", tc.header)
+			}
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+			_ = h.Landing(c)
+			if rec.Code != tc.wantStatus {
+				t.Errorf("status = %d, want %d", rec.Code, tc.wantStatus)
+			}
+			if tc.wantWWWAuth {
+				if got := rec.Header().Get("WWW-Authenticate"); got == "" {
+					t.Error("missing WWW-Authenticate challenge header on 401")
+				}
+			}
+		})
+	}
+}
+
+func basicAuth(user, pass string) string {
+	// Manually construct Basic auth header value
+	// (avoid importing encoding/base64 just to keep the test tight).
+	const b64 = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz+/"
+	raw := user + ":" + pass
+	enc := make([]byte, 0, ((len(raw)+2)/3)*4)
+	src := []byte(raw)
+	for i := 0; i < len(src); i += 3 {
+		var b [3]byte
+		n := copy(b[:], src[i:])
+		enc = append(enc, b64[b[0]>>2])
+		enc = append(enc, b64[((b[0]&0x03)<<4)|(b[1]>>4)])
+		if n > 1 {
+			enc = append(enc, b64[((b[1]&0x0f)<<2)|(b[2]>>6)])
+		} else {
+			enc = append(enc, '=')
+		}
+		if n > 2 {
+			enc = append(enc, b64[b[2]&0x3f])
+		} else {
+			enc = append(enc, '=')
+		}
+	}
+	return "Basic " + string(enc)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+go test ./internal/api/ops/ -v
+```
+
+Expected: compile error — `Handler`, `LoadTemplates`, `Landing` undefined.
+
+- [ ] **Step 3: Implement the handler skeleton + Basic Auth**
+
+Create `internal/api/ops/handler.go`:
+
+```go
+// Package ops implements the /ops/* HTML operator UI for the airdrop relayer.
+// All routes use HTTP Basic Auth checked inline (see basicAuthOK) — no shared
+// middleware, since this is the only route group that uses Basic Auth.
+package ops
+
+import (
+	"crypto/subtle"
+	"embed"
+	"fmt"
+	"html/template"
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"github.com/sirupsen/logrus"
+
+	"github.com/vultisig/agent-backend/internal/service/airdrop/relayer"
+	"github.com/vultisig/agent-backend/internal/storage/postgres"
+)
+
+//go:embed templates/*.html
+var templatesFS embed.FS
+
+// Handler bundles the deps + templates the four /ops routes share.
+type Handler struct {
+	Username string
+	Password string
+
+	// Data sources for the pages
+	BalanceLoader      func(echo.Context) (BalanceView, error) // Task-13 wires to the in-process /internal/relayer/balance call
+	StuckClaimsLoader  func(echo.Context) (StuckClaimsView, error)
+	ClaimRepo          *postgres.ClaimRepository
+	RebroadcastService *relayer.RebroadcastService
+
+	Logger    *logrus.Logger
+	templates *template.Template
+}
+
+// LoadTemplates parses every .html file under templates/. Call once at boot.
+func (h *Handler) LoadTemplates() error {
+	t, err := template.ParseFS(templatesFS, "templates/*.html")
+	if err != nil {
+		return fmt.Errorf("parse ops templates: %w", err)
+	}
+	h.templates = t
+	return nil
+}
+
+// basicAuthOK enforces HTTP Basic Auth inline. Returns true on success;
+// on failure it has already written the 401 + WWW-Authenticate response.
+func (h *Handler) basicAuthOK(c echo.Context) bool {
+	user, pass, ok := c.Request().BasicAuth()
+	if !ok {
+		h.challenge(c)
+		return false
+	}
+	uOK := subtle.ConstantTimeCompare([]byte(user), []byte(h.Username)) == 1
+	pOK := subtle.ConstantTimeCompare([]byte(pass), []byte(h.Password)) == 1
+	if !uOK || !pOK {
+		h.challenge(c)
+		return false
+	}
+	return true
+}
+
+func (h *Handler) challenge(c echo.Context) {
+	c.Response().Header().Set("WWW-Authenticate", `Basic realm="airdrop-ops"`)
+	_ = c.String(http.StatusUnauthorized, "401 Unauthorized\n")
+}
+
+// Render is the shared template-render path. Wraps in <html><body> via layout.html.
+func (h *Handler) Render(c echo.Context, name string, data any) error {
+	c.Response().Header().Set("Content-Type", "text/html; charset=utf-8")
+	c.Response().WriteHeader(http.StatusOK)
+	return h.templates.ExecuteTemplate(c.Response().Writer, name, data)
+}
+
+// View structs — handed to templates by the page-specific handlers below.
+
+type BalanceView struct {
+	RelayerAddress           string
+	EthBalanceHuman          string
+	VultContractBalanceHuman string
+	LowBalanceWarning        bool
+	LowBalanceThresholdEth   string
+	EstimatedClaimsRemaining int64
+	NextNonce                int64
+}
+
+type StuckClaimRow struct {
+	PublicKey          string
+	TxHash             string
+	Nonce              int64
+	SubmittedAt        string
+	MinutesPending     int64
+	MaxFeeGwei         int32
+	MaxPriorityFeeGwei int32
+	PreviousTxHashes   []string
+}
+
+type StuckClaimsView struct {
+	Rows  []StuckClaimRow
+	Count int
+}
+```
+
+- [ ] **Step 4: Implement the four route handlers**
+
+Create `internal/api/ops/landing.go`:
+
+```go
+package ops
+
+import "github.com/labstack/echo/v4"
+
+type landingData struct {
+	Title string
+}
+
+func (h *Handler) Landing(c echo.Context) error {
+	if !h.basicAuthOK(c) {
+		return nil
+	}
+	return h.Render(c, "landing.html", landingData{Title: "Airdrop Ops"})
+}
+```
+
+Create `internal/api/ops/balance.go`:
+
+```go
+package ops
+
+import (
+	"github.com/labstack/echo/v4"
+)
+
+func (h *Handler) Balance(c echo.Context) error {
+	if !h.basicAuthOK(c) {
+		return nil
+	}
+	view, err := h.BalanceLoader(c)
+	if err != nil {
+		h.Logger.WithError(err).Error("ops balance loader failed")
+		return h.Render(c, "balance.html", map[string]any{"Err": err.Error()})
+	}
+	return h.Render(c, "balance.html", map[string]any{"V": view})
+}
+```
+
+Create `internal/api/ops/stuck_claims.go`:
+
+```go
+package ops
+
+import (
+	"github.com/labstack/echo/v4"
+)
+
+func (h *Handler) StuckClaims(c echo.Context) error {
+	if !h.basicAuthOK(c) {
+		return nil
+	}
+	view, err := h.StuckClaimsLoader(c)
+	if err != nil {
+		h.Logger.WithError(err).Error("ops stuck-claims loader failed")
+		return h.Render(c, "stuck_claims.html", map[string]any{"Err": err.Error()})
+	}
+	return h.Render(c, "stuck_claims.html", map[string]any{"V": view})
+}
+```
+
+Create `internal/api/ops/rebroadcast.go`:
+
+```go
+package ops
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/vultisig/agent-backend/internal/service/airdrop/relayer"
+)
+
+func (h *Handler) Rebroadcast(c echo.Context) error {
+	if !h.basicAuthOK(c) {
+		return nil
+	}
+	publicKey := c.FormValue("public_key")
+	bumpStr := c.FormValue("bump_gwei")
+	if publicKey == "" {
+		return c.String(http.StatusBadRequest, "missing public_key")
+	}
+	bump := int32(50)
+	if bumpStr != "" {
+		n, err := strconv.Atoi(bumpStr)
+		if err != nil || n <= 0 {
+			return c.String(http.StatusBadRequest, "invalid bump_gwei")
+		}
+		bump = int32(n)
+	}
+
+	result, err := h.RebroadcastService.Rebroadcast(c.Request().Context(), publicKey, bump)
+	switch {
+	case errors.Is(err, relayer.ErrNoSubmission):
+		c.Response().WriteHeader(http.StatusNotFound)
+		return h.templates.ExecuteTemplate(c.Response().Writer, "rebroadcast_result.html",
+			map[string]any{"Err": "No submission for this public_key"})
+	case errors.Is(err, relayer.ErrAlreadyConfirmed):
+		c.Response().WriteHeader(http.StatusBadRequest)
+		return h.templates.ExecuteTemplate(c.Response().Writer, "rebroadcast_result.html",
+			map[string]any{"Err": "Claim already confirmed — rebroadcast not needed"})
+	case err != nil:
+		h.Logger.WithError(err).Error("ops rebroadcast failed")
+		c.Response().WriteHeader(http.StatusServiceUnavailable)
+		return h.templates.ExecuteTemplate(c.Response().Writer, "rebroadcast_result.html",
+			map[string]any{"Err": err.Error()})
+	}
+	return h.Render(c, "rebroadcast_result.html", map[string]any{"OK": true, "R": result})
+}
+```
+
+- [ ] **Step 5: Add the templates**
+
+Create `internal/api/ops/templates/layout.html`:
+
+```html
+{{ define "layout" }}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>{{ .Title }}</title>
+  <style>
+    body { font-family: -apple-system, system-ui, sans-serif; background: #0d1117; color: #c9d1d9; padding: 24px; max-width: 1200px; margin: 0 auto; }
+    h1 { color: #58a6ff; }
+    a { color: #58a6ff; }
+    table { width: 100%; border-collapse: collapse; margin-top: 16px; }
+    th, td { padding: 8px 12px; text-align: left; border-bottom: 1px solid #30363d; font-family: monospace; }
+    th { background: #161b22; }
+    .warning { background: #f85149; color: white; padding: 12px; border-radius: 6px; margin: 12px 0; font-weight: bold; }
+    .ok { background: #238636; color: white; padding: 12px; border-radius: 6px; margin: 12px 0; }
+    .err { background: #f85149; color: white; padding: 12px; border-radius: 6px; margin: 12px 0; }
+    .nav { margin-bottom: 24px; padding-bottom: 12px; border-bottom: 1px solid #30363d; }
+    .nav a { margin-right: 16px; }
+    button { background: #238636; color: white; border: 0; padding: 6px 12px; border-radius: 4px; cursor: pointer; font-family: monospace; }
+    button:hover { background: #2ea043; }
+    form { display: inline; }
+  </style>
+</head>
+<body>
+  <div class="nav">
+    <a href="/ops">home</a>
+    <a href="/ops/balance">balance</a>
+    <a href="/ops/stuck-claims">stuck-claims</a>
+  </div>
+  {{ template "content" . }}
+</body>
+</html>
+{{ end }}
+```
+
+Create `internal/api/ops/templates/landing.html`:
+
+```html
+{{ define "landing.html" }}{{ template "layout" . }}{{ end }}
+{{ define "content" }}
+  <h1>Airdrop Ops</h1>
+  <p>Operator console for the Vultiverse airdrop relayer.</p>
+  <ul>
+    <li><a href="/ops/balance">Balance</a> — relayer ETH balance, VULT contract balance, low-balance warning</li>
+    <li><a href="/ops/stuck-claims">Stuck claims</a> — submitted txs older than 10 minutes; rebroadcast button per row</li>
+  </ul>
+{{ end }}
+```
+
+Create `internal/api/ops/templates/balance.html`:
+
+```html
+{{ define "balance.html" }}{{ template "layout" (dict "Title" "Balance" "Body" .) }}{{ end }}
+{{ define "content" }}
+  <meta http-equiv="refresh" content="30">
+  <h1>Relayer Balance</h1>
+  {{ with .Err }}
+    <div class="err">Error: {{ . }}</div>
+  {{ else }}
+    {{ with .V }}
+      {{ if .LowBalanceWarning }}
+        <div class="warning">⚠ LOW BALANCE: relayer below {{ .LowBalanceThresholdEth }} ETH — top up immediately</div>
+      {{ end }}
+      <table>
+        <tr><th>Relayer address</th><td>{{ .RelayerAddress }}</td></tr>
+        <tr><th>ETH balance</th><td>{{ .EthBalanceHuman }} ETH</td></tr>
+        <tr><th>VULT in contract</th><td>{{ .VultContractBalanceHuman }} VULT</td></tr>
+        <tr><th>Estimated claims remaining</th><td>{{ .EstimatedClaimsRemaining }}</td></tr>
+        <tr><th>Next nonce</th><td>{{ .NextNonce }}</td></tr>
+        <tr><th>Low-balance threshold</th><td>{{ .LowBalanceThresholdEth }} ETH</td></tr>
+      </table>
+    {{ end }}
+  {{ end }}
+{{ end }}
+```
+
+Note on the layout/content split: Go's html/template makes the "layout-with-named-content-block" pattern slightly awkward when defining everything in one file. The simplest version that works: define the `layout` block with a `{{ template "content" . }}` placeholder; each page file defines both a top-level template (matching the file name passed to ExecuteTemplate) that calls layout, AND a `content` template that renders the page body. The `dict` helper above is illustrative — Go's stdlib template doesn't include it. Replace with this simpler shape that uses the data directly:
+
+Replace the contents of `internal/api/ops/templates/landing.html` with:
+
+```html
+{{ define "landing.html" }}
+<!DOCTYPE html><html><head><meta charset="utf-8"><title>Airdrop Ops</title>
+<style>body{font-family:-apple-system,system-ui,sans-serif;background:#0d1117;color:#c9d1d9;padding:24px;max-width:1200px;margin:0 auto}h1{color:#58a6ff}a{color:#58a6ff;margin-right:16px}.nav{margin-bottom:24px;padding-bottom:12px;border-bottom:1px solid #30363d}</style>
+</head><body>
+<div class="nav"><a href="/ops">home</a><a href="/ops/balance">balance</a><a href="/ops/stuck-claims">stuck-claims</a></div>
+<h1>Airdrop Ops</h1>
+<p>Operator console for the Vultiverse airdrop relayer.</p>
+<ul>
+  <li><a href="/ops/balance">Balance</a> — relayer ETH balance, VULT contract balance, low-balance warning</li>
+  <li><a href="/ops/stuck-claims">Stuck claims</a> — submitted txs older than 10 minutes; rebroadcast button per row</li>
+</ul>
+</body></html>
+{{ end }}
+```
+
+Replace `internal/api/ops/templates/balance.html` with:
+
+```html
+{{ define "balance.html" }}
+<!DOCTYPE html><html><head><meta charset="utf-8"><title>Balance</title>
+<meta http-equiv="refresh" content="30">
+<style>body{font-family:-apple-system,system-ui,sans-serif;background:#0d1117;color:#c9d1d9;padding:24px;max-width:1200px;margin:0 auto}h1{color:#58a6ff}a{color:#58a6ff;margin-right:16px}.nav{margin-bottom:24px;padding-bottom:12px;border-bottom:1px solid #30363d}table{width:100%;border-collapse:collapse;margin-top:16px}th,td{padding:8px 12px;text-align:left;border-bottom:1px solid #30363d;font-family:monospace}th{background:#161b22;width:30%}.warning{background:#f85149;color:white;padding:12px;border-radius:6px;margin:12px 0;font-weight:bold}.err{background:#f85149;color:white;padding:12px;border-radius:6px;margin:12px 0}</style>
+</head><body>
+<div class="nav"><a href="/ops">home</a><a href="/ops/balance">balance</a><a href="/ops/stuck-claims">stuck-claims</a></div>
+<h1>Relayer Balance</h1>
+{{ with .Err }}<div class="err">Error: {{ . }}</div>{{ end }}
+{{ with .V }}
+{{ if .LowBalanceWarning }}<div class="warning">⚠ LOW BALANCE: relayer below {{ .LowBalanceThresholdEth }} ETH — top up immediately</div>{{ end }}
+<table>
+  <tr><th>Relayer address</th><td>{{ .RelayerAddress }}</td></tr>
+  <tr><th>ETH balance</th><td>{{ .EthBalanceHuman }} ETH</td></tr>
+  <tr><th>VULT in contract</th><td>{{ .VultContractBalanceHuman }} VULT</td></tr>
+  <tr><th>Estimated claims remaining</th><td>{{ .EstimatedClaimsRemaining }}</td></tr>
+  <tr><th>Next nonce</th><td>{{ .NextNonce }}</td></tr>
+  <tr><th>Low-balance threshold</th><td>{{ .LowBalanceThresholdEth }} ETH</td></tr>
+</table>
+{{ end }}
+</body></html>
+{{ end }}
+```
+
+Replace `internal/api/ops/templates/stuck_claims.html` with:
+
+```html
+{{ define "stuck_claims.html" }}
+<!DOCTYPE html><html><head><meta charset="utf-8"><title>Stuck Claims</title>
+<meta http-equiv="refresh" content="30">
+<style>body{font-family:-apple-system,system-ui,sans-serif;background:#0d1117;color:#c9d1d9;padding:24px;max-width:1400px;margin:0 auto}h1{color:#58a6ff}a{color:#58a6ff;margin-right:16px}.nav{margin-bottom:24px;padding-bottom:12px;border-bottom:1px solid #30363d}table{width:100%;border-collapse:collapse;margin-top:16px}th,td{padding:8px 12px;text-align:left;border-bottom:1px solid #30363d;font-family:monospace;font-size:12px}th{background:#161b22}button{background:#238636;color:white;border:0;padding:6px 12px;border-radius:4px;cursor:pointer;font-family:monospace}button:hover{background:#2ea043}.ok{background:#238636;color:white;padding:12px;border-radius:6px}.err{background:#f85149;color:white;padding:12px;border-radius:6px}</style>
+</head><body>
+<div class="nav"><a href="/ops">home</a><a href="/ops/balance">balance</a><a href="/ops/stuck-claims">stuck-claims</a></div>
+<h1>Stuck Claims</h1>
+{{ with .Err }}<div class="err">Error: {{ . }}</div>{{ end }}
+{{ with .V }}
+{{ if eq .Count 0 }}<div class="ok">✓ No stuck claims (everything submitted has confirmed within 10 minutes)</div>
+{{ else }}
+<p>{{ .Count }} claim(s) submitted but unconfirmed for &gt;10 min. Each rebroadcast bumps fees by 50 gwei and reuses the same nonce.</p>
+<table>
+  <tr><th>Public key</th><th>Nonce</th><th>Tx hash</th><th>Min pending</th><th>Max fee (gwei)</th><th>Tip (gwei)</th><th>Prior hashes</th><th>Action</th></tr>
+  {{ range .Rows }}
+  <tr>
+    <td>{{ .PublicKey }}</td>
+    <td>{{ .Nonce }}</td>
+    <td>{{ .TxHash }}</td>
+    <td>{{ .MinutesPending }}</td>
+    <td>{{ .MaxFeeGwei }}</td>
+    <td>{{ .MaxPriorityFeeGwei }}</td>
+    <td>{{ len .PreviousTxHashes }}</td>
+    <td>
+      <form method="POST" action="/ops/rebroadcast">
+        <input type="hidden" name="public_key" value="{{ .PublicKey }}">
+        <input type="hidden" name="bump_gwei" value="50">
+        <button type="submit">Rebroadcast (+50 gwei)</button>
+      </form>
+    </td>
+  </tr>
+  {{ end }}
+</table>
+{{ end }}
+{{ end }}
+</body></html>
+{{ end }}
+```
+
+Replace `internal/api/ops/templates/rebroadcast_result.html` with:
+
+```html
+{{ define "rebroadcast_result.html" }}
+<!DOCTYPE html><html><head><meta charset="utf-8"><title>Rebroadcast Result</title>
+<style>body{font-family:-apple-system,system-ui,sans-serif;background:#0d1117;color:#c9d1d9;padding:24px;max-width:1200px;margin:0 auto}h1{color:#58a6ff}a{color:#58a6ff;margin-right:16px}.nav{margin-bottom:24px;padding-bottom:12px;border-bottom:1px solid #30363d}table{width:100%;border-collapse:collapse;margin-top:16px}th,td{padding:8px 12px;text-align:left;border-bottom:1px solid #30363d;font-family:monospace}th{background:#161b22;width:30%}.ok{background:#238636;color:white;padding:12px;border-radius:6px;margin:12px 0}.err{background:#f85149;color:white;padding:12px;border-radius:6px;margin:12px 0}</style>
+</head><body>
+<div class="nav"><a href="/ops">home</a><a href="/ops/balance">balance</a><a href="/ops/stuck-claims">stuck-claims</a></div>
+<h1>Rebroadcast Result</h1>
+{{ if .OK }}
+  {{ with .R }}
+  <div class="ok">✓ Submitted new tx at same nonce {{ .Nonce }}. Old tx and new tx race in the mempool — only one (the higher-fee new one) should confirm.</div>
+  <table>
+    <tr><th>Old tx hash</th><td>{{ .OldTxHash }} (<a href="https://etherscan.io/tx/{{ .OldTxHash }}">etherscan</a>)</td></tr>
+    <tr><th>New tx hash</th><td>{{ .NewTxHash }} (<a href="https://etherscan.io/tx/{{ .NewTxHash }}">etherscan</a>)</td></tr>
+    <tr><th>Nonce (unchanged)</th><td>{{ .Nonce }}</td></tr>
+    <tr><th>New max fee (gwei)</th><td>{{ .NewMaxFeeGwei }}</td></tr>
+    <tr><th>New tip (gwei)</th><td>{{ .NewTipGwei }}</td></tr>
+  </table>
+  {{ end }}
+{{ else }}
+  <div class="err">{{ .Err }}</div>
+{{ end }}
+<p><a href="/ops/stuck-claims">← back to stuck claims</a></p>
+</body></html>
+{{ end }}
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+```bash
+go test ./internal/api/ops/ -v
+```
+
+Expected: PASS for `TestOpsBasicAuth_Rejects` (4 subtests). The "correct creds" subtest hits `Landing` which requires `LoadTemplates` was called — confirmed by the test's setup.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/api/ops/
+git commit -m "feat(airdrop): add /ops HTML console with inline Basic Auth"
+```
+
+---
+
+## Task 14: Wire all routes into `cmd/server/main.go` + push PR
+
+**Why:** Until now the new code exists but is unreachable. This task plugs the four new HTTP surfaces (claim, balance, stuck-claims, ops) into the running service, runs the auto-init nonce step at boot, and opens the PR.
+
+**Files:**
+- Modify: `cmd/server/main.go` — repos, services, KMS signer, RPC client, route registration
+- Modify: `internal/api/server.go` — add fields if needed for cross-handler dependencies
+
+- [ ] **Step 1: Wire dependencies in `cmd/server/main.go`**
+
+Add imports near the top of the file (alongside existing service imports):
+
+```go
+import (
+	// ... existing imports ...
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	airdropops "github.com/vultisig/agent-backend/internal/api/ops"
+	airdroprelayerapi "github.com/vultisig/agent-backend/internal/api/relayer"
+	airdropethclient "github.com/vultisig/agent-backend/internal/service/airdrop/ethclient"
+	airdropkms "github.com/vultisig/agent-backend/internal/service/airdrop/kms"
+	"github.com/vultisig/agent-backend/internal/service/airdrop/quests"
+	airdroprelayer "github.com/vultisig/agent-backend/internal/service/airdrop/relayer"
+)
+```
+
+Insert this block after the existing `txProposalRepo` instantiation (around line 210, just before `server := api.NewServer(...)`):
+
+```go
+	// ---- Airdrop Stage 4 wiring ----
+	airdropClaimRepo := postgres.NewClaimRepository(db.Pool())
+	airdropStateRepo := postgres.NewRelayerStateRepository(db.Pool())
+
+	airdropRPC, err := airdropethclient.NewClient(cfg.Airdrop.EVMRPCURL)
+	if err != nil {
+		logger.WithError(err).Fatal("airdrop: failed to dial EVM RPC")
+	}
+	airdropSigner, err := airdropkms.NewKMSSigner(ctx, cfg.Airdrop.KMSRelayerKeyARN)
+	if err != nil {
+		logger.WithError(err).Fatal("airdrop: failed to construct KMS signer")
+	}
+
+	// Auto-init the relayer nonce if it's NULL (first boot). No-op on subsequent boots.
+	if err := airdroprelayer.InitNonceIfNeeded(ctx, airdropStateRepo, airdropRPC, airdropSigner.Address()); err != nil {
+		logger.WithError(err).Fatal("airdrop: failed to init relayer nonce")
+	}
+	logger.WithField("relayer_address", airdropSigner.Address().Hex()).Info("airdrop relayer ready")
+
+	contractAddr := common.HexToAddress(cfg.Airdrop.AirdropClaimContractAddress)
+	chainID := big.NewInt(int64(cfg.Airdrop.EVMChainID))
+
+	airdropClaimSvc := airdroprelayer.NewClaimService(airdroprelayer.ClaimServiceConfig{
+		ChainID:         chainID,
+		ContractAddress: contractAddr,
+		ClaimRepo:       airdropClaimRepo,
+		StateRepo:       airdropStateRepo,
+		WinnerLookup:    airdroprelayer.NewPgxWinnerLookup(db.Pool()),
+		RPC:             airdropRPC,
+		Signer:          airdropSigner,
+	})
+	airdropRebroadcastSvc := airdroprelayer.NewRebroadcastService(airdroprelayer.RebroadcastConfig{
+		ChainID: chainID, ContractAddress: contractAddr,
+		ClaimRepo: airdropClaimRepo, RPC: airdropRPC, Signer: airdropSigner,
+	})
+
+	// Parse low-balance threshold (string → wei big.Int) once.
+	lowBalanceWei := parseEthString(cfg.Airdrop.LowBalanceThresholdETH, logger)
+```
+
+Append the following helper anywhere in `main.go` (above `main()` works):
+
+```go
+// parseEthString parses a decimal-ETH string like "0.5" into a *big.Int wei.
+// Format: an integer part, optional "." plus up to 18 decimal digits.
+// Used once at boot for the airdrop low-balance threshold; reasonable to keep here
+// rather than introduce a money helper package for one call site.
+func parseEthString(s string, logger *logrus.Logger) *big.Int {
+	dot := -1
+	for i, r := range s {
+		if r == '.' {
+			dot = i
+			break
+		}
+	}
+	intStr, fracStr := s, ""
+	if dot >= 0 {
+		intStr = s[:dot]
+		fracStr = s[dot+1:]
+	}
+	for len(fracStr) < 18 {
+		fracStr += "0"
+	}
+	if len(fracStr) > 18 {
+		fracStr = fracStr[:18]
+	}
+	combined := intStr + fracStr
+	wei, ok := new(big.Int).SetString(combined, 10)
+	if !ok {
+		logger.WithField("raw", s).Fatal("airdrop: failed to parse LOW_BALANCE_THRESHOLD_ETH")
+	}
+	return wei
+}
+```
+
+After `server.SetCreditRepo(...)` (around line 238), add:
+
+```go
+	server.SetInternalToken(cfg.Airdrop.InternalAPIKey)
+```
+
+(Already exists if shared infra fully wired — `grep -n SetInternalToken cmd/server/main.go` to check; if absent, add it.)
+
+- [ ] **Step 2: Register the routes**
+
+Replace the `agentGroup` route block (around line 309) with the following extension. Add **after** the existing `/agent` and `/auth` routes:
+
+```go
+	// ---- Airdrop Stage 4 routes ----
+
+	// JWT-scoped: POST /airdrop/claim
+	airdropEligibility := quests.NewEligibilityChecker(db.Pool()) // small wrapper exposing IsClaimEligible(ctx, pk, threshold)
+	claimH := &api.AirdropClaimHandler{
+		Svc:               airdropClaimSvc,
+		Eligibility:       airdropEligibility,
+		QuestThreshold:    cfg.Airdrop.QuestThreshold,
+		ClaimWindowOpenAt: cfg.Airdrop.ClaimWindowOpenAt,
+		ClaimEnabled:      cfg.Airdrop.ClaimEnabled,
+		Now:               time.Now,
+	}
+	airdropGroup := e.Group("/airdrop", server.AuthMiddleware)
+	airdropGroup.POST("/claim", claimH.Handle)
+
+	// X-Internal-Token-scoped: GET /internal/relayer/balance, GET /internal/relayer/stuck-claims
+	balanceH := &airdroprelayerapi.BalanceHandler{
+		RPC:                 airdropRPC,
+		StateRepo:           airdropStateRepo,
+		RelayerAddress:      airdropSigner.Address(),
+		ContractAddress:     contractAddr,
+		LowBalanceWei:       lowBalanceWei,
+		LowBalanceEthString: cfg.Airdrop.LowBalanceThresholdETH,
+		Logger:              logger,
+	}
+	stuckH := &airdroprelayerapi.StuckClaimsHandler{Repo: airdropClaimRepo, Logger: logger}
+
+	internalRelayer := e.Group("/internal/relayer", server.InternalTokenMiddleware)
+	internalRelayer.GET("/balance", balanceH.Handle)
+	internalRelayer.GET("/stuck-claims", stuckH.Handle)
+
+	// Basic Auth-scoped: /ops/* HTML pages
+	opsHandler := &airdropops.Handler{
+		Username: cfg.Airdrop.OpsUsername,
+		Password: cfg.Airdrop.OpsPassword,
+		BalanceLoader: func(c echo.Context) (airdropops.BalanceView, error) {
+			// In-process call: invoke the JSON handler against a captured ResponseRecorder
+			// would be silly; instead, build the view directly.
+			ctx := c.Request().Context()
+			ethBal, _ := airdropRPC.Balance(ctx, airdropSigner.Address())
+			vultBal, _ := airdropRPC.BalanceOf(ctx, contractAddr, contractAddr)
+			st, _ := airdropStateRepo.Get(ctx)
+			nonce := int64(0)
+			if st != nil && st.NextNonce != nil {
+				nonce = *st.NextNonce
+			}
+			estimated := int64(0)
+			baseFee, _ := airdropRPC.LatestBaseFee(ctx)
+			tip, _ := airdropRPC.SuggestGasTipCap(ctx)
+			if baseFee != nil && tip != nil {
+				gasPrice := new(big.Int).Add(baseFee, tip)
+				if gasPrice.Sign() > 0 {
+					cost := new(big.Int).Mul(gasPrice, big.NewInt(62_000))
+					if ethBal != nil && cost.Sign() > 0 {
+						estimated = new(big.Int).Quo(ethBal, cost).Int64()
+					}
+				}
+			}
+			view := airdropops.BalanceView{
+				RelayerAddress:           airdropSigner.Address().Hex(),
+				EthBalanceHuman:          formatWeiToEthShort(ethBal),
+				VultContractBalanceHuman: formatWeiToEthShort(vultBal),
+				LowBalanceWarning:        ethBal != nil && ethBal.Cmp(lowBalanceWei) < 0,
+				LowBalanceThresholdEth:   cfg.Airdrop.LowBalanceThresholdETH,
+				EstimatedClaimsRemaining: estimated,
+				NextNonce:                nonce,
+			}
+			return view, nil
+		},
+		StuckClaimsLoader: func(c echo.Context) (airdropops.StuckClaimsView, error) {
+			rows, err := airdropClaimRepo.ListStuck(c.Request().Context(), 10)
+			if err != nil {
+				return airdropops.StuckClaimsView{}, err
+			}
+			view := airdropops.StuckClaimsView{Count: len(rows)}
+			now := time.Now().UTC()
+			for _, r := range rows {
+				prev := r.PreviousTxHashes
+				if prev == nil {
+					prev = []string{}
+				}
+				view.Rows = append(view.Rows, airdropops.StuckClaimRow{
+					PublicKey:          r.PublicKey,
+					TxHash:             r.TxHash,
+					Nonce:              r.Nonce,
+					SubmittedAt:        r.SubmittedAt.Format(time.RFC3339),
+					MinutesPending:     int64(now.Sub(r.SubmittedAt).Minutes()),
+					MaxFeeGwei:         r.MaxFeeGwei,
+					MaxPriorityFeeGwei: r.MaxPriorityFeeGwei,
+					PreviousTxHashes:   prev,
+				})
+			}
+			return view, nil
+		},
+		ClaimRepo:          airdropClaimRepo,
+		RebroadcastService: airdropRebroadcastSvc,
+		Logger:             logger,
+	}
+	if err := opsHandler.LoadTemplates(); err != nil {
+		logger.WithError(err).Fatal("ops: failed to load templates")
+	}
+	e.GET("/ops", opsHandler.Landing)
+	e.GET("/ops/balance", opsHandler.Balance)
+	e.GET("/ops/stuck-claims", opsHandler.StuckClaims)
+	e.POST("/ops/rebroadcast", opsHandler.Rebroadcast)
+```
+
+Add `formatWeiToEthShort` helper near `parseEthString`:
+
+```go
+// formatWeiToEthShort divides wei by 1e18, formats with 3 decimal places.
+func formatWeiToEthShort(wei *big.Int) string {
+	if wei == nil {
+		return "0"
+	}
+	one := new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil)
+	intPart := new(big.Int)
+	frac := new(big.Int)
+	intPart.QuoRem(wei, one, frac)
+	fracStr := frac.String()
+	for len(fracStr) < 18 {
+		fracStr = "0" + fracStr
+	}
+	return fmt.Sprintf("%s.%s", intPart.String(), fracStr[:3])
+}
+```
+
+The `claimHandler` struct from Task 8 is package-private. Either export it (`AirdropClaimHandler`) or expose a constructor `func NewAirdropClaimHandler(...) echo.HandlerFunc`. The latter keeps the type private; recommended:
+
+In `internal/api/airdrop_claim.go`, export the constructor:
+
+```go
+type AirdropClaimHandler struct {
+	Svc               claimSubmitter
+	Eligibility       eligibilityChecker
+	QuestThreshold    int
+	ClaimWindowOpenAt time.Time
+	ClaimEnabled      bool
+	Now               func() time.Time
+}
+
+func (h *AirdropClaimHandler) Handle(c echo.Context) error {
+	// Re-uses the existing claimHandler.Handle logic — copy or adapt.
+	// (Easiest: rename claimHandler → AirdropClaimHandler in Task 8 and skip this.)
+}
+```
+
+Equivalently, rename `claimHandler` → `AirdropClaimHandler` in Task 8's commit — cleaner. Either approach works; pick one and stay consistent.
+
+The `quests.NewEligibilityChecker(pool)` shim is a 5-line adapter — Stage 1 ships `quests.IsClaimEligible` as a free function, and the handler wants an interface. Add this to `internal/service/airdrop/quests/eligibility.go` if it isn't already there:
+
+```go
+import "github.com/jackc/pgx/v5/pgxpool"
+
+type EligibilityChecker struct{ pool *pgxpool.Pool }
+
+func NewEligibilityChecker(pool *pgxpool.Pool) *EligibilityChecker {
+	return &EligibilityChecker{pool: pool}
+}
+
+func (e *EligibilityChecker) IsClaimEligible(ctx context.Context, publicKey string, threshold int) (bool, string, error) {
+	return IsClaimEligible(ctx, e.pool, publicKey, threshold)
+}
+```
+
+If Stage 1 already defined this, skip.
+
+- [ ] **Step 3: Build and run locally**
+
+```bash
+go build ./cmd/server ./cmd/scheduler
+```
+
+Expected: PASS for both.
+
+```bash
+make build
+DATABASE_DSN="postgres://..." \
+  REDIS_URI="redis://localhost:6379" \
+  AI_API_KEY="..." \
+  JWT_SECRET="..." \
+  MCP_SERVER_URL="..." \
+  TRANSITION_WINDOW_START="2026-04-25T00:00:00Z" \
+  TRANSITION_WINDOW_END="2026-04-30T00:00:00Z" \
+  INTERNAL_API_KEY="local-internal-token" \
+  QUEST_ACTIVATION_TIMESTAMP="2026-05-01T00:00:00Z" \
+  KMS_RELAYER_KEY_ARN="arn:aws:kms:..." \
+  EVM_RPC_URL="https://ethereum-rpc.publicnode.com" \
+  AIRDROP_CLAIM_CONTRACT_ADDRESS="0x0000000000000000000000000000000000000000" \
+  CLAIM_WINDOW_OPEN_AT="2026-05-15T00:00:00Z" \
+  CLAIM_ENABLED="true" \
+  OPS_USERNAME="ops" \
+  OPS_PASSWORD="ops-secret" \
+  ./bin/server
+```
+
+In another terminal:
+
+```bash
+# Internal endpoint smoke (no JWT, just the shared secret)
+curl -s -H "X-Internal-Token: local-internal-token" \
+  http://localhost:8080/internal/relayer/balance | jq .
+
+curl -s -H "X-Internal-Token: local-internal-token" \
+  http://localhost:8080/internal/relayer/stuck-claims | jq .
+
+# Ops UI
+curl -u ops:ops-secret -i http://localhost:8080/ops
+curl -u ops:ops-secret -i http://localhost:8080/ops/balance
+```
+
+Expected:
+- `/internal/relayer/balance` returns the JSON shape from the spec (with `eth_balance_wei`, `vult_contract_balance_wei`, etc.). Note: against a real KMS key, ETH balance is whatever's on the relayer wallet; against LocalStack KMS the GetPublicKey call fails — staging is the real test bed.
+- `/internal/relayer/stuck-claims` returns `{"stuck_claims": [], "count": 0}`.
+- `/ops` returns 200 with HTML (links to balance + stuck-claims).
+- Without `-u ops:ops-secret`, all `/ops/*` URLs return 401 with `WWW-Authenticate: Basic realm="airdrop-ops"` header.
+
+- [ ] **Step 4: Commit the wiring**
+
+```bash
+git add cmd/server/main.go internal/api/airdrop_claim.go internal/service/airdrop/quests/eligibility.go
+git commit -m "feat(airdrop): wire stage 4 routes into cmd/server"
+```
+
+- [ ] **Step 5: Run the full test suite + lint**
+
+```bash
+go test ./... -timeout 120s
+make lint
+```
+
+Expected: PASS. Investigate any failures before pushing.
+
+- [ ] **Step 6: Push branch**
+
+```bash
+git push -u origin feat/airdrop-stage-4-claim-relayer
+```
+
+- [ ] **Step 7: Open the PR**
+
+```bash
+gh pr create --title "feat(airdrop): Stage 4 claim relayer (POST /airdrop/claim, /ops console, monitor)" --body "$(cat <<'EOF'
+## Summary
+
+Stage 4 of the Vultiverse Airdrop pipeline — the on-chain claim relayer.
+
+- \`POST /airdrop/claim\` (JWT) — synchronous KMS-signed EIP-1559 broadcast under a SELECT FOR UPDATE lock. Idempotent retries return the existing tx_hash.
+- \`/ops/*\` (Basic Auth) — server-rendered HTML console: landing, balance (auto-refresh, with low-balance banner), stuck-claims with per-row "Rebroadcast (+50 gwei)" form.
+- \`POST /ops/rebroadcast\` — re-signs at the same nonce with bumped fees, updates the row in place. Audit trail in structured logs.
+- Confirmation monitor goroutine inside cmd/scheduler — polls every \`CONFIRMATION_POLL_INTERVAL_SECONDS\` (default 15s), flips submitted → confirmed/failed.
+- Auto-init relayer nonce on first boot via SELECT FOR UPDATE (no manual psql UPDATE needed).
+- No \`/internal/relayer/*\` HTTP routes — balance + stuck-claims are served directly from /ops over Basic Auth (cleanup pass simplification).
+
+Spec source of truth: \`docs/airdrop-specs/stage-4-claim-relayer.md\`.
+
+## Architecture
+
+- **Concurrency model:** the spec is explicit. SELECT FOR UPDATE on \`agent_relayer_state WHERE id=1\` serialises every claim handler. Inside the txn: load nonce → fetch winner → build/sign/broadcast → INSERT claim row → increment nonce → COMMIT. ROLLBACK on any failure (so nonce stays unchanged, no claim_submissions row, user can retry).
+- **Idempotency:** the partial unique index \`agent_claim_submissions (public_key) WHERE status IN ('submitted','confirmed')\` is the DB-level guard. Concurrent same-user calls: one wins the index, the rest read the existing row.
+- **Restart-safety:** the monitor's first tick on boot picks up any submitted rows from before a crash. Tested by \`TestMonitor_RestartSafety\`.
+- **Operator UI:** server-rendered HTML, no JS build, CSS inlined. Auto-refresh via \`<meta http-equiv="refresh" content="30">\`. Basic Auth check inlined in the handler — no shared middleware (per cleanup pass).
+- **Confirmation monitor lives in cmd/scheduler** alongside the existing tasks poller; both share ctx + signal handler.
+
+## Spec coverage (vs "Done when" checklist)
+
+- ✅ \`/airdrop/claim\` returns documented shapes against documented status codes (\`TestClaimHandler_StatusCodeMatrix\`)
+- ✅ DB unique partial index enforces "one claim per user" — concurrency test passes (\`TestClaimService_Submit_ConcurrentSameUser_SingleTx\`: 50 concurrent → 1 tx + 49 idempotent retries)
+- ✅ 50 concurrent distinct-user requests submit all 50 with distinct nonces (\`TestClaimService_Submit_ConcurrentDistinctUsers_DistinctNonces\`)
+- ✅ Confirmation monitor flips submitted → confirmed (\`TestMonitor_OneTick_FlipsConfirmed\`)
+- ✅ Restart test (\`TestMonitor_RestartSafety\`)
+- ✅ Rebroadcast endpoint succeeds with bumped gas (\`TestRebroadcastService_BumpsFeesAndAppendsHash\`)
+- ✅ \`/internal/relayer/balance\` returns sane values; low-balance flag flips at the configured threshold (\`TestBalanceHandler_LowBalanceFlag\`)
+- ✅ \`/internal/relayer/stuck-claims\` lists pending-too-long rows; empty when none (\`TestStuckClaimsHandler_DefaultThreshold\`, \`...CustomThreshold\`)
+- ✅ \`/ops\` UI reachable behind Basic Auth (\`TestOpsBasicAuth_Rejects\`)
+- ⏭ E2E test against Foundry-deployed AirdropClaim.sol — runbook'd but not in CI (depends on contract repo's deploy script being checked in; cross-repo E2E lives in the contract team's PR)
+- ⏭ Day 28 runbook (\`docs/runbooks/relayer-day-28.md\`) — write before the Day 28 deadline; not blocking this PR
+
+## Test plan
+- [ ] \`go test ./... -timeout 120s\` passes (with DATABASE_DSN set; integration tests skip otherwise)
+- [ ] \`make lint\` clean
+- [ ] \`make build\` produces \`bin/server\` and \`bin/scheduler\`
+- [ ] Local smoke: server boots; \`/internal/relayer/balance\` + \`/ops\` return expected shapes (against a public mainnet RPC)
+- [ ] Anvil-backed integration: spin up Anvil, deploy AirdropClaim fixture, exercise full claim → monitor → confirmed loop
+
+## Hard deadline
+Live in production by Day 28. Bring up in staging behind \`CLAIM_ENABLED=false\`, smoke-test against Sepolia, then flip the switch on Day 28.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Capture and report the PR URL.
+
+---
+
+## Self-review notes
+
+This plan was reviewed against `stage-4-claim-relayer.md` after writing. Each "Done when" bullet, mapped to where it's covered:
+
+- **`/airdrop/claim` returns documented shapes against documented status codes** — Task 8 (`TestClaimHandler_StatusCodeMatrix` covers all seven status codes from `stage-4-claim-relayer.md:74-85`).
+- **DB unique partial index enforces "one claim per user" — 50 concurrent same-user requests yield exactly one tx** — Task 7 (`TestClaimService_Submit_ConcurrentSameUser_SingleTx`, with `len(rpc.sentTxs) == 1` assertion) plus the migration in shared infra (`idx_claim_submissions_one_per_user`).
+- **50 concurrent distinct-user requests submit all 50 in ~serialised order, all with distinct nonces** — Task 7 (`TestClaimService_Submit_ConcurrentDistinctUsers_DistinctNonces`).
+- **Confirmation monitor flips submitted → confirmed against Anvil within seconds** — Task 9 (`TestMonitor_OneTick_FlipsConfirmed` covers the DB transition; full Anvil-backed E2E runs in the integration suite via Task 1's `anviltest` helper, not in CI).
+- **Restart test: kill mid-pipeline, restart, observe monitor pick up unfinished work** — Task 9 (`TestMonitor_RestartSafety` runs `Run()` cold and confirms the boot tick catches a pre-seeded submitted row).
+- **Rebroadcast endpoint succeeds with bumped gas; original tx is replaced** — Task 12 (`TestRebroadcastService_BumpsFeesAndAppendsHash` checks new tx_hash, prior in array, fees bumped, nonce unchanged).
+- **`/internal/relayer/balance` returns sane values; low-balance flag flips at the configured threshold** — Task 10 (both `TestBalanceHandler_HappyPath` and `TestBalanceHandler_LowBalanceFlag`).
+- **`/internal/relayer/stuck-claims` lists pending-too-long rows; empty when none** — Task 11 (`TestStuckClaimsHandler_DefaultThreshold` populated, `...CustomThreshold` empty).
+- **`/ops` UI is reachable behind Basic Auth and renders the three pages correctly** — Task 13 (`TestOpsBasicAuth_Rejects` covers all four auth states; the templates render via `LoadTemplates`). Manual smoke in Task 14 Step 3 confirms HTML output.
+- **E2E test against Foundry-deployed AirdropClaim.sol** — deferred. The contract repo's deploy script + an integration test that boots Anvil, deploys the contract, calls setWinners, runs a claim through this relayer end-to-end is a cross-repo concern. Task 1's `anviltest` helper is the seed for that work; the plan calls it out as a follow-up runbook test, not in this PR.
+- **Day 28 runbook (`docs/runbooks/relayer-day-28.md`)** — out of scope for this implementation PR. Spec asks for it as a deliverable; recommend writing it as a separate PR before Day 28 (no engineering risk; pure operational).
+- **Stuck-tx runbook (`docs/runbooks/relayer-stuck-tx.md`)** — same as above. Not in this PR.
+
+Cleanup-pass items honoured:
+
+- **No separate `/internal/relayer/rebroadcast` endpoint** — collapsed into `POST /ops/rebroadcast` (Task 13). The spec at line 167-168 makes this explicit.
+- **Inline Basic Auth check, no shared middleware** — Task 13's `Handler.basicAuthOK` uses `subtle.ConstantTimeCompare` directly inside the ops package.
+- **Auto-init relayer nonce on first boot** — Task 6 (`InitNonceIfNeeded`) wired into `cmd/server/main.go` Step 1 of Task 14. No manual psql UPDATE in any runbook.
+- **Status response addition (`claim_tx_hash`)** — out of scope here. Stage 1's status handler reads the same `agent_claim_submissions` rows this stage writes; no Stage 4 code touches it.
+
+Items intentionally NOT in this plan:
+
+- **Prometheus metrics for the relayer** (counter histogram set listed at `stage-4-claim-relayer.md:275-289`). The repo's `internal/metrics/` package is the right home; pattern is already established in `scheduler.go`. Adding a `relayer.go` metrics file with the listed counters is mechanical and ~80 lines — left as a follow-up PR to keep this one focused on functionality. Recommend a small `feat(airdrop): add relayer Prometheus metrics` PR before Day 28.
+- **`BlockNumber` ethclient method** — added in shared-infra Task 5; consumed here in Task 10's balance handler to populate `RpcBlockHeight`. No follow-up needed.
+- **LocalStack-backed KMS integration test** — shared infra's plan flagged this as a Stage 4 deliverable, but in practice the production path needs a real KMS key (the relayer wallet); the LocalStack round-trip test would only confirm what `TestSignRoundTrip` in shared infra already proves (DER decoding + recovery byte selection). Skip in favour of staging-environment smoke tests against the real KMS key.
+- **Runbooks** (covered above).
+
+Stage 4 has no follow-on stage. Once this PR ships and the runbooks are written, the airdrop pipeline is complete from boarding through claim.


### PR DESCRIPTION
Part of #18.

## Summary

Moves the Vultiverse Airdrop spec set **and** the implementation plans into this repo as the single source of truth for the mission:

- **10 spec files** moved from `StationWallet/station-mobile/docs/airdrop-specs/` → `docs/airdrop-specs/`
- **5 plan files** added under `plans/airdrop/` — previously lived in a local `/plans/airdrop/` directory outside any git repo, which meant they weren't reviewable, weren't versioned, and weren't discoverable to anyone but the author

Vultihub already owns the mission umbrella (`#18`) and cross-repo tracking, so the specs + plans belong here alongside.

Companion PR in `StationWallet/station-mobile` deletes the old spec files and leaves a redirect stub so any existing link to the old location still points somewhere useful: [StationWallet/station-mobile#70](https://github.com/StationWallet/station-mobile/pull/70).

## What's in the move

### Specs (`docs/airdrop-specs/`)

All 10 files, with every correction from this week's investigation folded in:

- **MCP repo**: `vultisig/mcp` (Go) → `vultisig/mcp-ts` (TypeScript) — the agent chat path goes through the TS server, not the Go one
- **Contract repo**: `vultisig/mergecontract` → `vultisig/vultiagent-airdrop` (Neo's dedicated repo, contract already implemented there)
- **Mobile app split**: Day 8–12 boarding lives in `StationWallet/station-mobile`; Day 13+ quest/claim work lives in `vultisig/vultiagent-app` after the mid-campaign Station → VultiAgent swap
- **File-path alignment**: shared-infra packages (kms, ethclient) at their actual shipped locations; migration numbers made concrete (20260423000005 / 06) with "shipped by shared-infra plan" annotations
- **Schema**: `agent_quest_events` shape reflects the actual migration (`counted BOOLEAN` + `tx_proposal_id UUID` soft reference — no JSONB payload duplication)
- **Contract status**: banner marking `AirdropClaim.sol` as implemented by @NeOMakinG with the only outstanding item being mainnet deploy

### Plans (`plans/airdrop/`)

Five dated implementation plans, one per stage plus the shared-infra foundation:

- `2026-04-23-shared-infra.md` — the config + migrations + KMS signer + ethclient + middleware PR (already in flight as `vultisig/agent-backend#150`)
- `2026-04-23-stage-1-boarding.md` — `/airdrop/register` + `/airdrop/status` + `/airdrop/stats` + eligibility helper
- `2026-04-23-stage-2-raffle-cli.md` — `airdrop-raffle` CLI with `draw`, `load-winners`, `verify-onchain`
- `2026-04-23-stage-3-quest-tracking.md` — quest endpoint + validators + SignTxProposal hook
- `2026-04-23-stage-4-claim-relayer.md` — claim handler + relayer package + monitor + ops UI

Spec-path references inside plans updated from `/Users/…/station-mobile/docs/airdrop-specs/…` to the sibling path `docs/airdrop-specs/…`.

## What doesn't move

- `vultiagent-airdrop/README.md`, `ISSUE-19.md`, `spike-consensus.md` — repo-scoped contract decision docs, belong with the contract
- The existing vultihub docs (`MARKETING.md`, `TEAM-PROCESS.md`, deck HTMLs) — unrelated to the airdrop mission

## Test plan

- [x] All 10 spec files render on GitHub's markdown viewer
- [x] All 5 plan files render (they are long — 2k–4k lines each)
- [x] Zero `station-mobile/docs/airdrop-specs/` references remain in the moved files
- [x] Relative link from `docs/airdrop-specs/README.md` to `ai-combinator/vultihub#18` still resolves
- [x] Companion PR in station-mobile leaves a redirect stub at the old path

🤖 Generated with [Claude Code](https://claude.com/claude-code)
