### PR TITLE
docs(airdrop): use admin dashboard for operator controls

### DIFF
--- a/docs/airdrop-specs/README.md
+++ b/docs/airdrop-specs/README.md
@@ -11,7 +11,7 @@ For a non-technical walkthrough start with [`overview.md`](overview.md). Technic
 - [`stage-1-boarding.md`](stage-1-boarding.md) — Days 8–12. Three endpoints (`POST /airdrop/register`, `GET /airdrop/status`, `GET /airdrop/stats`), one table.
 - [`stage-2-raffle-draw.md`](stage-2-raffle-draw.md) — Day 12. Single `airdrop-raffle` CLI with `draw`, `load-winners`, `verify-onchain` subcommands. Hands `winners.csv` to the multisig for batched `setWinners(...)` calls. One table for winners.
 - [`stage-3-quest-tracking.md`](stage-3-quest-tracking.md) — Days 13–27. One internal endpoint, two tables, hard-coded validators per quest type. Backend-side eligibility (no on-chain attestation).
-- [`stage-4-claim-relayer.md`](stage-4-claim-relayer.md) — Day 28+. On-chain submission path, operator UI, confirmation monitor. Two tables.
+- [`stage-4-claim-relayer.md`](stage-4-claim-relayer.md) — Day 28+. On-chain submission path, admin-dashboard operator controls, confirmation monitor. Two tables.
 
 ## Sibling missions (other engineers)
 

--- a/docs/airdrop-specs/overview.md
+++ b/docs/airdrop-specs/overview.md
@@ -77,14 +77,14 @@ The user taps "claim my VULT." The app POSTs to `/airdrop/claim`. The backend:
 8. A background process watches Ethereum, sees the transaction confirm, and updates our database to "confirmed."
 9. Next time the user polls `/airdrop/status`, they see `already_claimed: true` and the app shows "VULT received!"
 
-### 5. Run an operator dashboard so a human can fix things if they break
+### 5. Use the existing admin dashboard so a human can fix things if they break
 
-A simple HTML page (no JavaScript, just server-rendered) at `/ops` showing:
+An Airdrop section in the existing `agent-backend` admin dashboard showing:
 - How much ETH is left in the relayer wallet (for "we need to top up" alerts).
 - A list of any transactions that have been pending for too long.
 - A "rebroadcast with higher gas" button per stuck transaction.
 
-Behind a username/password.
+This uses the same admin login, roles, TOTP-backed sessions, and audit logging as the rest of the production admin UI. We are not building a separate `/ops` dashboard or a second Basic Auth surface for this campaign.
 
 ---
 
@@ -114,4 +114,4 @@ Lives in the agent-app / station-mobile codebase, built by the mobile engineer:
 
 ## The mental model in one sentence
 
-A small Go service that **takes registrations, picks winners, watches the app for qualifying actions, then pays VULT out of a hot wallet on demand** — with a database keeping track of who's at what stage and a tiny dashboard for ops. Surrounded by an on-chain contract that holds the prize pool, and a mobile app that talks to both.
+A small Go service that **takes registrations, picks winners, watches the app for qualifying actions, then pays VULT out of a hot wallet on demand** — with a database keeping track of who's at what stage and admin-dashboard controls for ops. Surrounded by an on-chain contract that holds the prize pool, and a mobile app that talks to both.

--- a/docs/airdrop-specs/shared-concerns.md
+++ b/docs/airdrop-specs/shared-concerns.md
@@ -79,15 +79,16 @@ Six new tables, one shared types prefix (`airdrop_*` for Postgres enums). All na
 
 | Table | Owning stage | Purpose | Key columns |
 |---|---|---|---|
-| `agent_airdrop_registrations` | 1 | One row per user who joined the raffle | `public_key` (PK), `source`, `recipient_address`, `registered_at` |
+| `agent_airdrop_registrations` | 1 | One row per user who joined the raffle | `public_key` (PK), `source`, `bucket`, `recipient_address`, `registered_at` |
 | `agent_raffle_winners` | 2 | One row per winner; populated by `load-winners` CLI. Mirrors the contract's on-chain `allowance` mapping for status display. | `public_key` (PK), `recipient`, `amount`, `loaded_at` |
 | `agent_quest_events` | 3 | Append-only audit log of incoming quest events (counted + rejected) | `tool_call_id` (PK), `public_key`, `quest_id`, `tx_hash`, `counted` (bool), `reject_reason`, `tx_proposal_id`, `created_at` |
 | `agent_user_quests` | 3 | Materialized "which quests has each user completed" | `(public_key, quest_id)` (PK), `completed_at` |
 | `agent_claim_submissions` | 4 | One row per claim attempt; lifecycle from submitted → confirmed/failed. Rebroadcasts update `tx_hash` in place. | `nonce` (UNIQUE), `public_key`, `recipient`, `amount`, `tx_hash`, `status`, gas fields, timestamps |
 | `agent_relayer_state` | 4 | Singleton holding the relayer's `next_nonce` counter | `id=1` (CHECK), `next_nonce`, `last_synced` |
 
-Plus three Postgres enum types:
-- `airdrop_registration_source` — `seed`, `vault_share`
+Plus four Postgres enum types:
+- `airdrop_registration_source` — `seed`, `vault_share`, `create`
+- `airdrop_bucket` — `station_migration`, `campaign_new`
 - `airdrop_quest_id` — `swap`, `bridge`, `defi_action`, `alert`, `dca`
 - `airdrop_claim_status` — `submitted`, `confirmed`, `failed`
 
@@ -188,7 +189,7 @@ Three artifacts cross repo boundaries. All need to be locked early to avoid late
 
 ### Backend → Operator
 
-The `winners.csv` artifact from Stage 2's `draw` subcommand, handed to the multisig signer for batched `setWinners(...)` calls. Standard CSV with header row: `public_key, recipient, amount, registered_at, source`. The multisig signer (or their tooling) splits this into ~100-row batches and constructs one `setWinners(addresses[], amounts[])` tx per batch.
+The `winners.csv` artifact from Stage 2's `draw` subcommand, handed to the multisig signer for batched `setWinners(...)` calls. Standard CSV with header row: `public_key, recipient, amount, registered_at, source, bucket`. The multisig signer (or their tooling) splits this into ~100-row batches and constructs one `setWinners(addresses[], amounts[])` tx per batch.
 
 ---
 

--- a/docs/airdrop-specs/shared-concerns.md
+++ b/docs/airdrop-specs/shared-concerns.md
@@ -35,11 +35,11 @@ Three distinct auth mechanisms, each owning a clear path prefix:
 |---|---|---|---|
 | `/airdrop/register`, `/airdrop/status`, `/airdrop/claim` | JWT (existing `/auth/token` flow — vault ECDSA sig → 24h JWT) | Mobile app | Existing `internal/api/middleware.go` — no changes needed |
 | `/internal/quests/event` | `X-Internal-Token: <secret>` matching `INTERNAL_API_KEY` env var | The agent-backend's `SignTxProposal` handler (in this same binary), curl by ops | New: `internal/api/internal_token_middleware.go` |
-| `/ops/*` (HTML pages, including `POST /ops/rebroadcast`) | HTTP Basic Auth via `OPS_USERNAME` + `OPS_PASSWORD` env vars | Operator's browser, or curl-from-script | Inlined: 5-line stdlib check in the ops handler |
+| `/admin/*` + `/admin/api/airdrop/*` | Existing agent-backend admin login, TOTP/session cookie, role middleware, audit log | Operators and support staff | Existing `cmd/admin` / `internal/admin`; add airdrop pages and API handlers there |
 | `/airdrop/stats` | None (public) | Marketing | n/a |
 | `/healthz` | None (existing) | Load balancer | Existing |
 
-The internal-token middleware is tiny (~15 lines). Implement it once in the shared infra phase; every internal endpoint picks it up via route registration. Basic Auth is inlined in the ops handler — only one route group uses it, so no shared package warranted.
+The internal-token middleware is tiny (~15 lines). Implement it once in the shared infra phase; every internal endpoint picks it up via route registration. Do **not** build a separate Basic Auth `/ops/*` dashboard for the airdrop: airdrop operations belong in the existing admin dashboard so they inherit roles, TOTP-backed sessions, and audit logging.
 
 ---
 
@@ -63,13 +63,12 @@ All 19 vars across the 5 stages, in one table. Locked values come from the Stage
 | `AIRDROP_CLAIM_CONTRACT_ADDRESS` | 4 | 0x-address | none | Deployed `AirdropClaim.sol` address |
 | `CLAIM_WINDOW_OPEN_AT` | 4 | RFC3339 | none | Day 28 wall clock; claims rejected before |
 | `CLAIM_ENABLED` | 4 | bool | true | Operator kill switch; checked on every request |
-| `LOW_BALANCE_THRESHOLD_ETH` | 4 | decimal | 0.5 | Triggers `low_balance_warning` in balance endpoint |
+| `LOW_BALANCE_THRESHOLD_ETH` | 4 | decimal | 0.5 | Triggers `low_balance_warning` in admin relayer balance view |
 | `CONFIRMATION_BLOCKS` | 4 | int | 1 | Reorg depth before marking confirmed |
 | `CONFIRMATION_POLL_INTERVAL_SECONDS` | 4 | int | 15 | How often the monitor checks receipts |
-| `OPS_USERNAME` | 4 | string | none | Basic Auth user for `/ops/*` |
-| `OPS_PASSWORD` | 4 | string secret | none | Basic Auth password |
-
 Loaded via the existing `internal/config/config.go` with `envconfig` (or whatever the agent-backend uses today). Add fields to the existing struct rather than introducing a new config struct.
+
+`OPS_USERNAME` and `OPS_PASSWORD` are intentionally absent. They belonged to the superseded Basic Auth `/ops/*` dashboard design and should be removed from backend config/sample envs.
 
 ---
 
@@ -121,7 +120,7 @@ Code that should live in one place even though multiple stages use it.
 func (s *Server) InternalTokenMiddleware(next echo.HandlerFunc) echo.HandlerFunc
 ```
 
-Reads `X-Internal-Token` header, compares to `s.internalToken` (constant-time), 401 on mismatch. Used by Stage 3 (`/internal/quests/event`). Stage 4's ops health and stuck-claims views are served directly from `/ops/*` over Basic Auth — no `/internal/relayer/*` route group exists.
+Reads `X-Internal-Token` header, compares to `s.internalToken` (constant-time), 401 on mismatch. Used by Stage 3 (`/internal/quests/event`). Stage 4's operator views are served through the existing admin dashboard; do not add `/internal/relayer/*` routes just to feed UI pages.
 
 ### `internal/service/airdrop/quests/eligibility.go`
 
@@ -199,7 +198,7 @@ Across all stages:
 
 - **Logging.** Structured JSON via the existing `logrus` setup. Always include: `request_id`, `public_key` (first 8 chars only — privacy), the action verb, and `result`. Per-stage specs add fields specific to their domain (`tool_call_id`, `nonce`, `tx_hash`, etc.).
 - **Metrics.** Prometheus, registered under the existing `internal/metrics/` registry. Naming convention `airdrop_<verb>_<unit>` (e.g. `airdrop_register_total`, `airdrop_claim_submit_duration_seconds`). Every endpoint gets a counter + a duration histogram.
-- **Alerts.** One alert worth paging on: `airdrop_relayer_eth_balance_wei < 0.5e18`. Wire to whatever the team uses (PagerDuty, Slack, etc.). Other metrics are dashboard fodder, not page-worthy.
+- **Alerts.** One alert worth paging on: `airdrop_relayer_eth_balance_wei < 0.5e18`. Wire to whatever the team uses (PagerDuty, Slack, etc.). Other metrics are admin-dashboard fodder, not page-worthy.
 - **Tracing.** Use the existing tracing setup if there is one; otherwise nothing new to introduce.
 
 ---
@@ -226,6 +225,6 @@ To keep scope clear:
 - KMS signer can sign a no-op digest against a real (LocalStack) KMS key and the recovered EVM address matches.
 - ETH client can read the latest base fee + block number against a public mainnet RPC.
 
-(Basic Auth coverage lives in Stage 4 — it's inlined in the ops handler, not part of shared infra.)
+(Airdrop operator UI coverage lives in Stage 4 and uses the existing admin auth/role/audit stack, not Basic Auth.)
 
 Once those tick, the per-stage work has the foundations it needs.

--- a/docs/airdrop-specs/sibling-mobile-app.md
+++ b/docs/airdrop-specs/sibling-mobile-app.md
@@ -31,11 +31,23 @@ What still needs to be built is the wiring between those screens and the airdrop
 2. RiveIntro plays, user swipes up.
 3. AuthMenu offers: Import Seed Phrase / Import Vault Share / Create New Vault.
 4. User picks a path. Existing migration / vault-creation UI runs through to a working Fast Vault.
-5. **App computes the user's EVM address** from the new Fast Vault locally — see [EVM address derivation](#evm-address-derivation) below.
-6. App acquires a JWT via the existing `POST /auth/token` flow (vault sig → 24h JWT).
-7. App calls `POST /airdrop/register` with `{ source: "seed" | "vault_share", recipient_address }`.
-8. App stores the response (`registered_at`, `recipient_address`, `source`).
-9. App transitions to the waiting screen.
+5. **App determines the airdrop bucket**: `station_migration` if this wallet existed in the legacy Station keychain, otherwise `campaign_new` for a wallet added during the campaign window.
+6. **App computes the user's EVM address** from the new Fast Vault locally — see [EVM address derivation](#evm-address-derivation) below.
+7. App acquires a JWT via the existing `POST /auth/token` flow (vault sig → 24h JWT).
+8. App calls `POST /airdrop/register` with `{ source: "seed" | "vault_share" | "create", bucket: "station_migration" | "campaign_new", recipient_address }`.
+9. App stores the response (`registered_at`, `recipient_address`, `source`, `bucket`).
+10. App transitions to the waiting screen.
+
+### Bucket classification
+
+The app owns classification because it is the only layer that can see whether a wallet came from Station's old keychain.
+
+| Bucket | When to send it |
+|---|---|
+| `station_migration` | The wallet was present in the legacy Station auth/keychain data before being migrated to a Fast Vault. |
+| `campaign_new` | The user added the wallet during the campaign window: Create New Vault, Recover Seed, Import Seed Phrase, or Import Vault Share. |
+
+`source` remains the import/create path (`seed`, `vault_share`, `create`). `bucket` is the allocation segment. They must be stored separately.
 
 ### Flow 2 — Pending (Days 8–28+)
 

--- a/docs/airdrop-specs/stage-1-boarding.md
+++ b/docs/airdrop-specs/stage-1-boarding.md
@@ -31,12 +31,15 @@ Authorization: Bearer <jwt>
 Content-Type: application/json
 
 {
-  "source": "seed" | "vault_share",
+  "source": "seed" | "vault_share" | "create",
+  "bucket": "station_migration" | "campaign_new",
   "recipient_address": "0x..."
 }
 ```
 
-`source` is the import flow the user came through: `seed` for "import a seed phrase into a Fast Vault," `vault_share` for "import an existing Vultisig vault share."
+`source` is the import flow the user came through: `seed` for "import a seed phrase into a Fast Vault," `vault_share` for "import an existing Vultisig vault share," and `create` for "create a new Fast Vault."
+
+`bucket` is the allocation segment: `station_migration` for a wallet that existed in Station's legacy keychain and was migrated, `campaign_new` for a wallet added during the campaign window (create, recover seed, or import vault share). The app detects this locally and the backend stores it; the backend does not infer it.
 
 `recipient_address` is the EVM address VULT will be paid to if this entry wins. **Required.** The client computes it locally from the vault — for standard Vultisig vaults that means deriving the EVM address from the vault's ECDSA public key; for legacy Terra-only vaults (which can't derive one) the client prompts the user for an address. **The backend never derives, never inspects vault internals, never tries to detect Terra-only — it just stores what the client sends.** This keeps backend logic simple and puts the derivation in the place that already has the vault material.
 
@@ -45,6 +48,7 @@ Content-Type: application/json
 {
   "registered_at": "2026-04-25T12:34:56Z",
   "source": "seed",
+  "bucket": "station_migration",
   "recipient_address": "0x..."
 }
 ```
@@ -57,16 +61,17 @@ The client can tell whether this was a fresh registration or a retry by inspecti
 |---|---|---|
 | 401 | (handled by middleware) | Missing or invalid JWT |
 | 400 | `{"error":"INVALID_SOURCE"}` | `source` missing, or value not in enum |
+| 400 | `{"error":"INVALID_BUCKET"}` | `bucket` missing, or value not in enum |
 | 400 | `{"error":"INVALID_RECIPIENT_ADDRESS"}` | `recipient_address` missing, or doesn't match `^0x[a-fA-F0-9]{40}$` |
 | 403 | `{"error":"WINDOW_NOT_OPEN"}` | `now() < TRANSITION_WINDOW_START` |
 | 403 | `{"error":"WINDOW_CLOSED"}` | `now() >= TRANSITION_WINDOW_END` |
 
 **Behavior:**
 
-1. Validate body shape; reject with `400 INVALID_SOURCE` if `source` is missing or not in the enum.
+1. Validate body shape; reject with `400 INVALID_SOURCE` if `source` is missing or not in the enum, or `400 INVALID_BUCKET` if `bucket` is missing or not in the enum.
 2. Validate `recipient_address` against `^0x[a-fA-F0-9]{40}$` (no EIP-55 checksum required); reject with `400 INVALID_RECIPIENT_ADDRESS` if missing or malformed.
 3. Check window: if `now()` is outside `[TRANSITION_WINDOW_START, TRANSITION_WINDOW_END)`, reject with the appropriate 403.
-4. `INSERT ... ON CONFLICT (public_key) DO NOTHING RETURNING ...`, then `SELECT` to return the actual row. Existing row wins — both `source` and `recipient_address` are **immutable** after first registration. Re-registering with different values is a no-op (returns the original row); the analytics signal stays clean.
+4. `INSERT ... ON CONFLICT (public_key) DO NOTHING RETURNING ...`, then `SELECT` to return the actual row. Existing row wins — `source`, `bucket`, and `recipient_address` are **immutable** after first registration. Re-registering with different values is a no-op (returns the original row); the analytics signal stays clean.
 5. Return the row at 200.
 
 ### `GET /airdrop/status`
@@ -85,6 +90,7 @@ Authorization: Bearer <jwt>
   "registered": true,
   "registered_at": "2026-04-25T12:34:56Z",
   "source": "seed",
+  "bucket": "station_migration",
   "recipient_address": "0x...",
   "raffle_state": "pending" | "awaiting_draw" | "won" | "lost",
   "quests": {
@@ -137,14 +143,15 @@ The "raffle has been drawn" signal is just `EXISTS(SELECT 1 FROM agent_raffle_wi
 ```json
 {
   "total_registrations": 1234,
-  "by_source": { "seed": 800, "vault_share": 434 },
+  "by_source": { "seed": 700, "vault_share": 234, "create": 300 },
+  "by_bucket": { "station_migration": 500, "campaign_new": 734 },
   "window_state": "upcoming" | "open" | "closed",
   "window_opens_at": "2026-04-25T00:00:00Z",
   "window_closes_at": "2026-04-30T00:00:00Z"
 }
 ```
 
-**Behavior:** single Postgres query (`SELECT source, COUNT(*) FROM agent_airdrop_registrations GROUP BY source`), marshal, return. Table is small (single-digit thousands at most); query is sub-millisecond. No caching — the cache layer was more code than the query it would protect.
+**Behavior:** grouped Postgres query over `source, bucket`, marshal per-source and per-bucket totals, return. Table is small (single-digit thousands at most); query is sub-millisecond.
 
 **Errors:** none expected.
 
@@ -155,11 +162,13 @@ The "raffle has been drawn" signal is just `EXISTS(SELECT 1 FROM agent_raffle_wi
 ```sql
 -- Migration: XXXXXXXXXXXXXX_create_airdrop_registrations.sql
 
-CREATE TYPE airdrop_registration_source AS ENUM ('seed', 'vault_share');
+CREATE TYPE airdrop_registration_source AS ENUM ('seed', 'vault_share', 'create');
+CREATE TYPE airdrop_bucket AS ENUM ('station_migration', 'campaign_new');
 
 CREATE TABLE agent_airdrop_registrations (
     public_key        TEXT                        PRIMARY KEY,
     source            airdrop_registration_source NOT NULL,
+    bucket            airdrop_bucket              NOT NULL,
     recipient_address TEXT                        NOT NULL,    -- 0x-prefixed EVM address; client computes; backend never derives
     registered_at     TIMESTAMPTZ                 NOT NULL DEFAULT NOW()
 );
@@ -190,22 +199,23 @@ Prometheus metrics (following existing `agent-backend` conventions in `internal/
 
 | Metric | Type | Labels |
 |---|---|---|
-| `airdrop_register_total` | Counter | `result` ∈ `{created, existing, window_not_open, window_closed, invalid_source}` |
+| `airdrop_register_total` | Counter | `result` ∈ `{created, existing, window_not_open, window_closed, invalid_source, invalid_bucket}` |
 | `airdrop_status_total` | Counter | `state` ∈ `{not_registered, pending, awaiting_draw, won, lost}` |
 
 Per-endpoint latency + error metrics come from the existing HTTP middleware automatically.
 
-Structured logs include: `public_key` (first 8 chars only — privacy), `source`, `request_id`, `result`. The existing logrus context wiring handles this if we add the fields per request.
+Structured logs include: `public_key` (first 8 chars only — privacy), `source`, `bucket`, `request_id`, `result`. The existing logrus context wiring handles this if we add the fields per request.
 
 ---
 
 ## Tests
 
 **Unit (in `internal/service/airdrop/registration_test.go`):**
-- Source enum validation: missing, empty, wrong value, valid `seed`, valid `vault_share`.
+- Source enum validation: missing, empty, wrong value, valid `seed`, valid `vault_share`, valid `create`.
+- Bucket enum validation: missing, empty, wrong value, valid `station_migration`, valid `campaign_new`.
 - Recipient validation: missing (rejected), valid lowercase, valid mixed-case, missing 0x prefix, wrong length, non-hex chars.
 - Window enforcement: before-start, at-start, mid-window, at-end, after-end. Use an injected clock.
-- Idempotency: register twice returns same row; second source / recipient_address values are ignored.
+- Idempotency: register twice returns same row; second source / bucket / recipient_address values are ignored.
 - Raffle state computation: each of the four states with mocked `raffle_winners` and clock.
 
 **Integration (against real Postgres):**
@@ -233,7 +243,7 @@ internal/service/airdrop/
 
 internal/storage/postgres/
 ├── migrations/XXXXXXXXXXXXXX_create_airdrop_registrations.sql
-└── sqlc/airdrop_registrations.sql     Insert (idempotent), select-by-pk, count-all, count-by-source
+└── sqlc/airdrop_registrations.sql     Insert (idempotent), select-by-pk, count-by-source-and-bucket
 
 internal/api/server.go   (edit) — register the three new routes under existing JWT middleware (and bare for /stats)
 internal/config/config.go (edit) — add TRANSITION_WINDOW_START / _END env vars

--- a/docs/airdrop-specs/stage-2-raffle-draw.md
+++ b/docs/airdrop-specs/stage-2-raffle-draw.md
@@ -76,8 +76,8 @@ All routed from one binary: `airdrop-raffle <subcommand>`.
 4. Otherwise, seed PRNG with `--seed` (or freshly generated u64), run Fisher–Yates shuffle, take the first `slot_count` entries.
 5. For each winner, read `recipient_address` from the registration row.
 6. Serialize artifacts:
-   - `winners.csv` — `public_key, recipient, amount, registered_at, source` per row, header line included. **This is the file the multisig signer reads to construct setWinners batches.**
-   - `manifest.json` — `{ seed, slot_count, vult_amount, registration_count, winner_count, draw_timestamp, undersubscribed: bool }`.
+   - `winners.csv` — `public_key, recipient, amount, registered_at, source, bucket` per row, header line included. **This is the file the multisig signer reads to construct setWinners batches.**
+   - `manifest.json` — `{ seed, slot_count, vult_amount, registration_count, winner_count, draw_timestamp, undersubscribed: bool, bucket_counts }`.
 7. Write both files to `--output-dir`.
 8. Print a summary: winner count, seed, undersubscribed flag, output path. Operator commits the directory to the ops repo for durability.
 

--- a/docs/airdrop-specs/stage-4-claim-relayer.md
+++ b/docs/airdrop-specs/stage-4-claim-relayer.md
@@ -9,7 +9,7 @@ Two invariants must hold:
 1. **At most one on-chain claim per user, ever.** Network retries, double-taps, races between threads, restarts mid-submit — none of these can result in two on-chain txs for the same vault.
 2. **No claim is forgotten across service restarts.** If we crash after broadcasting but before recording confirmation, the next process must pick up where we left off.
 
-This is the only stage that touches mainnet. It's also where the operator interface lives — a basic HTML dashboard for monitoring relayer health and triggering manual rebroadcasts on stuck transactions.
+This is the only stage that touches mainnet. It's also where the operator controls live — inside the existing `agent-backend` admin dashboard, for monitoring relayer health and triggering manual rebroadcasts on stuck transactions.
 
 ---
 
@@ -31,9 +31,9 @@ Concurrency model: claim handlers serialize through `SELECT FOR UPDATE` on the r
 | Surface | Auth |
 |---|---|
 | `POST /airdrop/claim` | JWT (existing middleware) |
-| `GET /ops/*`, `POST /ops/*` | HTTP Basic Auth via `OPS_USERNAME` + `OPS_PASSWORD` env vars |
+| `GET /admin/*`, `GET /admin/api/airdrop/*`, `POST /admin/api/airdrop/*` | Existing admin login/session/TOTP middleware. Read-only airdrop views require admin access; rebroadcast requires `super_admin` or the equivalent high-risk admin role. All writes audit-log operator, action, old tx hash, new tx hash, nonce, and gas bump. |
 
-There are no `/internal/relayer/*` routes. The balance + stuck-claims views are served directly from `/ops/balance` and `/ops/stuck-claims` over Basic Auth — same logic, half the surface, one less auth mechanism.
+Do **not** build a separate Basic Auth `/ops/*` dashboard for this campaign. Airdrop operations belong in the existing admin dashboard so they inherit the same auth, role checks, TOTP, and audit trail used for other production controls.
 
 ---
 
@@ -111,24 +111,24 @@ If any of steps 9–14 fail, ROLLBACK. The state row's `next_nonce` is unchanged
 
 The eligibility check in step 4 calls the shared `eligibility.go` helper from Stage 3 (in-process Go function call, not an HTTP roundtrip — eligibility is a pure DB read with no signing or external calls, so the API-endpoint pattern doesn't apply).
 
-There is no `/internal/relayer/*` route group. Balance and stuck-claims health are served directly from `/ops/balance` and `/ops/stuck-claims` (Basic Auth). The data shapes are documented in the Operator interface section below.
+There is no `/internal/relayer/*` route group just to feed UI pages. Balance and stuck-claims health are exposed through the admin API and backed by in-process relayer service calls. The data shapes are documented in the Operator interface section below.
 
 ---
 
-## Operator interface
+## Admin dashboard operator controls
 
-Server-rendered HTML pages using Go's `html/template`. No JS build, no client-side framework. Lives in the same binary, behind HTTP Basic Auth.
+Add an Airdrop section to the existing `agent-backend` admin dashboard. Reuse the current admin static app and admin API patterns; do not introduce a separate UI stack, Basic Auth island, or `/ops` route group.
 
-| Path | Page |
+| Path | Purpose |
 |---|---|
-| `GET /ops` | Landing page. Links to balance, stuck-claims. Shows last-refreshed time. |
-| `GET /ops/balance` | Renders relayer health as a styled table. Auto-refreshes every 30s via `<meta http-equiv="refresh">`. Big red banner if `low_balance_warning`. Shape: `relayer_address`, `eth_balance_wei`/`_human`, `vult_contract_balance_wei`/`_human`, `low_balance_warning`, `low_balance_threshold_eth`, `estimated_claims_remaining`, `next_nonce`, `rpc_block_height`. `estimated_claims_remaining = floor(eth_balance / (avg_gas_per_claim * current_gas_price))`. `low_balance_warning = true` when `eth_balance < LOW_BALANCE_THRESHOLD_ETH`. |
-| `GET /ops/stuck-claims` | Table of submitted-but-unconfirmed claims older than `?older_than_minutes=N` (default 10), sorted by minutes-pending descending. Each row shows `public_key` (first 8), `tx_hash` (linked to Etherscan), `nonce`, `submitted_at`, `minutes_pending`, `max_fee_gwei`, `max_priority_fee_gwei`. Each row has a "Rebroadcast (+50 gwei)" button. Empty table is the healthy state. |
-| `POST /ops/rebroadcast` | Form handler. Reads `{public_key, bump_gwei}` (default 50). Calls the rebroadcast service in-process: sign new EIP-1559 tx with **same nonce** + bumped fees, broadcast, update `tx_hash` + gas fields on the row. Returns 404 if no row, 400 if already confirmed, 503 if RPC failed. Renders a success/error page with the new tx hash + Etherscan link. The old tx and new tx race in the mempool — both share the same nonce so only one can confirm. |
+| `GET /admin` | Existing admin dashboard. Add an Airdrop/Relayer section or nav item. |
+| `GET /admin/api/airdrop/relayer/balance` | Returns relayer health for display: `relayer_address`, `eth_balance_wei`/`_human`, `vult_contract_balance_wei`/`_human`, `low_balance_warning`, `low_balance_threshold_eth`, `estimated_claims_remaining`, `next_nonce`, `rpc_block_height`. `estimated_claims_remaining = floor(eth_balance / (avg_gas_per_claim * current_gas_price))`. `low_balance_warning = true` when `eth_balance < LOW_BALANCE_THRESHOLD_ETH`. |
+| `GET /admin/api/airdrop/relayer/stuck-claims?older_than_minutes=N` | Returns submitted-but-unconfirmed claims older than the threshold (default 10), sorted by minutes-pending descending. Each row includes `public_key` (redacted to first 8 chars in the UI), `tx_hash`, `nonce`, `submitted_at`, `minutes_pending`, `max_fee_gwei`, `max_priority_fee_gwei`. Empty list is the healthy state. |
+| `POST /admin/api/airdrop/relayer/rebroadcast` | High-risk admin action. Reads `{public_key, bump_gwei}` (default 50). Calls the rebroadcast service in-process: sign new EIP-1559 tx with **same nonce** + bumped fees, broadcast, update `tx_hash` + gas fields on the row. Returns 404 if no row, 400 if already confirmed, 503 if RPC failed. The old tx and new tx race in the mempool — both share the same nonce so only one can confirm. |
 
-Pages query the DB + RPC directly via the relayer service — no internal HTTP roundtrip.
+Admin handlers query the DB + RPC through the relayer service — no internal HTTP roundtrip.
 
-Templates in `internal/api/ops/templates/`. CSS inlined into `<style>` blocks (no separate static asset pipeline). One Go file per route.
+Implement the server handlers in the existing admin package and extend the existing admin static assets. Reuse the admin audit logger for rebroadcast attempts and results.
 
 ---
 
@@ -210,11 +210,12 @@ Rebroadcasts update `tx_hash` in place. Audit trail of prior bumps lives in the 
 | `AIRDROP_CLAIM_CONTRACT_ADDRESS` | 0x-address | Same value as Stage 3's `verifyingContract`. |
 | `CLAIM_WINDOW_OPEN_AT` | RFC3339 timestamp | Day 28 wall clock; before this, `/airdrop/claim` returns 403. |
 | `CLAIM_ENABLED` | bool, default true | Operator kill switch. Read on every request — hot-reload by env-var change + service signal, or a redeploy. |
-| `LOW_BALANCE_THRESHOLD_ETH` | decimal, default 0.5 | Triggers `low_balance_warning: true` in `/ops/balance`. |
+| `LOW_BALANCE_THRESHOLD_ETH` | decimal, default 0.5 | Triggers `low_balance_warning: true` in the admin relayer balance view. |
 | `CONFIRMATION_BLOCKS` | int, default 1 | Required reorg depth before marking a tx `confirmed`. |
 | `CONFIRMATION_POLL_INTERVAL_SECONDS` | int, default 15 | How often the monitor checks for receipts. |
-| `OPS_USERNAME` / `OPS_PASSWORD` | strings | HTTP Basic Auth credentials for the operator UI. |
 | `INTERNAL_API_KEY` | string secret | (Reused from Stage 3.) `X-Internal-Token` header value. |
+
+`OPS_USERNAME` and `OPS_PASSWORD` are not Stage 4 config. They belonged to the superseded Basic Auth `/ops/*` dashboard design and should not be present in target prod envs or sample env files.
 
 ---
 
@@ -255,7 +256,7 @@ A Prometheus alert on `airdrop_relayer_eth_balance_wei < 0.5e18` pages ops.
 - Restart-safety: kill the service after the broadcast UPDATE but before… (well, the broadcast and UPDATE are in one txn, so there's no in-between state). Test instead: kill the service immediately after broadcast (one tx in `submitted` state in DB), restart, observe monitor pick up the submitted row on its first tick and confirm against Anvil.
 - Concurrency: 50 concurrent /airdrop/claim calls for 50 distinct eligible users → 50 distinct nonces, 50 distinct tx hashes, no DB constraint violations, all submitted within ~50 seconds.
 - Concurrency: 50 concurrent /airdrop/claim calls for the same user → exactly one tx submitted, 49 idempotent-retry responses with the same tx_hash.
-- Stuck-tx flow: tx broadcast at low gas → never confirms → `/ops/stuck-claims` lists it → `POST /ops/rebroadcast` form with bump → new tx confirms → original is dropped (same nonce).
+- Stuck-tx flow: tx broadcast at low gas → never confirms → admin stuck-claims view lists it → admin rebroadcast action with bump → new tx confirms → original is dropped (same nonce).
 - Balance endpoint returns expected values; low-balance threshold flips the warning.
 
 **End-to-end (with `vultiagent-airdrop`):**
@@ -272,14 +273,12 @@ cmd/scheduler/
 internal/api/airdrop/
 └── claim.go              POST /airdrop/claim handler
 
-internal/api/ops/
-├── handler.go            Routing + inline Basic Auth check (5-line stdlib helper, no shared middleware)
-├── templates/
-│   ├── layout.html
-│   ├── balance.html
-│   ├── stuck_claims.html
-│   └── rebroadcast_result.html
-└── ops.go                One file per page wiring data → template; balance and stuck-claims pages call the relayer service directly; rebroadcast page calls relayer/rebroadcast.go directly
+internal/admin/
+└── airdrop_handlers.go   Admin API handlers for balance, stuck claims, and rebroadcast. Reuse existing admin auth, roles, and audit logging.
+
+internal/admin/static/
+├── index.html            Add Airdrop/Relayer section to the existing admin dashboard shell.
+└── js/app.js             Add relayer balance, stuck claims, and rebroadcast UI using the admin API.
 
 internal/service/airdrop/relayer/
 ├── claim.go              Top-level claim flow (validation → tx build → broadcast → DB). Calls eligibility helper from internal/service/airdrop/quests/eligibility.go. Uses the shared kms + ethclient packages below.
@@ -298,7 +297,7 @@ internal/storage/postgres/
 
 docs/runbooks/
 ├── relayer-day-28.md            "How to bring up the relayer on Day 28"
-└── relayer-stuck-tx.md          "What to do when /ops/stuck-claims has rows"
+└── relayer-stuck-tx.md          "What to do when the admin stuck-claims view has rows"
 ```
 
 ---
@@ -326,11 +325,11 @@ docs/runbooks/
 - Confirmation monitor flips `submitted` → `confirmed` against Anvil within seconds of the receipt landing.
 - Restart test: kill mid-pipeline, restart, observe monitor pick up unfinished work.
 - Rebroadcast endpoint succeeds with bumped gas; original tx is replaced by the new one.
-- `/ops/balance` returns sane values; low-balance flag flips at the configured threshold.
-- `/ops/stuck-claims` lists pending-too-long rows; empty when none.
-- `/ops` UI is reachable behind Basic Auth and renders all four pages correctly.
+- Admin relayer balance API returns sane values; low-balance flag flips at the configured threshold.
+- Admin stuck-claims API lists pending-too-long rows; empty when none.
+- Existing admin dashboard renders the Airdrop/Relayer controls. Read-only views are admin-gated; rebroadcast is high-risk-role-gated and audit-logged.
 - E2E test against Foundry-deployed `AirdropClaim.sol` passes start-to-finish: register → win raffle → multisig calls setWinners → complete quests → claim → VULT received at recipient.
 - Day 28 runbook drafted (`docs/runbooks/relayer-day-28.md`) covering: deploy steps, smoke test, kill switch flip-on. (No manual nonce sync step — that auto-runs on first boot.)
-- Stuck-tx runbook drafted covering: how to read `/ops/stuck-claims`, decide bump amount, handle "still stuck after rebroadcast" case (probably a free RPC throttling issue → switch RPC URL or pay for one).
-- Top-up runbook drafted (`docs/runbooks/relayer-top-up.md`): when `low_balance_warning` fires (or alert fires below 0.5 ETH), the funding multisig sends ETH to the relayer address (visible at the top of `/ops/balance`). Standard EOA send, no contract interaction. Safe to do mid-campaign at any time; no service restart needed. The relayer wallet is fundable from any wallet — there's no allow-list on the receive side.
+- Stuck-tx runbook drafted covering: how to read the admin stuck-claims view, decide bump amount, handle "still stuck after rebroadcast" case (probably a free RPC throttling issue → switch RPC URL or pay for one).
+- Top-up runbook drafted (`docs/runbooks/relayer-top-up.md`): when `low_balance_warning` fires (or alert fires below 0.5 ETH), the funding multisig sends ETH to the relayer address (visible in the admin relayer balance view). Standard EOA send, no contract interaction. Safe to do mid-campaign at any time; no service restart needed. The relayer wallet is fundable from any wallet — there's no allow-list on the receive side.
 - End-of-campaign runbook drafted (`docs/runbooks/relayer-end-of-campaign.md`): once the claim window has decisively closed (e.g. 90 days past `CLAIM_WINDOW_OPEN_AT` with no recent claims), the multisig flips `CLAIM_ENABLED=false` (kill switch — every claim immediately 403s with `CLAIM_DISABLED`), then calls `recoverERC20(VULT, balance, treasuryAddress)` on the contract to drain the unclaimed VULT back to treasury, then optionally calls `recoverERC20` on the relayer wallet's remaining ETH (sent from the relayer via a one-off KMS-signed tx, or just left to fund a future campaign). Document the multisig signers' steps and which etherscan calls to watch.


### PR DESCRIPTION
## Summary

- update the airdrop specs to use the existing `agent-backend` admin dashboard for Stage 4 operator controls
- remove the target `/ops/*` Basic Auth dashboard design from the canonical specs
- document that `OPS_USERNAME` / `OPS_PASSWORD` are intentionally absent and should be removed from backend config/sample envs

## Related issue updates

- Updated `vultisig/agent-backend#158` from `/ops/*` UI to admin-dashboard airdrop/relayer controls
- Updated `vultisig/agent-backend#156` so relayer health/stuck-claims/rebroadcast are service methods consumed by admin handlers, not `/internal/relayer/*` UI feed endpoints
- Updated `ai-combinator/vultihub#20` with the admin-dashboard decision and production window values
- Commented on `ai-combinator/vultihub#18` with the engineering decision

## Related backend PR

- `vultisig/agent-backend#308` removes the obsolete `OPS_USERNAME` / `OPS_PASSWORD` env vars from backend config and sample env files

## Validation

- `git diff --check`
- `rg -n "OPS_USERNAME|OPS_PASSWORD|Basic Auth|/ops" docs/airdrop-specs` only returns explicit notes saying not to build/use the old `/ops` design
